### PR TITLE
Add tag usage statistics to calendar

### DIFF
--- a/src/components/TagStats.tsx
+++ b/src/components/TagStats.tsx
@@ -1,0 +1,21 @@
+import { useCalendar } from "../features/calendar/useCalendar";
+
+export default function TagStats() {
+  const { tagTotals } = useCalendar();
+  const entries = Object.entries(tagTotals);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div style={{ marginTop: 20 }}>
+      <h3>Tag Stats</h3>
+      <ul>
+        {entries.map(([tag, ms]) => (
+          <li key={tag}>
+            {tag}: {(ms / (1000 * 60 * 60)).toFixed(2)}h
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useCalendar } from "../features/calendar/useCalendar";
 import Countdown from "../components/Countdown";
+import TagStats from "../components/TagStats";
 
 function pad(n: number) {
   return n.toString().padStart(2, "0");
@@ -168,6 +169,7 @@ export default function Calendar() {
           Add
         </button>
       </div>
+      <TagStats />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add TagStats component to display total hours per tag using existing calendar store
- render TagStats on the calendar page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cf134416c8325b0a8e295db0b5f7a