### PR TITLE
Add double-click creation and event deletion to calendar

### DIFF
--- a/src/components/CalendarDay.tsx
+++ b/src/components/CalendarDay.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import type { CalendarEvent } from '../features/calendar/types';
+import { useCalendar } from '../features/calendar/useCalendar';
 
 interface Props {
   day: number | null;
@@ -9,6 +10,8 @@ interface Props {
 }
 
 const CalendarDay = React.memo(({ day, events, onDayClick, isToday }: Props) => {
+  const removeEvent = useCalendar((s) => s.removeEvent);
+
   const handleClick = useCallback(() => {
     if (day) onDayClick(day);
   }, [day, onDayClick]);
@@ -24,6 +27,7 @@ const CalendarDay = React.memo(({ day, events, onDayClick, isToday }: Props) => 
         isToday ? 'bg-blue-100 border-blue-300' : 'bg-white'
       }`}
       onClick={handleClick}
+      onDoubleClick={handleClick}
       onKeyDown={(e) => e.key === 'Enter' && handleClick()}
       tabIndex={0}
       role="gridcell"
@@ -31,8 +35,22 @@ const CalendarDay = React.memo(({ day, events, onDayClick, isToday }: Props) => 
     >
       <div className="font-semibold text-gray-900 mb-1">{day}</div>
       {events.map((ev) => (
-        <div key={ev.id} className="text-xs truncate">
-          {ev.title}
+        <div
+          key={ev.id}
+          className="text-xs truncate group flex items-center"
+        >
+          <span className="flex-1">{ev.title}</span>
+          <button
+            type="button"
+            aria-label="Delete event"
+            className="ml-1 text-red-500 opacity-0 group-hover:opacity-100"
+            onClick={(e) => {
+              e.stopPropagation();
+              removeEvent(ev.id);
+            }}
+          >
+            ×
+          </button>
         </div>
       ))}
     </div>

--- a/src/pages/Calendar.test.tsx
+++ b/src/pages/Calendar.test.tsx
@@ -60,4 +60,36 @@ describe('Calendar time validation', () => {
     fireEvent.keyDown(document, { key: 'ArrowRight' });
     expect(screen.getByTestId('day-2')).toHaveFocus();
   });
+
+  it('prefills times when double clicking a day', () => {
+    render(<Calendar />);
+    const day1 = screen.getByTestId('day-1');
+    fireEvent.doubleClick(day1);
+    const dateInput = screen.getByTestId('date-input') as HTMLInputElement;
+    const endInput = screen.getByTestId('end-input') as HTMLInputElement;
+    expect(dateInput.value).toMatch(/T09:00/);
+    expect(endInput.value).toMatch(/T10:00/);
+  });
+
+  it('allows deleting events', () => {
+    render(<Calendar />);
+    const now = new Date();
+    const yyyy = now.getFullYear();
+    const mm = String(now.getMonth() + 1).padStart(2, '0');
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'Meeting' },
+    });
+    fireEvent.change(screen.getByTestId('date-input'), {
+      target: { value: `${yyyy}-${mm}-01T09:00` },
+    });
+    fireEvent.change(screen.getByTestId('end-input'), {
+      target: { value: `${yyyy}-${mm}-01T10:00` },
+    });
+    fireEvent.click(screen.getByTestId('add-button'));
+    const deleteBtn = screen.getByLabelText('Delete event');
+    fireEvent.click(deleteBtn);
+    expect(
+      useCalendar.getState().events.some((e) => e.title === 'Meeting')
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Allow double-clicking on a day to start creating an event
- Add delete buttons to inline event listings
- Test double-click behavior and event deletion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ec53a7de08325ae3ef2ea724f9a04