### PR TITLE
Add ambience level control for lo-fi generator

### DIFF
--- a/src-tauri/python/lofi_gpu.py
+++ b/src-tauri/python/lofi_gpu.py
@@ -430,13 +430,15 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60):
     if not amb_list:
        amb_list = random.choice([["rain"], ["cafe"], ["rain","cafe"]])
 
+    amb_level = float(np.clip(motif.get("ambience_level", 1.0), 0.0, 1.0))
+
     amb_mix = np.zeros(n, dtype=np.float32)
     if "rain" in amb_list:
-        amb_mix += _butter_lowpass((np.random.rand(n).astype(np.float32)*2-1)*0.04, 1200)
+        amb_mix += _butter_lowpass((np.random.rand(n).astype(np.float32)*2-1)*0.02, 1200)
     if "cafe" in amb_list:
-        amb_mix += (np.random.rand(n).astype(np.float32)*2-1)*0.01
+        amb_mix += (np.random.rand(n).astype(np.float32)*2-1)*0.003
 
-    mix = 0.7*drums + 0.7*hats + 0.6*keys + 0.5*bass + 0.3*amb_mix
+    mix = 0.7*drums + 0.7*hats + 0.6*keys + 0.5*bass + 0.3*amb_mix*amb_level
     mix = np.tanh(mix * 1.2).astype(np.float32)
     return _np_to_segment(mix)
 
@@ -494,10 +496,16 @@ def main():
         rng_key = np.random.default_rng((seed ^ 0xA5A5A5A5) & 0xFFFFFFFF)
         key_val = rng_key.choice(list("CDEFGAB"))
 
+    try:
+        amb_lvl = float(spec.get("ambience_level", 1.0))
+    except Exception:
+        amb_lvl = 1.0
+
     motif = {
         "mood": spec.get("mood") or [],
         "instruments": spec.get("instruments") or [],
         "ambience": spec.get("ambience") or [],
+        "ambience_level": amb_lvl,
         "key": key_val,
         "drum_pattern": spec.get("drum_pattern"),
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -167,6 +167,7 @@ pub struct SongSpec {
   pub mood: Vec<String>,
   pub instruments: Vec<String>,
   pub ambience: Vec<String>,
+  pub ambience_level: Option<f32>,
   pub seed: u64,
   pub variety: Option<u32>,
   pub drum_pattern: Option<String>,

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -14,6 +14,7 @@ type SongSpec = {
   mood: string[];
   instruments: string[];
   ambience: string[];
+  ambienceLevel: number; // 0..1
   seed: number;
 };
 
@@ -42,6 +43,7 @@ export default function SongForm() {
   const [mood, setMood] = useState<string[]>(["calm", "nostalgic"]);
   const [instruments, setInstruments] = useState<string[]>(["rhodes", "nylon guitar", "upright bass"]);
   const [ambience, setAmbience] = useState<string[]>(["rain"]);
+  const [ambienceLevel, setAmbienceLevel] = useState(1);
   const [structure, setStructure] = useState<Section[]>([
     { name: "Intro", bars: 4 },
     { name: "A", bars: 16 },
@@ -168,6 +170,7 @@ export default function SongForm() {
       mood,
       instruments,
       ambience,
+      ambienceLevel,
       seed: pickSeed(i),
     };
   }
@@ -426,6 +429,16 @@ export default function SongForm() {
                 );
               })}
             </div>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={ambienceLevel}
+              onChange={(e) => setAmbienceLevel(Number(e.target.value))}
+              style={S.slider}
+            />
+            <div style={S.small}>{Math.round(ambienceLevel * 100)}% intensity</div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- lower rain and café ambience mix and add scaling knob
- add ambienceLevel slider to SongForm so users can adjust ambience
- plumb new ambience_level field through Rust and Python layers

## Testing
- `python -m py_compile src-tauri/python/lofi_gpu.py`
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `cd src-tauri && cargo check` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*


------
https://chatgpt.com/codex/tasks/task_e_689c163ff7748325ae3e2271023561d0