### PR TITLE
Add General Chat via local Ollama model

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "ureq",
 ]
 
 [[package]]
@@ -3095,6 +3096,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3120,6 +3135,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3548,6 +3598,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -4381,6 +4437,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4699,6 +4779,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4889,6 +4987,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5346,6 +5453,12 @@ dependencies = [
  "syn 2.0.104",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,4 +25,5 @@ tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+ureq = { version = "2", features = ["json"] }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -14,6 +14,9 @@ fn main() {
       commands::comfy_status,
       commands::comfy_start,
       commands::comfy_stop,
+      // Ollama general chat:
+      commands::start_ollama,
+      commands::general_chat,
       // Blender:
       commands::blender_run_script,
     ])

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Music from "./pages/Music";
 import Calendar from "./pages/Calendar";
 import Comfy from "./pages/Comfy";
 import Assistant from "./pages/Assistant";
+import GeneralChat from "./pages/GeneralChat";
 import Laser from "./pages/Laser";
 import Lofi from "./pages/Lofi";
 
@@ -24,6 +25,7 @@ export default function App() {
         <Route path="/calendar" element={<Calendar />} />
         <Route path="/comfy" element={<Comfy />} />
         <Route path="/assistant" element={<Assistant />} />
+        <Route path="/assistant/general-chat" element={<GeneralChat />} />
         <Route path="/laser" element={<Laser />} />
         <Route path="/lofi" element={<Lofi />} />
       </Routes>

--- a/src/pages/Assistant.tsx
+++ b/src/pages/Assistant.tsx
@@ -1,25 +1,36 @@
 import { Button, Stack } from "@mui/material";
+import { useNavigate } from "react-router-dom";
 import Center from "./_Center";
 
-const features = [
-  "Prompt Factory",
-  "Script",
-  "Music",
-  "SEO",
-  "Orchestration",
-  "RAG",
-  "Chat",
-  "World Builder",
-  "Big Brother updates",
+interface Feature {
+  label: string;
+  path?: string;
+}
+
+const features: Feature[] = [
+  { label: "Prompt Factory" },
+  { label: "Script" },
+  { label: "Music" },
+  { label: "SEO" },
+  { label: "Orchestration" },
+  { label: "RAG" },
+  { label: "General Chat", path: "/assistant/general-chat" },
+  { label: "World Builder" },
+  { label: "Big Brother updates" },
 ];
 
 export default function Assistant() {
+  const navigate = useNavigate();
   return (
     <Center>
       <Stack spacing={2} sx={{ width: "100%", maxWidth: 400 }}>
         {features.map((feature) => (
-          <Button key={feature} variant="contained">
-            {feature}
+          <Button
+            key={feature.label}
+            variant="contained"
+            onClick={() => feature.path && navigate(feature.path)}
+          >
+            {feature.label}
           </Button>
         ))}
       </Stack>

--- a/src/pages/GeneralChat.tsx
+++ b/src/pages/GeneralChat.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/tauri";
+import { listen } from "@tauri-apps/api/event";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import Center from "./_Center";
+
+interface Message {
+  role: "user" | "assistant" | "system";
+  content: string;
+  ts: number;
+}
+
+export default function GeneralChat() {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [status, setStatus] = useState<"init" | "starting" | "ready" | "error">("init");
+  const [error, setError] = useState<string>("");
+  const [logs, setLogs] = useState<string[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("generalChatHistory");
+    if (stored) {
+      try {
+        const parsed: Message[] = JSON.parse(stored);
+        const now = Date.now();
+        const tenDays = 10 * 24 * 60 * 60 * 1000;
+        const pruned = parsed.filter((m) => now - m.ts < tenDays);
+        setMessages(pruned);
+        localStorage.setItem("generalChatHistory", JSON.stringify(pruned));
+      } catch {
+        // ignore
+      }
+    }
+
+    const unlistenPromise = listen<string>("ollama_log", (e) => {
+      setLogs((prev) => [...prev, e.payload]);
+    });
+
+    startEngine();
+
+    return () => {
+      unlistenPromise.then((f) => f());
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function startEngine() {
+    setStatus("starting");
+    setLogs([]);
+    try {
+      await invoke("start_ollama");
+      setStatus("ready");
+    } catch (e) {
+      setError(String(e));
+      setStatus("error");
+    }
+  }
+
+  async function send() {
+    if (!input.trim()) return;
+    const userMsg: Message = { role: "user", content: input, ts: Date.now() };
+    const newMessages = [...messages, userMsg];
+    setMessages(newMessages);
+    setInput("");
+    setLoading(true);
+    try {
+      const reply: string = await invoke("general_chat", {
+        messages: newMessages.map(({ role, content }) => ({ role, content })),
+      });
+      const asst: Message = { role: "assistant", content: reply, ts: Date.now() };
+      const updated = [...newMessages, asst];
+      setMessages(updated);
+      localStorage.setItem("generalChatHistory", JSON.stringify(updated));
+    } catch (e) {
+      setError(String(e));
+      setStatus("error");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (status !== "ready") {
+    return (
+      <Center>
+        <Stack spacing={2} sx={{ width: "100%", maxWidth: 500 }}>
+          {status === "starting" && (
+            <>
+              <Typography>Starting local AI…</Typography>
+              {logs.length > 0 && (
+                <Box sx={{ maxHeight: 200, overflowY: "auto", bgcolor: "#000", color: "#0f0", p: 1 }}>
+                  {logs.map((l, i) => (
+                    <Typography key={i} variant="body2">
+                      {l}
+                    </Typography>
+                  ))}
+                </Box>
+              )}
+            </>
+          )}
+          {status === "error" && (
+            <>
+              <Typography color="error">{error}</Typography>
+              <Button variant="contained" onClick={startEngine}>
+                Restart local AI
+              </Button>
+            </>
+          )}
+        </Stack>
+      </Center>
+    );
+  }
+
+  return (
+    <Center>
+      <Stack spacing={2} sx={{ width: "100%", maxWidth: 600, height: "100%" }}>
+        <Box sx={{ flexGrow: 1, overflowY: "auto", width: "100%" }}>
+          {messages.map((m, i) => (
+            <Box
+              key={i}
+              sx={{
+                display: "flex",
+                justifyContent: m.role === "user" ? "flex-end" : "flex-start",
+                my: 1,
+              }}
+            >
+              <Box
+                sx={{
+                  bgcolor: m.role === "user" ? "primary.main" : "grey.300",
+                  color: m.role === "user" ? "primary.contrastText" : "text.primary",
+                  borderRadius: 1,
+                  p: 1,
+                  maxWidth: "80%",
+                  whiteSpace: "pre-wrap",
+                }}
+              >
+                {m.content}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+        <Stack direction="row" spacing={1}>
+          <TextField
+            fullWidth
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                send();
+              }
+            }}
+          />
+          <Button variant="contained" onClick={send} disabled={loading}>
+            Send
+          </Button>
+          {loading && <CircularProgress size={24} />}
+        </Stack>
+      </Stack>
+    </Center>
+  );
+}


### PR DESCRIPTION
## Summary
- launch `ollama serve` and auto-pull `gpt-oss:20b` for chat
- add Tauri commands and React UI for General Chat with 10-day history
- wire General Chat tab into Assistant page and routing

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed7e8085c83258a162cc71720c0d1