### PR TITLE
feat: add basic calendar with countdown reminders

### DIFF
--- a/src/components/Countdown.tsx
+++ b/src/components/Countdown.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+function calc(target: string) {
+  const diff = new Date(target).getTime() - Date.now();
+  const total = diff > 0 ? diff : 0;
+  const seconds = Math.floor(total / 1000) % 60;
+  const minutes = Math.floor(total / 1000 / 60) % 60;
+  const hours = Math.floor(total / 1000 / 60 / 60) % 24;
+  const days = Math.floor(total / 1000 / 60 / 60 / 24);
+  return { total, days, hours, minutes, seconds };
+}
+
+export default function Countdown({ target }: { target: string }) {
+  const [time, setTime] = useState(() => calc(target));
+  useEffect(() => {
+    const id = setInterval(() => setTime(calc(target)), 1000);
+    return () => clearInterval(id);
+  }, [target]);
+
+  if (time.total <= 0) return <span>Due</span>;
+  return (
+    <span>
+      {time.days}d {time.hours}h {time.minutes}m {time.seconds}s
+    </span>
+  );
+}

--- a/src/features/calendar/types.ts
+++ b/src/features/calendar/types.ts
@@ -1,0 +1,11 @@
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  date: string; // ISO string
+  hasCountdown: boolean;
+}
+
+export interface CalendarState {
+  events: CalendarEvent[];
+  selectedCountdownId: string | null;
+}

