### PR TITLE
Refine lofi mix balance and ambience

### DIFF
--- a/src-tauri/python/lofi_gpu.py
+++ b/src-tauri/python/lofi_gpu.py
@@ -117,9 +117,9 @@ def enhanced_post_process_chain(audio: AudioSegment, rng=None) -> AudioSegment:
     a = audio.high_pass_filter(30)
 
     # multi-stage low-pass to emulate vintage gear
-    lpf_base = 7500
+    lpf_base = 7800
     if rng is not None:
-        lpf_base = int(rng.integers(6500, 8500))
+        lpf_base = int(rng.integers(7000, 8500))
     a = a.low_pass_filter(lpf_base + 500)
     a = a.low_pass_filter(lpf_base)
 
@@ -573,15 +573,16 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60):
     if "rain" in amb_list:
         r = (np.random.rand(n).astype(np.float32)*2-1)*0.01
         r = _butter_lowpass(r, 1200)
+        r = _butter_highpass(r, 200)
         amb_mix += r
     if "cafe" in amb_list:
         c = (np.random.rand(n).astype(np.float32)*2-1)*0.0015
         c = _butter_lowpass(c, 3000)
-        mid = _butter_bandpass(c, 1000, 2000)
+        mid = _butter_bandpass(c, 1200, 1800)
         c -= mid * 0.15
         amb_mix += c
 
-    mix = 0.72*drums + 0.55*hats + 0.68*keys + 0.52*bass + 0.12*amb_mix*amb_level
+    mix = 0.66*drums + 0.44*hats + 0.73*keys + 0.49*bass + 0.08*amb_mix*amb_level
     mix = mix.astype(np.float32)
     return _np_to_segment(mix)
 

--- a/src-tauri/python/lofi_gpu_hq.py
+++ b/src-tauri/python/lofi_gpu_hq.py
@@ -167,9 +167,9 @@ def enhanced_post_process_chain(audio: AudioSegment, rng=None) -> AudioSegment:
     """Darker, warmer finishing chain for lofi character."""
     a = audio.high_pass_filter(30)
 
-    lpf_base = 7500
+    lpf_base = 7800
     if rng is not None:
-        lpf_base = int(rng.integers(6500, 8500))
+        lpf_base = int(rng.integers(7000, 8500))
     a = a.low_pass_filter(lpf_base + 500)
     a = a.low_pass_filter(lpf_base)
 
@@ -537,10 +537,10 @@ def _swing_offset(eighth_ms, sub_idx, swing=0.58):
 def calculate_mix_levels(mood, section_name):
     """Calculate context-aware mix levels"""
     levels = {
-        "drum_gain": 0.35,
-        "hat_gain": 0.25,
+        "drum_gain": 0.32,
+        "hat_gain": 0.20,
         "key_gain": 1.0,
-        "bass_gain": 0.45,
+        "bass_gain": 0.42,
         "pad_gain": 0.7,
     }
 
@@ -722,7 +722,6 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60):
         chord_pos += chord_len
 
     if "piano" in instrs:
-        keys = keys * 1.06
         mood = motif.get("mood") or []
         if "calm" in mood or "melancholy" in mood or variety <= 40:
             hp_freq = rng.uniform(800, 1000)
@@ -769,11 +768,12 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60):
     if "rain" in amb_list:
         r = ((rng.random(n).astype(np.float32)*2-1) if rng is not None else (np.random.rand(n).astype(np.float32)*2-1)) * 0.004
         r = _butter_lowpass(r, 1200)
+        r = _butter_highpass(r, 200)
         amb_mix += r
     if "cafe" in amb_list:
         c = ((rng.random(n).astype(np.float32)*2-1) if rng is not None else (np.random.rand(n).astype(np.float32)*2-1)) * 0.0008
         c = _butter_lowpass(c, 3000)
-        mid = _butter_bandpass(c, 1000, 2000)
+        mid = _butter_bandpass(c, 1200, 1800)
         c -= mid * 0.15
         amb_mix += c
 
@@ -818,6 +818,8 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60):
 
     # final mix (mono bus)
     levels = calculate_mix_levels(mood, section_name)
+    if "piano" in instrs:
+        levels["key_gain"] *= 1.08
     drum_gain = levels["drum_gain"]
     hat_gain = levels["hat_gain"]
     key_gain = levels["key_gain"]


### PR DESCRIPTION
## Summary
- adjust bus gains for drums, hats, keys, and bass
- notch and high-pass ambience beds for cleaner mix
- align post-process tone tilt to 7–8.5 kHz range

## Testing
- `python -m py_compile src-tauri/python/lofi_gpu.py src-tauri/python/lofi_gpu_hq.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689edcf6f4c88325b21a33b6ac4b6983