### PR TITLE
Use HQ lofi script

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -118,19 +118,23 @@ fn conda_python() -> PathBuf {
   PathBuf::from(r"C:\Users\Owner\.conda\envs\blossom-ml\python.exe")
 }
 
-/// Resolve path to the non-stream script (dev -> repo path; prod -> Resources).
+/// Resolve path to the HQ non-stream script (dev -> repo path; prod -> Resources).
 fn script_path<R: Runtime>(app: &AppHandle<R>) -> PathBuf {
   if let Ok(cwd) = std::env::current_dir() {
-    let dev = cwd.join("src-tauri").join("python").join("lofi_gpu.py");
+    let dev = cwd
+      .join("src-tauri")
+      .join("python")
+      .join("lofi_gpu_hq.py");
     if dev.exists() {
       return dev;
     }
   }
-  app.path()
+  app
+    .path()
     .resource_dir()
     .expect("resource dir")
     .join("python")
-    .join("lofi_gpu.py")
+    .join("lofi_gpu_hq.py")
 }
 
 /// Resolve path to the stream script.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,9 +30,9 @@
       "icons/icon.ico"
     ],
     "resources": [
-  "python/lofi_gpu.py",
-  "python/lofi_gpu_stream.py"
-]
+      "python/lofi_gpu_hq.py",
+      "python/lofi_gpu_stream.py"
+    ]
 
   }
 }


### PR DESCRIPTION
## Summary
- point `script_path` at the high-quality `lofi_gpu_hq.py`
- bundle the new HQ Python script with the Tauri app

## Testing
- `npm test`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: The system library `gio-2.0` required by crate `gio-sys` was not found)*
- `npx tauri build` *(fails: TypeScript errors in front-end build)*

------
https://chatgpt.com/codex/tasks/task_e_689f8ea86a048325bb95c380bfc8bb92