### PR TITLE
Refine home carousel visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;800&display=swap" rel="stylesheet" />
     <title>Tauri + React + Typescript</title>
   </head>
 

--- a/src/components/FeatureCarousel.tsx
+++ b/src/components/FeatureCarousel.tsx
@@ -3,24 +3,34 @@ import type { ReactNode } from "react";
 import { useMemo, useRef, useState } from "react";
 import { IconButton } from "@mui/material";
 import {
-  FaMusic, FaCubes, FaCameraRetro, FaRobot, FaBolt, FaCalendarAlt
+  FaMusic,
+  FaCubes,
+  FaCameraRetro,
+  FaRobot,
+  FaBolt,
+  FaCalendarAlt,
 } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 
-type Item = { icon: ReactNode; label: string; color: string; path: string };
+type Item = { icon: ReactNode; label: string; path: string };
 export default function FeatureCarousel({
   onHoverColor,
 }: { onHoverColor: (c: string) => void }) {
   const nav = useNavigate();
 
-  const items: Item[] = useMemo(() => ([
-    { icon:<FaCubes/>,       label:"3D Object",    color:"rgba(165,216,255,0.55)", path:"/objects" },
-    { icon:<FaMusic/>,       label:"Lo‑Fi Music",  color:"rgba(245,176,194,0.55)", path:"/music" },
-    { icon:<FaCalendarAlt/>, label:"Calendar",     color:"rgba(211,200,255,0.55)", path:"/calendar" },
-    { icon:<FaCameraRetro/>, label:"ComfyUI",      color:"rgba(255,213,165,0.55)", path:"/comfy" },
-    { icon:<FaRobot/>,       label:"AI Assistant", color:"rgba(175,245,215,0.55)", path:"/assistant" },
-    { icon:<FaBolt/>,        label:"Laser Lab",    color:"rgba(255,180,180,0.55)", path:"/laser" },
-  ]), []);
+  const ACCENT = "#00bcd4";
+
+  const items: Item[] = useMemo(
+    () => [
+      { icon: <FaCubes />, label: "3D Object", path: "/objects" },
+      { icon: <FaMusic />, label: "Lo‑Fi Music", path: "/music" },
+      { icon: <FaCalendarAlt />, label: "Calendar", path: "/calendar" },
+      { icon: <FaCameraRetro />, label: "ComfyUI", path: "/comfy" },
+      { icon: <FaRobot />, label: "AI Assistant", path: "/assistant" },
+      { icon: <FaBolt />, label: "Laser Lab", path: "/laser" },
+    ],
+    []
+  );
 
   // index of the centered item
   const [i, setI] = useState(0);
@@ -39,22 +49,10 @@ export default function FeatureCarousel({
     go(e.deltaY > 0 || e.deltaX > 0 ? 1 : -1);
   };
 
-  // hover zones (auto-advance while hovering)
-  const leftTimer = useRef<number | null>(null);
-  const rightTimer = useRef<number | null>(null);
-
-  const startAuto = (dir: 1 | -1, ref: React.MutableRefObject<number | null>) => {
-    if (ref.current) return;
-    ref.current = window.setInterval(() => go(dir), 700);
-  };
-  const stopAuto = (ref: React.MutableRefObject<number | null>) => {
-    if (ref.current) { clearInterval(ref.current); ref.current = null; }
-  };
-
   // layout constants
-  const GAP = 140;         // distance between items
-  const SCALE_MID = 1.0;   // center scale
-  const SCALE_SIDE = 0.7;  // side scale
+  const GAP = 140; // distance between items
+  const SCALE_MID = 1.05; // center scale
+  const SCALE_SIDE = 0.7; // side scale
 
   return (
     <div
@@ -68,29 +66,6 @@ export default function FeatureCarousel({
         zIndex: 1
       }}
     >
-      {/* LEFT hover area */}
-      <div
-        onMouseEnter={() => startAuto(-1, leftTimer)}
-        onMouseLeave={() => stopAuto(leftTimer)}
-        onClick={() => go(-1)}
-        style={{
-          position: "absolute", left: 0, top: 0, bottom: 0, width: "18%",
-          cursor: "w-resize", zIndex: 2
-        }}
-        aria-label="Previous"
-      />
-      {/* RIGHT hover area */}
-      <div
-        onMouseEnter={() => startAuto(1, rightTimer)}
-        onMouseLeave={() => stopAuto(rightTimer)}
-        onClick={() => go(1)}
-        style={{
-          position: "absolute", right: 0, top: 0, bottom: 0, width: "18%",
-          cursor: "e-resize", zIndex: 2
-        }}
-        aria-label="Next"
-      />
-
       {/* items */}
       <div style={{ position: "relative", width: "100%", height: 240 }}>
         {[-2, -1, 0, 1, 2].map((offset) => {
@@ -111,27 +86,38 @@ export default function FeatureCarousel({
                 textAlign: "center",
                 opacity: center ? 1 : 0.6,
                 userSelect: "none",
-                width: 180
+                width: 180,
               }}
             >
               <IconButton
                 sx={{
-                  fontSize: "3.5rem",
-                  color: "white",
+                  fontSize: "3rem",
+                  color: center ? ACCENT : "white",
+                  boxShadow: center ? `0 0 20px 6px ${ACCENT}55` : "none",
+                  transition:
+                    "transform 280ms ease, color 180ms ease, box-shadow 180ms ease",
                   "&:hover": {
-                    color: it.color.replace("0.55", "1"),
-                    transform: "scale(1.06)",
-                    filter: "drop-shadow(0 8px 18px rgba(0,0,0,.18))"
+                    color: ACCENT,
+                    transform: "scale(1.05)",
+                    boxShadow: `0 0 20px 6px ${ACCENT}55`,
                   },
                 }}
-                onMouseEnter={() => onHoverColor(it.color)}
+                onMouseEnter={() => onHoverColor(`${ACCENT}55`)}
                 onMouseLeave={() => onHoverColor("rgba(255,255,255,0.22)")}
-                onClick={() => center ? nav(it.path) : setI(idx)}
+                onClick={() => (center ? nav(it.path) : setI(idx))}
                 aria-label={it.label}
               >
                 {it.icon}
               </IconButton>
-              <div style={{ color: "white", marginTop: 8, fontSize: 14 }}>{it.label}</div>
+              <div
+                style={{
+                  color: center ? ACCENT : "white",
+                  marginTop: 12,
+                  fontSize: 14,
+                }}
+              >
+                {it.label}
+              </div>
             </div>
           );
         })}

--- a/src/components/VersionBadge.tsx
+++ b/src/components/VersionBadge.tsx
@@ -10,8 +10,8 @@ export default function VersionBadge({
 }) {
   const wrap: React.CSSProperties = {
     display: "flex",
-    gap: 12,
-    alignItems: "baseline",
+    flexDirection: "column",
+    alignItems: "center",
     pointerEvents: "none",
   };
   const nameStyle: React.CSSProperties = {
@@ -22,16 +22,15 @@ export default function VersionBadge({
     textShadow: "0 2px 12px rgba(0,0,0,.45)",
   };
   const verStyle: React.CSSProperties = {
-    fontSize: 26,
-    fontWeight: 800,
-    color: "#fff",
-    opacity: 0.95,
+    fontSize: 20,
+    fontWeight: 700,
+    color: "#00bcd4",
     textShadow: "0 2px 12px rgba(0,0,0,.45)",
   };
   return (
     <div style={wrap}>
       <div style={nameStyle}>{name}</div>
-      <div style={verStyle}>{version}</div>
+      <div style={verStyle}>Version {version}</div>
     </div>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -48,8 +48,7 @@ export default function Home() {
           color: "#fff",
         }}
       >
-        <h1 style={{ margin: 0, fontSize: "2rem" }}>Blossom</h1>
-        <VersionBadge version="0.1.3" />
+        <VersionBadge />
       </div>
 
       {/* Background hover effect */}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,7 +2,7 @@
 * { box-sizing: border-box; }
 html, body, #root { height: 100%; margin: 0; }
 body {
-  background: #290808;                /* light grey canvas */
-  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Arial;
+  background: radial-gradient(circle at center, #3d0a0a, #290808);
+  font-family: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Arial;
 }
 a { color: inherit; text-decoration: none; }


### PR DESCRIPTION
## Summary
- Replace duplicate title with stacked version badge and modern Inter font
- Simplify feature carousel: remove hover auto-scroll, add teal accent glow, adjust icon sizing and spacing
- Apply radial gradient background for depth

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c1f3684048325a4efcf8c304a3516