### PR TITLE
Optimize Calendar holiday initialization

### DIFF
--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,10 +1,17 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useCalendar } from "../features/calendar/useCalendar";
 import Countdown from "../components/Countdown";
 
 function pad(n: number) {
   return n.toString().padStart(2, "0");
 }
+
+const HOLIDAYS = [
+  { month: 0, day: 1, title: "New Year's Day" },
+  { month: 6, day: 4, title: "Independence Day" },
+  { month: 10, day: 31, title: "Halloween" },
+  { month: 11, day: 25, title: "Christmas Day" },
+];
 
 export default function Calendar() {
   const [current, setCurrent] = useState(new Date());
@@ -16,7 +23,12 @@ export default function Calendar() {
     "scheduled" | "canceled" | "missed" | "completed"
   >("scheduled");
   const [hasCountdown, setHasCountdown] = useState(false);
-  const { events, addEvent } = useCalendar();
+  const events = useCalendar((s) => s.events);
+  const addEvent = useCalendar((s) => s.addEvent);
+  const eventsRef = useRef(events);
+  useEffect(() => {
+    eventsRef.current = events;
+  }, [events]);
 
   const year = current.getFullYear();
   const month = current.getMonth();
@@ -56,17 +68,11 @@ export default function Calendar() {
   };
 
   useEffect(() => {
-    const holidays = [
-      { month: 0, day: 1, title: "New Year's Day" },
-      { month: 6, day: 4, title: "Independence Day" },
-      { month: 10, day: 31, title: "Halloween" },
-      { month: 11, day: 25, title: "Christmas Day" },
-    ];
-    holidays.forEach((h) => {
+    HOLIDAYS.forEach((h) => {
       const start = new Date(year, h.month, h.day, 0, 0).toISOString();
       const end = new Date(year, h.month, h.day, 23, 59).toISOString();
       const dayStr = start.slice(0, 10);
-      if (!events.some((e) => e.title === h.title && e.date.slice(0, 10) === dayStr)) {
+      if (!eventsRef.current.some((e) => e.title === h.title && e.date.slice(0, 10) === dayStr)) {
         addEvent({
           title: h.title,
           date: start,
@@ -77,7 +83,7 @@ export default function Calendar() {
         });
       }
     });
-  }, [year, events, addEvent]);
+  }, [year]);
 
   return (
     <div style={{ padding: 20, paddingTop: 80 }}>


### PR DESCRIPTION
## Summary
- Limit holiday initialization effect to run only when the year changes
- Read calendar events via ref and memoize holiday list for clarity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689cf136ccc483258b412b766b014448