### PR TITLE
Persist output directory across sessions

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -36,7 +36,7 @@ export default function SongForm() {
 
   // THEME (applies to all songs)
   const [titleBase, setTitleBase] = useState("Midnight Coffee");
-  const [outDir, setOutDir] = useState("");
+  const [outDir, setOutDir] = useState(localStorage.getItem('outDir') ?? '');
   const [bpm, setBpm] = useState(80);
   const [key, setKey] = useState<string>("C");
   const [mood, setMood] = useState<string[]>(["calm", "nostalgic"]);
@@ -77,6 +77,14 @@ export default function SongForm() {
       audioRef.current = null;
     };
   }, []);
+
+  // persist output directory across sessions
+  useEffect(() => {
+    localStorage.setItem('outDir', outDir);
+    return () => {
+      localStorage.setItem('outDir', outDir);
+    };
+  }, [outDir]);
 
   // progress listener from backend — attach to the "currently running" job
   const runningJobId = useMemo(
@@ -122,7 +130,10 @@ export default function SongForm() {
   async function pickFolder() {
     try {
       const dir = await open({ directory: true, multiple: false });
-      if (dir) setOutDir(dir as string);
+      if (dir) {
+        setOutDir(dir as string);
+        localStorage.setItem('outDir', dir as string);
+      }
     } catch (e: any) {
       setErr(e?.message || String(e));
     }


### PR DESCRIPTION
## Summary
- Remember last chosen output folder by initializing and saving to localStorage
- Persist directory on change or unmount for seamless relaunches

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c163e17ac8325a6e02a26ab70ad89