### PR TITLE
Add selectable themes and integrate with settings

### DIFF
--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+export type Theme = "default" | "ocean" | "forest" | "sunset" | "sakura";
+
+interface ThemeContextType {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored === "ocean" || stored === "forest" || stored === "sunset" || stored === "sakura") {
+      return stored;
+    }
+    return "default";
+  });
+
+  useEffect(() => {
+    const classes = ["theme-default", "theme-ocean", "theme-forest", "theme-sunset", "theme-sakura"];
+    document.body.classList.remove(...classes);
+    document.body.classList.add(`theme-${theme}`);
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error("useTheme must be used within ThemeProvider");
+  }
+  return ctx;
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./styles.css";
+import { ThemeProvider } from "./features/theme/ThemeContext";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,13 +1,25 @@
 // src/pages/Home.tsx
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Countdown from "../components/Countdown";
 import { useCalendar } from "../features/calendar/useCalendar";
 import HoverCircle from "../components/HoverCircle";
 import FeatureCarousel from "../components/FeatureCarousel";
 import VersionBadge from "../components/VersionBadge";
+import { Theme, useTheme } from "../features/theme/ThemeContext";
 
 export default function Home() {
-  const [hoverColor, setHoverColor] = useState("rgba(255,255,255,0.22)");
+  const { theme } = useTheme();
+  const themeColors: Record<Theme, string> = {
+    default: "rgba(255,255,255,0.22)",
+    ocean: "rgba(0,150,255,0.22)",
+    forest: "rgba(0,255,150,0.22)",
+    sunset: "rgba(255,150,0,0.22)",
+    sakura: "rgba(255,150,200,0.22)",
+  };
+  const [hoverColor, setHoverColor] = useState(themeColors[theme]);
+  useEffect(() => {
+    setHoverColor(themeColors[theme]);
+  }, [theme]);
   const { events, selectedCountdownId } = useCalendar();
   const countdownEvents = events.filter(
     (e) => e.hasCountdown && e.status !== "canceled" && e.status !== "missed"

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -8,8 +8,10 @@ import {
   MenuItem,
 } from "@mui/material";
 import { useCalendar } from "../features/calendar/useCalendar";
+import { Theme, useTheme } from "../features/theme/ThemeContext";
 
 export default function Settings() {
+  const { theme, setTheme } = useTheme();
   const { events, selectedCountdownId, setSelectedCountdownId } = useCalendar();
   const countdownEvents = events.filter(
     (e) => e.hasCountdown && e.status !== "canceled" && e.status !== "missed"
@@ -21,6 +23,21 @@ export default function Settings() {
         <Typography variant="body2" color="text.secondary">
           Put toggles, theme, and module switches here.
         </Typography>
+        <FormControl fullWidth sx={{ mt: 3 }}>
+          <InputLabel id="theme-label">Theme</InputLabel>
+          <Select
+            labelId="theme-label"
+            label="Theme"
+            value={theme}
+            onChange={(e) => setTheme(e.target.value as Theme)}
+          >
+            <MenuItem value="default">Default</MenuItem>
+            <MenuItem value="ocean">Ocean</MenuItem>
+            <MenuItem value="forest">Forest</MenuItem>
+            <MenuItem value="sunset">Sunset</MenuItem>
+            <MenuItem value="sakura">Sakura</MenuItem>
+          </Select>
+        </FormControl>
         {countdownEvents.length > 0 && (
           <FormControl fullWidth sx={{ mt: 3 }}>
             <InputLabel id="countdown-label">Home Countdown</InputLabel>

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,7 +6,22 @@
 * { box-sizing: border-box; }
 html, body, #root { height: 100%; margin: 0; }
 body {
-  background: radial-gradient(circle at center, #3d0a0a, #290808);
   font-family: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Arial;
 }
 a { color: inherit; text-decoration: none; }
+
+body.theme-default {
+  background: radial-gradient(circle at center, #3d0a0a, #290808);
+}
+body.theme-ocean {
+  background: radial-gradient(circle at center, #0a3d5e, #082938);
+}
+body.theme-forest {
+  background: radial-gradient(circle at center, #0a3d1a, #082912);
+}
+body.theme-sunset {
+  background: radial-gradient(circle at center, #5e2a0a, #381a08);
+}
+body.theme-sakura {
+  background: radial-gradient(circle at center, #5e0a3d, #380829);
+}


### PR DESCRIPTION
## Summary
- Introduce ThemeContext with persistence and body class management
- Add five themes with unique backgrounds and hover colors
- Allow selecting themes from Settings and apply changes to Home screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ed830e6e48325ae7f32136dffceef