--- a/src/features/calendar/useCalendar.ts
+++ b/src/features/calendar/useCalendar.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { CalendarEvent, CalendarState } from './types';
+
+interface Actions {
+  addEvent: (e: Omit<CalendarEvent, 'id'>) => void;
+  updateEvent: (id: string, patch: Partial<CalendarEvent>) => void;
+  removeEvent: (id: string) => void;
+  setSelectedCountdownId: (id: string | null) => void;
+}
+
+export const useCalendar = create<CalendarState & Actions>()(
+  persist(
+    (set) => ({
+      events: [],
+      selectedCountdownId: null,
+      addEvent: (e) =>
+        set((state) => ({
+          events: [...state.events, { id: crypto.randomUUID(), ...e }],
+        })),
+      updateEvent: (id, patch) =>
+        set((state) => ({
+          events: state.events.map((ev) =>
+            ev.id === id ? { ...ev, ...patch } : ev
+          ),
+        })),
+      removeEvent: (id) =>
+        set((state) => ({
+          events: state.events.filter((ev) => ev.id !== id),
+        })),
+      setSelectedCountdownId: (id) => set({ selectedCountdownId: id }),
+    }),
+    { name: 'calendar-store' }
+  )
+);

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,2 +1,103 @@
-import Center from "./_Center";
-export default function Calendar(){ return <Center>Calendar / Scheduler</Center>; }
+import { useState } from "react";
+import { useCalendar } from "../features/calendar/useCalendar";
+import Countdown from "../components/Countdown";
+
+function pad(n: number) {
+  return n.toString().padStart(2, "0");
+}
+
+export default function Calendar() {
+  const [current, setCurrent] = useState(new Date());
+  const [title, setTitle] = useState("");
+  const [date, setDate] = useState("");
+  const [hasCountdown, setHasCountdown] = useState(false);
+  const { events, addEvent } = useCalendar();
+
+  const year = current.getFullYear();
+  const month = current.getMonth();
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const cells: (number | null)[] = [];
+  for (let i = 0; i < firstDay; i++) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) cells.push(d);
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  const add = () => {
+    if (!title || !date) return;
+    addEvent({ title, date, hasCountdown });
+    setTitle("");
+    setDate("");
+    setHasCountdown(false);
+  };
+
+  const dayEvents = (day: number) => {
+    const dayStr = `${year}-${pad(month + 1)}-${pad(day)}`;
+    return events.filter((e) => e.date.slice(0, 10) === dayStr);
+  };
+
+  return (
+    <div style={{ padding: 20 }}>
+      <div
+        style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}
+      >
+        <button onClick={() => setCurrent(new Date(year, month - 1, 1))}>{"<"}</button>
+        <h2 style={{ margin: 0 }}>
+          {current.toLocaleString("default", { month: "long" })} {year}
+        </h2>
+        <button onClick={() => setCurrent(new Date(year, month + 1, 1))}>{">"}</button>
+      </div>
+      <div
+        style={{ display: "grid", gridTemplateColumns: "repeat(7,1fr)", gap: 4, marginTop: 10 }}
+      >
+        {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
+          <div key={d} style={{ textAlign: "center", fontWeight: "bold" }}>
+            {d}
+          </div>
+        ))}
+        {cells.map((day, idx) => (
+          <div key={idx} style={{ border: "1px solid #ccc", minHeight: 80, padding: 4 }}>
+            {day && (
+              <>
+                <div style={{ fontWeight: "bold" }}>{day}</div>
+                {dayEvents(day).map((ev) => (
+                  <div key={ev.id} style={{ fontSize: 10, marginTop: 2 }}>
+                    {ev.title}
+                    {ev.hasCountdown && (
+                      <div>
+                        <Countdown target={ev.date} />
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+      <div style={{ marginTop: 20 }}>
+        <h3>Add Event</h3>
+        <input
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <input
+          type="datetime-local"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
+        <label style={{ marginLeft: 8 }}>
+          <input
+            type="checkbox"
+            checked={hasCountdown}
+            onChange={(e) => setHasCountdown(e.target.checked)}
+          />
+          Countdown
+        </label>
+        <button onClick={add} style={{ marginLeft: 8 }}>
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,14 +1,40 @@
 // src/pages/Home.tsx
 import { useState } from "react";
+import Countdown from "../components/Countdown";
+import { useCalendar } from "../features/calendar/useCalendar";
 import HoverCircle from "../components/HoverCircle";
 import FeatureCarousel from "../components/FeatureCarousel";
 import VersionBadge from "../components/VersionBadge";
 
 export default function Home() {
   const [hoverColor, setHoverColor] = useState("rgba(255,255,255,0.22)");
+  const { events, selectedCountdownId } = useCalendar();
+  const countdownEvents = events.filter((e) => e.hasCountdown);
+  let event = null as typeof countdownEvents[number] | null;
+  if (selectedCountdownId) {
+    event = countdownEvents.find((e) => e.id === selectedCountdownId) || null;
+  } else if (countdownEvents.length === 1) {
+    event = countdownEvents[0];
+  }
 
   return (
     <>
+      {event && (
+        <div
+          style={{
+            position: "absolute",
+            top: 12,
+            right: 12,
+            zIndex: 50,
+            color: "#fff",
+            textAlign: "right",
+          }}
+        >
+          <div style={{ fontSize: 14 }}>
+            <strong>{event.title}:</strong> <Countdown target={event.date} />
+          </div>
+        </div>
+      )}
       {/* Top-center app title and version */}
       <div
         style={{

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,17 @@
-import { Box, Paper, Typography } from "@mui/material";
+import {
+  Box,
+  Paper,
+  Typography,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+} from "@mui/material";
+import { useCalendar } from "../features/calendar/useCalendar";
 
 export default function Settings() {
+  const { events, selectedCountdownId, setSelectedCountdownId } = useCalendar();
+  const countdownEvents = events.filter((e) => e.hasCountdown);
   return (
     <Box sx={{ height: "100vh", display: "grid", placeItems: "center" }}>
       <Paper elevation={3} sx={{ p: 4, borderRadius: 3, minWidth: 360 }}>
@@ -8,6 +19,26 @@ export default function Settings() {
         <Typography variant="body2" color="text.secondary">
           Put toggles, theme, and module switches here.
         </Typography>
+        {countdownEvents.length > 0 && (
+          <FormControl fullWidth sx={{ mt: 3 }}>
+            <InputLabel id="countdown-label">Home Countdown</InputLabel>
+            <Select
+              labelId="countdown-label"
+              label="Home Countdown"
+              value={selectedCountdownId ?? ""}
+              onChange={(e) =>
+                setSelectedCountdownId(e.target.value ? String(e.target.value) : null)
+              }
+            >
+              <MenuItem value="">None</MenuItem>
+              {countdownEvents.map((e) => (
+                <MenuItem key={e.id} value={e.id}>
+                  {e.title}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
       </Paper>
     </Box>
   );


### PR DESCRIPTION
## Summary
- build simple calendar page to create events and optional countdowns
- persist events and selected countdown in zustand store
- show chosen countdown on home screen and configurable in settings

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c1cd91344832599eeb28afc25a869