### PR TITLE
Add feature buttons to assistant page

### DIFF
--- a/src/pages/Assistant.tsx
+++ b/src/pages/Assistant.tsx
@@ -1,2 +1,28 @@
+import { Button, Stack } from "@mui/material";
 import Center from "./_Center";
-export default function Assistant(){ return <Center>AI Assistant</Center>; }
+
+const features = [
+  "Prompt Factory",
+  "Script",
+  "Music",
+  "SEO",
+  "Orchestration",
+  "RAG",
+  "Chat",
+  "World Builder",
+  "Big Brother updates",
+];
+
+export default function Assistant() {
+  return (
+    <Center>
+      <Stack spacing={2} sx={{ width: "100%", maxWidth: 400 }}>
+        {features.map((feature) => (
+          <Button key={feature} variant="contained">
+            {feature}
+          </Button>
+        ))}
+      </Stack>
+    </Center>
+  );
+}


### PR DESCRIPTION
## Summary
- Add placeholder buttons for various AI assistant features

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c27cadd08832591ef59a2457999d1