### PR TITLE
Introduce theme selector and pulsing glow

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;800&display=swap" rel="stylesheet" />
     <title>Tauri + React + Typescript</title>
   </head>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,10 +9,11 @@ import Comfy from "./pages/Comfy";
 import Assistant from "./pages/Assistant";
 import Laser from "./pages/Laser";
 import Lofi from "./pages/Lofi";
+import { ThemeProvider } from "./theme";
 
 export default function App() {
   return (
-    <>
+    <ThemeProvider>
       <TopBar />
       <Routes>
         <Route path="/" element={<Home />} />
@@ -25,6 +26,6 @@ export default function App() {
         <Route path="/laser" element={<Laser />} />
         <Route path="/lofi" element={<Lofi />} />
       </Routes>
-    </>
+    </ThemeProvider>
   );
 }

--- a/src/components/FeatureCarousel.tsx
+++ b/src/components/FeatureCarousel.tsx
@@ -3,24 +3,34 @@ import type { ReactNode } from "react";
 import { useMemo, useRef, useState } from "react";
 import { IconButton } from "@mui/material";
 import {
-  FaMusic, FaCubes, FaCameraRetro, FaRobot, FaBolt, FaCalendarAlt
+  FaMusic,
+  FaCubes,
+  FaCameraRetro,
+  FaRobot,
+  FaBolt,
+  FaCalendarAlt,
 } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
+import { useTheme } from "../theme";
 
-type Item = { icon: ReactNode; label: string; color: string; path: string };
+type Item = { icon: ReactNode; label: string; path: string };
 export default function FeatureCarousel({
   onHoverColor,
 }: { onHoverColor: (c: string) => void }) {
   const nav = useNavigate();
+  const { accent: ACCENT } = useTheme();
 
-  const items: Item[] = useMemo(() => ([
-    { icon:<FaCubes/>,       label:"3D Object",    color:"rgba(165,216,255,0.55)", path:"/objects" },
-    { icon:<FaMusic/>,       label:"Lo‑Fi Music",  color:"rgba(245,176,194,0.55)", path:"/music" },
-    { icon:<FaCalendarAlt/>, label:"Calendar",     color:"rgba(211,200,255,0.55)", path:"/calendar" },
-    { icon:<FaCameraRetro/>, label:"ComfyUI",      color:"rgba(255,213,165,0.55)", path:"/comfy" },
-    { icon:<FaRobot/>,       label:"AI Assistant", color:"rgba(175,245,215,0.55)", path:"/assistant" },
-    { icon:<FaBolt/>,        label:"Laser Lab",    color:"rgba(255,180,180,0.55)", path:"/laser" },
-  ]), []);
+  const items: Item[] = useMemo(
+    () => [
+      { icon: <FaCubes />, label: "3D Object", path: "/objects" },
+      { icon: <FaMusic />, label: "Lo‑Fi Music", path: "/music" },
+      { icon: <FaCalendarAlt />, label: "Calendar", path: "/calendar" },
+      { icon: <FaCameraRetro />, label: "ComfyUI", path: "/comfy" },
+      { icon: <FaRobot />, label: "AI Assistant", path: "/assistant" },
+      { icon: <FaBolt />, label: "Laser Lab", path: "/laser" },
+    ],
+    []
+  );
 
   // index of the centered item
   const [i, setI] = useState(0);
@@ -39,22 +49,10 @@ export default function FeatureCarousel({
     go(e.deltaY > 0 || e.deltaX > 0 ? 1 : -1);
   };
 
-  // hover zones (auto-advance while hovering)
-  const leftTimer = useRef<number | null>(null);
-  const rightTimer = useRef<number | null>(null);
-
-  const startAuto = (dir: 1 | -1, ref: React.MutableRefObject<number | null>) => {
-    if (ref.current) return;
-    ref.current = window.setInterval(() => go(dir), 700);
-  };
-  const stopAuto = (ref: React.MutableRefObject<number | null>) => {
-    if (ref.current) { clearInterval(ref.current); ref.current = null; }
-  };
-
   // layout constants
-  const GAP = 140;         // distance between items
-  const SCALE_MID = 1.0;   // center scale
-  const SCALE_SIDE = 0.7;  // side scale
+  const GAP = 170; // distance between items
+  const SCALE_MID = 1.05; // center scale
+  const SCALE_SIDE = 0.7; // side scale
 
   return (
     <div
@@ -68,29 +66,6 @@ export default function FeatureCarousel({
         zIndex: 1
       }}
     >
-      {/* LEFT hover area */}
-      <div
-        onMouseEnter={() => startAuto(-1, leftTimer)}
-        onMouseLeave={() => stopAuto(leftTimer)}
-        onClick={() => go(-1)}
-        style={{
-          position: "absolute", left: 0, top: 0, bottom: 0, width: "18%",
-          cursor: "w-resize", zIndex: 2
-        }}
-        aria-label="Previous"
-      />
-      {/* RIGHT hover area */}
-      <div
-        onMouseEnter={() => startAuto(1, rightTimer)}
-        onMouseLeave={() => stopAuto(rightTimer)}
-        onClick={() => go(1)}
-        style={{
-          position: "absolute", right: 0, top: 0, bottom: 0, width: "18%",
-          cursor: "e-resize", zIndex: 2
-        }}
-        aria-label="Next"
-      />
-
       {/* items */}
       <div style={{ position: "relative", width: "100%", height: 240 }}>
         {[-2, -1, 0, 1, 2].map((offset) => {
@@ -111,27 +86,58 @@ export default function FeatureCarousel({
                 textAlign: "center",
                 opacity: center ? 1 : 0.6,
                 userSelect: "none",
-                width: 180
+                width: 180,
               }}
             >
               <IconButton
                 sx={{
-                  fontSize: "3.5rem",
-                  color: "white",
+                  fontSize: "2.8rem",
+                  color: center ? ACCENT : "var(--text)",
+                  position: "relative",
+                  transition: "transform 280ms ease, color 180ms ease",
+                  "&::after": {
+                    content: '""',
+                    position: "absolute",
+                    top: "50%",
+                    left: "50%",
+                    transform: "translate(-50%, -50%)",
+                    width: "200%",
+                    height: "200%",
+                    borderRadius: "50%",
+                    background: `radial-gradient(circle, ${ACCENT}77 0%, ${ACCENT}00 70%)`,
+                    opacity: center ? 1 : 0,
+                    filter: "blur(24px)",
+                    transition: "opacity 180ms ease",
+                    animation: center ? "glowPulse 4s ease-in-out infinite" : "none",
+                    pointerEvents: "none",
+                  },
                   "&:hover": {
-                    color: it.color.replace("0.55", "1"),
-                    transform: "scale(1.06)",
-                    filter: "drop-shadow(0 8px 18px rgba(0,0,0,.18))"
+                    color: ACCENT,
+                    transform: "scale(1.05)",
+                    "&::after": {
+                      opacity: 1,
+                      animation: "glowPulse 4s ease-in-out infinite",
+                    },
                   },
                 }}
-                onMouseEnter={() => onHoverColor(it.color)}
+                onMouseEnter={() => onHoverColor(`${ACCENT}55`)}
                 onMouseLeave={() => onHoverColor("rgba(255,255,255,0.22)")}
-                onClick={() => center ? nav(it.path) : setI(idx)}
+                onClick={() => (center ? nav(it.path) : setI(idx))}
                 aria-label={it.label}
               >
                 {it.icon}
               </IconButton>
-              <div style={{ color: "white", marginTop: 8, fontSize: 14 }}>{it.label}</div>
+              <div
+                style={{
+                  color: center ? ACCENT : "var(--text)",
+                  marginTop: 16,
+                  fontSize: 14,
+                  fontFamily: "Inter, sans-serif",
+                  fontWeight: center ? 600 : 400,
+                }}
+              >
+                {it.label}
+              </div>
             </div>
           );
         })}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -5,13 +5,12 @@ import { useNavigate, useLocation } from "react-router-dom";
 export default function TopBar() {
   const nav = useNavigate();
   const { pathname } = useLocation();
-  const activeColor = (p: string) => (pathname === p ? "#111" : "white");
 
   return (
     <>
       <IconButton
         onClick={() => nav("/")}
-        style={{ position: "fixed", top: 12, left: 12, zIndex: 2, color: activeColor("/") }}
+        style={{ position: "fixed", top: 12, left: 12, zIndex: 2, color: "#fff" }}
         aria-label="Home"
       >
         <FaHome />
@@ -19,7 +18,13 @@ export default function TopBar() {
 
       <IconButton
         onClick={() => nav("/settings")}
-        style={{ position: "fixed", top: 12, right: 12, zIndex: 2, color: activeColor("/settings") }}
+        style={{
+          position: "fixed",
+          top: 12,
+          right: 12,
+          zIndex: 2,
+          color: pathname === "/settings" ? "var(--accent)" : "var(--text)",
+        }}
         aria-label="Settings"
       >
         <FaWrench />

--- a/src/components/VersionBadge.tsx
+++ b/src/components/VersionBadge.tsx
@@ -10,28 +10,27 @@ export default function VersionBadge({
 }) {
   const wrap: React.CSSProperties = {
     display: "flex",
-    gap: 12,
-    alignItems: "baseline",
+    flexDirection: "column",
+    alignItems: "center",
     pointerEvents: "none",
   };
   const nameStyle: React.CSSProperties = {
     fontSize: 34,
     fontWeight: 800,
-    color: "#fff",
+    color: "var(--text)",
     letterSpacing: 0.3,
     textShadow: "0 2px 12px rgba(0,0,0,.45)",
   };
   const verStyle: React.CSSProperties = {
-    fontSize: 26,
-    fontWeight: 800,
-    color: "#fff",
-    opacity: 0.95,
+    fontSize: 20,
+    fontWeight: 700,
+    color: "var(--accent)",
     textShadow: "0 2px 12px rgba(0,0,0,.45)",
   };
   return (
     <div style={wrap}>
       <div style={nameStyle}>{name}</div>
-      <div style={verStyle}>{version}</div>
+      <div style={verStyle}>Version {version}</div>
     </div>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,11 +5,13 @@ import { useCalendar } from "../features/calendar/useCalendar";
 import HoverCircle from "../components/HoverCircle";
 import FeatureCarousel from "../components/FeatureCarousel";
 import VersionBadge from "../components/VersionBadge";
+import { useTheme } from "../theme";
 
 export default function Home() {
   const [hoverColor, setHoverColor] = useState("rgba(255,255,255,0.22)");
   const { events, selectedCountdownId } = useCalendar();
   const countdownEvents = events.filter((e) => e.hasCountdown);
+  const { accent } = useTheme();
   let event = null as typeof countdownEvents[number] | null;
   if (selectedCountdownId) {
     event = countdownEvents.find((e) => e.id === selectedCountdownId) || null;
@@ -19,22 +21,6 @@ export default function Home() {
 
   return (
     <>
-      {event && (
-        <div
-          style={{
-            position: "absolute",
-            top: 12,
-            right: 12,
-            zIndex: 50,
-            color: "#fff",
-            textAlign: "right",
-          }}
-        >
-          <div style={{ fontSize: 14 }}>
-            <strong>{event.title}:</strong> <Countdown target={event.date} />
-          </div>
-        </div>
-      )}
       {/* Top-center app title and version */}
       <div
         style={{
@@ -45,11 +31,25 @@ export default function Home() {
           zIndex: 50,
           pointerEvents: "none",
           textAlign: "center",
-          color: "#fff",
+          color: "var(--text)",
         }}
       >
-        <h1 style={{ margin: 0, fontSize: "2rem" }}>Blossom</h1>
-        <VersionBadge version="0.1.3" />
+        <VersionBadge />
+        {event && (
+          <div
+            style={{
+              marginTop: 4,
+              fontSize: 14,
+              display: "inline-block",
+              padding: "2px 10px",
+              borderRadius: 12,
+              background: "rgba(0,0,0,0.35)",
+              color: accent,
+            }}
+          >
+            <strong>{event.title}:</strong> <Countdown target={event.date} />
+          </div>
+        )}
       </div>
 
       {/* Background hover effect */}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -8,10 +8,20 @@ import {
   MenuItem,
 } from "@mui/material";
 import { useCalendar } from "../features/calendar/useCalendar";
+import { useTheme, ThemeName } from "../theme";
 
 export default function Settings() {
   const { events, selectedCountdownId, setSelectedCountdownId } = useCalendar();
   const countdownEvents = events.filter((e) => e.hasCountdown);
+  const { theme, setTheme } = useTheme();
+  const themes: ThemeName[] = [
+    "light",
+    "dark",
+    "chocolate",
+    "galaxy",
+    "forest",
+    "synthwave",
+  ];
   return (
     <Box sx={{ height: "100vh", display: "grid", placeItems: "center" }}>
       <Paper elevation={3} sx={{ p: 4, borderRadius: 3, minWidth: 360 }}>
@@ -39,6 +49,21 @@ export default function Settings() {
             </Select>
           </FormControl>
         )}
+        <FormControl fullWidth sx={{ mt: 3 }}>
+          <InputLabel id="theme-label">Theme</InputLabel>
+          <Select
+            labelId="theme-label"
+            label="Theme"
+            value={theme}
+            onChange={(e) => setTheme(e.target.value as ThemeName)}
+          >
+            {themes.map((t) => (
+              <MenuItem key={t} value={t}>
+                {t.charAt(0).toUpperCase() + t.slice(1)}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
       </Paper>
     </Box>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,8 +1,67 @@
-:root { color-scheme: dark; }
 * { box-sizing: border-box; }
 html, body, #root { height: 100%; margin: 0; }
+:root {
+  --bg: radial-gradient(circle at center, #701f1f, #290808);
+  --text: #fff;
+  --accent: #00bcd4;
+  color-scheme: dark;
+}
 body {
-  background: #290808;                /* light grey canvas */
-  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Arial;
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Arial;
 }
 a { color: inherit; text-decoration: none; }
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: radial-gradient(circle at center, #701f1f, #290808);
+  --text: #fff;
+  --accent: #00bcd4;
+}
+
+[data-theme="light"] {
+  color-scheme: light;
+  --bg: radial-gradient(circle at center, #fdfdfd, #d0d0d0);
+  --text: #111;
+  --accent: #006064;
+}
+
+[data-theme="chocolate"] {
+  color-scheme: dark;
+  --bg: radial-gradient(circle at center, #5d4037, #3e2723);
+  --text: #fff;
+  --accent: #ffab40;
+}
+
+[data-theme="galaxy"] {
+  color-scheme: dark;
+  --bg: radial-gradient(circle at center, #1a237e, #000000);
+  --text: #e0f7fa;
+  --accent: #b388ff;
+}
+
+[data-theme="forest"] {
+  color-scheme: dark;
+  --bg: radial-gradient(circle at center, #2e7d32, #1b5e20);
+  --text: #e8f5e9;
+  --accent: #a5d6a7;
+}
+
+[data-theme="synthwave"] {
+  color-scheme: dark;
+  --bg: radial-gradient(circle at center, #2b0032, #000000);
+  --text: #ffffff;
+  --accent: #ff4081;
+}
+
+@keyframes glowPulse {
+  0%, 100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0.6;
+  }
+  50% {
+    transform: translate(-50%, -50%) scale(1.3);
+    opacity: 1;
+  }
+}

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+export type ThemeName =
+  | "light"
+  | "dark"
+  | "chocolate"
+  | "galaxy"
+  | "forest"
+  | "synthwave";
+
+const ACCENTS: Record<ThemeName, string> = {
+  light: "#006064",
+  dark: "#00bcd4",
+  chocolate: "#ffab40",
+  galaxy: "#b388ff",
+  forest: "#a5d6a7",
+  synthwave: "#ff4081",
+};
+
+const ThemeContext = createContext({
+  theme: "dark" as ThemeName,
+  accent: ACCENTS.dark,
+  setTheme: (_t: ThemeName) => {},
+});
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<ThemeName>("dark");
+
+  useEffect(() => {
+    document.body.dataset.theme = theme;
+  }, [theme]);
+
+  const accent = ACCENTS[theme];
+
+  return (
+    <ThemeContext.Provider value={{ theme, accent, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}


### PR DESCRIPTION
## Summary
- Fix home button color and highlight settings with theme accent
- Add theme picker with light, dark, chocolate, galaxy, forest, and synthwave schemes
- Soften carousel glow with blurred pulsing radial animation and place countdown beneath version badge

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c1f3684048325a4efcf8c304a3516