### PR TITLE
refactor: switch tauri invoke import to core

### DIFF
--- a/src/pages/GeneralChat.tsx
+++ b/src/pages/GeneralChat.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { invoke } from "@tauri-apps/api/tauri";
+import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import {
   Box,


### PR DESCRIPTION
## Summary
- use `@tauri-apps/api/core` for `invoke` in general chat page

## Testing
- `npm run build` *(fails: Argument of type 'KeyboardEvent<HTMLDivElement>' is not assignable to parameter of type 'MouseEvent<HTMLDivElement, MouseEvent>'.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f84a481108325b6626e12ab5d5769