### PR TITLE
feat: song mode UI and backend integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blossom",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
 name = "blossom"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,4 +22,5 @@ tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ fn main() {
     .invoke_handler(tauri::generate_handler![
       commands::lofi_generate_gpu,
       commands::lofi_generate_gpu_stream, // <-- add this
+      commands::run_lofi_song,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import Calendar from "./pages/Calendar";
 import Comfy from "./pages/Comfy";
 import Assistant from "./pages/Assistant";
 import Laser from "./pages/Laser";
-import LofiBot from "./pages/LofiBot";
+import Lofi from "./pages/Lofi";
 
 export default function App() {
   return (
@@ -23,7 +23,7 @@ export default function App() {
         <Route path="/comfy" element={<Comfy />} />
         <Route path="/assistant" element={<Assistant />} />
         <Route path="/laser" element={<Laser />} />
-        <Route path="/lofi-bot" element={<LofiBot />} /> {/* new route */}
+        <Route path="/lofi" element={<Lofi />} />
       </Routes>
     </>
   );

--- a/src/SongForm.tsx
+++ b/src/SongForm.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+import { open } from "@tauri-apps/api/dialog";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+
+interface Section { name: string; bars: number; }
+interface SongSpec {
+  title: string;
+  outDir: string;
+  bpm: number;
+  key: string;
+  structure: Section[];
+  mood: string[];
+  instruments: string[];
+  ambience: string[];
+  seed: number;
+}
+
+const MOODS = ["chill", "happy", "sad"];
+const INSTRUMENTS = ["piano", "guitar", "sax"];
+const AMBIENCE = ["rain", "vinyl", "fire"];
+const KEYS = ["C", "D", "E", "F", "G", "A", "B"];
+
+export default function SongForm() {
+  const [title, setTitle] = useState("My Song");
+  const [outDir, setOutDir] = useState("");
+  const [bpm, setBpm] = useState(80);
+  const [key, setKey] = useState("C");
+  const [structure, setStructure] = useState<Section[]>([
+    { name: "Intro", bars: 4 },
+    { name: "A", bars: 16 },
+    { name: "B", bars: 16 },
+    { name: "A", bars: 16 },
+    { name: "Outro", bars: 8 },
+  ]);
+  const [mood, setMood] = useState<string[]>([]);
+  const [instruments, setInstruments] = useState<string[]>([]);
+  const [ambience, setAmbience] = useState<string[]>([]);
+  const [seed, setSeed] = useState<number>(0);
+  const [status, setStatus] = useState("idle");
+  const [busy, setBusy] = useState(false);
+
+  const toggle = (arr: string[], set: (v: string[]) => void, item: string) => {
+    set(arr.includes(item) ? arr.filter((x) => x !== item) : [...arr, item]);
+  };
+
+  const pickOutDir = async () => {
+    const dir = await open({ directory: true, multiple: false });
+    if (typeof dir === "string") setOutDir(dir);
+  };
+
+  const randomizeSeed = () => setSeed(Math.floor(Math.random() * 1_000_000));
+
+  const render = async () => {
+    setBusy(true);
+    setStatus("starting");
+    const spec: SongSpec = {
+      title,
+      outDir,
+      bpm,
+      key,
+      structure,
+      mood,
+      instruments,
+      ambience,
+      seed,
+    };
+    const unlisten = await listen<string>("lofi_progress", (e) => {
+      setStatus(String(e.payload));
+    });
+    try {
+      const saved = await invoke<string>("run_lofi_song", { spec });
+      setStatus(`saved: ${saved}`);
+    } catch (e: any) {
+      setStatus(`error: ${e}`);
+    } finally {
+      unlisten();
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem", maxWidth: 600 }}>
+      <label>
+        Title
+        <input value={title} onChange={(e) => setTitle(e.target.value)} />
+      </label>
+      <label>
+        Output Folder
+        <div style={{ display: "flex", gap: 8 }}>
+          <input value={outDir} readOnly style={{ flex: 1 }} />
+          <button onClick={pickOutDir}>Choose</button>
+        </div>
+      </label>
+      <label>
+        BPM
+        <input type="number" value={bpm} onChange={(e) => setBpm(parseInt(e.target.value) || 0)} />
+      </label>
+      <div>
+        Key
+        <div style={{ display: "flex", gap: 6 }}>
+          {KEYS.map((k) => (
+            <label key={k}>
+              <input type="radio" name="key" value={k} checked={key === k} onChange={() => setKey(k)} />{k}
+            </label>
+          ))}
+        </div>
+      </div>
+      <div>
+        Structure
+        {structure.map((s, i) => (
+          <div key={i} style={{ display: "flex", gap: 6, alignItems: "center" }}>
+            <span style={{ width: 60 }}>{s.name}</span>
+            <input
+              type="number"
+              value={s.bars}
+              onChange={(e) => {
+                const n = [...structure];
+                n[i] = { ...n[i], bars: parseInt(e.target.value) || 0 };
+                setStructure(n);
+              }}
+            />
+            <span>bars</span>
+          </div>
+        ))}
+      </div>
+      <div>
+        Mood
+        {MOODS.map((m) => (
+          <label key={m} style={{ marginRight: 8 }}>
+            <input
+              type="checkbox"
+              checked={mood.includes(m)}
+              onChange={() => toggle(mood, setMood, m)}
+            />
+            {m}
+          </label>
+        ))}
+      </div>
+      <div>
+        Instruments
+        {INSTRUMENTS.map((m) => (
+          <label key={m} style={{ marginRight: 8 }}>
+            <input
+              type="checkbox"
+              checked={instruments.includes(m)}
+              onChange={() => toggle(instruments, setInstruments, m)}
+            />
+            {m}
+          </label>
+        ))}
+      </div>
+      <div>
+        Ambience
+        {AMBIENCE.map((m) => (
+          <label key={m} style={{ marginRight: 8 }}>
+            <input
+              type="checkbox"
+              checked={ambience.includes(m)}
+              onChange={() => toggle(ambience, setAmbience, m)}
+            />
+            {m}
+          </label>
+        ))}
+      </div>
+      <label>
+        Seed
+        <div style={{ display: "flex", gap: 8 }}>
+          <input
+            type="number"
+            value={seed}
+            onChange={(e) => setSeed(parseInt(e.target.value) || 0)}
+          />
+          <button type="button" onClick={randomizeSeed}>
+            Randomize
+          </button>
+        </div>
+      </label>
+      <button onClick={render} disabled={busy}>
+        {busy ? "Rendering..." : "Render Song"}
+      </button>
+      <div>Status: {status}</div>
+    </div>
+  );
+}

--- a/src/components/VersionBadge.tsx
+++ b/src/components/VersionBadge.tsx
@@ -1,0 +1,9 @@
+import pkg from '../../package.json';
+
+export default function VersionBadge() {
+  return (
+    <div style={{ fontSize: '48px', color: 'white', fontWeight: 800 }}>
+      {pkg.version}
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import HoverCircle from "../components/HoverCircle";
 import FeatureCarousel from "../components/FeatureCarousel";
+import VersionBadge from "../components/VersionBadge";
 
 export default function Home() {
   const [hoverColor, setHoverColor] = useState("rgba(255,255,255,0.22)");
@@ -8,6 +9,9 @@ export default function Home() {
     <>
       <HoverCircle color={hoverColor} />
       <FeatureCarousel onHoverColor={setHoverColor} />
+      <div style={{ position: "absolute", top: 20, right: 20 }}>
+        <VersionBadge />
+      </div>
     </>
   );
 }

--- a/src/pages/Lofi.tsx
+++ b/src/pages/Lofi.tsx
@@ -1,0 +1,11 @@
+import SongForm from "../SongForm";
+import VersionBadge from "../components/VersionBadge";
+
+export default function Lofi() {
+  return (
+    <div style={{ padding: "2rem" }}>
+      <VersionBadge />
+      <SongForm />
+    </div>
+  );
+}

--- a/src/pages/LofiBot.tsx
+++ b/src/pages/LofiBot.tsx
@@ -1,8 +1,0 @@
-export default function LofiBot() {
-  return (
-    <div style={{ padding: "2rem" }}>
-      <h1>Lo-Fi Bot</h1>
-      <p>Your chill AI music companion.</p>
-    </div>
-  );
-}


### PR DESCRIPTION
## Summary
- show app version 0.1.1 and add a song creation form
- wire song generation command to Python backend with output folder selection

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module '@tauri-apps/api/dialog')*
- `cargo check` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `python src-tauri/python/lofi_gpu.py --song-json '{"title":"Test","bpm":80,"seed":1}' --out /tmp/test.wav` *(fails: No module named 'pydub')*

------
https://chatgpt.com/codex/tasks/task_e_68990282c14083259d0b2a1e11b21a97