### PR TITLE
Expose groove variety controls and soften static

### DIFF
--- a/src-tauri/python/lofi_gpu.py
+++ b/src-tauri/python/lofi_gpu.py
@@ -297,9 +297,11 @@ DRUM_PATTERNS = {
     "half_time_shuffle": {"kick": [(0,0.00), (3,0.50)], "snare":[(2,0.00)], "hat_8ths": True},
 }
 
-PROG_BANK_A = [["I","vi","IV","V"], ["I","V","vi","IV"], ["I","iii","vi","IV"], ["I","vi","ii","V"], ["I","IV","ii","V"]]
-PROG_BANK_B = [["vi","IV","I","V"], ["ii","V","I","vi"], ["IV","I","V","vi"], ["vi","ii","V","I"], ["IV","vi","ii","V"]]
-PROG_BANK_INTRO = [["I","IV"], ["ii","V"], ["I","V"], ["vi","IV"], ["I","ii"]]
+PROG_BANK_A = [["I","vi","IV","V"], ["I","V","vi","IV"], ["I","iii","vi","IV"], ["I","vi","ii","V"], ["I","IV","ii","V"],
+                ["I","IV","V","IV"], ["I","ii","V","IV"], ["I","V","IV","V"]]
+PROG_BANK_B = [["vi","IV","I","V"], ["ii","V","I","vi"], ["IV","I","V","vi"], ["vi","ii","V","I"], ["IV","vi","ii","V"],
+                ["vi","IV","ii","V"], ["ii","vi","IV","I"], ["vi","V","IV","V"]]
+PROG_BANK_INTRO = [["I","IV"], ["ii","V"], ["I","V"], ["vi","IV"], ["I","ii"], ["I","vi"], ["IV","V"], ["ii","iii"]]
 
 BASS_PATTERNS = ["roots_13", "root5_13", "held_whole"]
 
@@ -484,11 +486,11 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60):
 
     amb_mix = np.zeros(n, dtype=np.float32)
     if "rain" in amb_list:
-        amb_mix += _butter_lowpass((np.random.rand(n).astype(np.float32)*2-1)*0.02, 1200)
+        amb_mix += _butter_lowpass((np.random.rand(n).astype(np.float32)*2-1)*0.01, 1000)
     if "cafe" in amb_list:
-        amb_mix += (np.random.rand(n).astype(np.float32)*2-1)*0.003
+        amb_mix += (np.random.rand(n).astype(np.float32)*2-1)*0.0015
 
-    mix = 0.7*drums + 0.7*hats + 0.6*keys + 0.5*bass + 0.3*amb_mix*amb_level
+    mix = 0.7*drums + 0.55*hats + 0.6*keys + 0.5*bass + 0.15*amb_mix*amb_level
     mix = np.tanh(mix * 1.2).astype(np.float32)
     return _np_to_segment(mix)
 

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -16,6 +16,8 @@ type SongSpec = {
   ambience: string[];
   ambienceLevel: number; // 0..1
   seed: number;
+  variety: number;
+  drum_pattern?: string;
 };
 
 type Job = {
@@ -39,6 +41,7 @@ const INSTR = [
   "airy pads",
 ];
 const AMBI = ["rain", "cafe"];
+const DRUM_PATS = ["random", "boom_bap_A", "boom_bap_B", "laidback", "half_time", "swing", "half_time_shuffle"];
 
 export default function SongForm() {
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -68,6 +71,8 @@ export default function SongForm() {
   const [autoKeyPerSong, setAutoKeyPerSong] = useState(false);
   const [bpmJitterPct, setBpmJitterPct] = useState(5); // +/- %
   const [playLast, setPlayLast] = useState(true);
+  const [drumPattern, setDrumPattern] = useState<string>("random");
+  const [variety, setVariety] = useState(60);
 
   // UI state
   const [busy, setBusy] = useState(false);
@@ -191,6 +196,8 @@ export default function SongForm() {
       ambience,
       ambienceLevel,
       seed: pickSeed(i),
+      variety,
+      drum_pattern: drumPattern === "random" ? undefined : drumPattern,
     };
   }
 
@@ -458,6 +465,36 @@ export default function SongForm() {
               style={S.slider}
             />
             <div style={S.small}>{Math.round(ambienceLevel * 100)}% intensity</div>
+          </div>
+        </div>
+
+        {/* rhythm & feel */}
+        <div style={S.grid2}>
+          <div style={S.panel}>
+            <label style={S.label}>Drum Pattern</label>
+            <select
+              value={drumPattern}
+              onChange={(e) => setDrumPattern(e.target.value)}
+              style={{ ...S.input, padding: "8px 12px" }}
+            >
+              {DRUM_PATS.map((p) => (
+                <option key={p} value={p}>{p}</option>
+              ))}
+            </select>
+            <div style={S.small}>Choose a groove or leave random</div>
+          </div>
+
+          <div style={S.panel}>
+            <label style={S.label}>Variety</label>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              value={variety}
+              onChange={(e) => setVariety(Number(e.target.value))}
+              style={S.slider}
+            />
+            <div style={S.small}>{variety}% fills & swing</div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Add drum pattern selector and variety slider to SongForm so users can tweak groove generation
- Expand progression banks and lower ambience levels in lofi_gpu to reduce static and add harmonic variety

## Testing
- `npm test` (fails: Missing script)
- `npm run build`
- `python -m py_compile src-tauri/python/lofi_gpu.py`


------
https://chatgpt.com/codex/tasks/task_e_689c1b1b18b883258ad1beb5a08f7888