### PR TITLE
feat: expand groove and instrument options

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -28,7 +28,15 @@ type Job = {
 
 const KEYS = ["C", "D", "E", "F", "G", "A", "B"];
 const MOODS = ["calm", "melancholy", "cozy", "hopeful", "nostalgic"];
-const INSTR = ["rhodes", "nylon guitar", "upright bass", "pads"];
+const INSTR = [
+  "rhodes",
+  "nylon guitar",
+  "upright bass",
+  "pads",
+  "electric piano",
+  "clean electric guitar",
+  "airy pads",
+];
 const AMBI = ["rain", "cafe"];
 
 export default function SongForm() {


### PR DESCRIPTION
## Summary
- add swing and halftime shuffle drum styles with broader chord progressions
- support electric piano, clean electric guitar, and airy pad layers that appear probabilistically
- surface the new instruments in the song form for user toggles

## Testing
- `python -m py_compile src-tauri/python/lofi_gpu.py`
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c163706288325b6da34fc34950034