### PR TITLE
Validate event time ordering

### DIFF
--- a/src/features/calendar/tests/useCalendar.test.ts
+++ b/src/features/calendar/tests/useCalendar.test.ts
@@ -71,5 +71,17 @@ describe('useCalendar store', () => {
     expect(totals.work).toBe(1.5 * hour);
     expect(totals.play).toBe(0.5 * hour);
   });
+
+  it('rejects events where end is not after start', () => {
+    useCalendar.getState().addEvent({
+      title: 'Bad',
+      date: '2024-01-01T09:00',
+      end: '2024-01-01T09:00',
+      tags: [],
+      status: 'scheduled',
+      hasCountdown: false,
+    });
+    expect(useCalendar.getState().events).toHaveLength(0);
+  });
 });
 

--- a/src/features/calendar/useCalendar.ts
+++ b/src/features/calendar/useCalendar.ts
@@ -32,11 +32,15 @@ export const useCalendar = create<CalendarState & Actions>()(
         events: [],
         selectedCountdownId: null,
         tagTotals: {},
-        addEvent: (e) =>
+        addEvent: (e) => {
+          const start = new Date(e.date).getTime();
+          const end = new Date(e.end).getTime();
+          if (end <= start) return;
           set((state) => {
             const events = [...state.events, { id: crypto.randomUUID(), ...e }];
             return { events, tagTotals: recalc(events) };
-          }),
+          });
+        },
         updateEvent: (id, patch) =>
           set((state) => {
             const events = state.events.map((ev) =>

--- a/src/pages/Calendar.test.tsx
+++ b/src/pages/Calendar.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Calendar from './Calendar';
+import { useCalendar } from '../features/calendar/useCalendar';
+
+describe('Calendar time validation', () => {
+  beforeEach(() => {
+    useCalendar.setState({ events: [], selectedCountdownId: null, tagTotals: {} });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useCalendar.setState({ events: [], selectedCountdownId: null, tagTotals: {} });
+  });
+
+  it('allows adding events with valid times', () => {
+    render(<Calendar />);
+    fireEvent.change(screen.getByPlaceholderText('Title'), {
+      target: { value: 'Meeting' },
+    });
+    fireEvent.change(screen.getByTestId('date-input'), {
+      target: { value: '2024-01-01T09:00' },
+    });
+    fireEvent.change(screen.getByTestId('end-input'), {
+      target: { value: '2024-01-01T10:00' },
+    });
+    const addButton = screen.getByTestId('add-button');
+    expect(addButton).not.toBeDisabled();
+    expect(screen.queryByTestId('time-error')).toBeNull();
+    fireEvent.click(addButton);
+    expect(
+      useCalendar.getState().events.some((e) => e.title === 'Meeting')
+    ).toBe(true);
+  });
+
+  it('disables add when end is before start', () => {
+    render(<Calendar />);
+    fireEvent.change(screen.getByPlaceholderText('Title'), {
+      target: { value: 'Meeting' },
+    });
+    fireEvent.change(screen.getByTestId('date-input'), {
+      target: { value: '2024-01-01T10:00' },
+    });
+    fireEvent.change(screen.getByTestId('end-input'), {
+      target: { value: '2024-01-01T09:00' },
+    });
+    const addButton = screen.getByTestId('add-button');
+    expect(addButton).toBeDisabled();
+    expect(screen.getByTestId('time-error')).toBeInTheDocument();
+    fireEvent.click(addButton);
+    expect(
+      useCalendar.getState().events.some((e) => e.title === 'Meeting')
+    ).toBe(false);
+  });
+});

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -19,6 +19,7 @@ export default function Calendar() {
   const [title, setTitle] = useState("");
   const [date, setDate] = useState("");
   const [end, setEnd] = useState("");
+  const [timeError, setTimeError] = useState(false);
   const [tags, setTags] = useState("");
   const [status, setStatus] = useState<
     "scheduled" | "canceled" | "missed" | "completed"
@@ -41,7 +42,7 @@ export default function Calendar() {
   while (cells.length % 7 !== 0) cells.push(null);
 
   const add = () => {
-    if (!title || !date || !end) return;
+    if (!title || !date || !end || timeError) return;
     const tagsArr = tags
       .split(",")
       .map((t) => t.trim())
@@ -54,6 +55,14 @@ export default function Calendar() {
     setStatus("scheduled");
     setHasCountdown(false);
   };
+
+  useEffect(() => {
+    if (!date || !end) {
+      setTimeError(false);
+      return;
+    }
+    setTimeError(new Date(end).getTime() <= new Date(date).getTime());
+  }, [date, end]);
 
   const dayEvents = (day: number) => {
     const dayStr = `${year}-${pad(month + 1)}-${pad(day)}`;
@@ -155,6 +164,11 @@ export default function Calendar() {
           value={end}
           onChange={(e) => setEnd(e.target.value)}
         />
+        {timeError && (
+          <div style={{ color: "red" }} data-testid="time-error">
+            End time must be after start time
+          </div>
+        )}
         <input
           placeholder="Tags (comma separated)"
           value={tags}
@@ -174,7 +188,12 @@ export default function Calendar() {
           />
           Countdown
         </label>
-        <button onClick={add} style={{ marginLeft: 8 }} data-testid="add-button">
+        <button
+          onClick={add}
+          style={{ marginLeft: 8 }}
+          data-testid="add-button"
+          disabled={timeError}
+        >
           Add
         </button>
       </div>


### PR DESCRIPTION
## Summary
- prevent creating calendar events where end time is not after start
- surface inline time validation in Calendar page and disable Add button
- test valid and invalid time ranges for store and UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d063bdc9483258d25c89706091c0a