### PR TITLE
feat: add piano instrument option

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -43,6 +43,7 @@ const INSTR = [
   "upright bass",
   "pads",
   "electric piano",
+  "piano",
   "clean electric guitar",
   "airy pads",
 ];


### PR DESCRIPTION
## Summary
- expose new `piano` instrument toggle in SongForm for lofi_gpu_hq

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d061d6304832587e16b0344066944