### PR TITLE
fix: type theme for markdown render

### DIFF
--- a/src/pages/GeneralChat.tsx
+++ b/src/pages/GeneralChat.tsx
@@ -9,6 +9,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import type { Theme } from "@mui/material/styles";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import Center from "./_Center";
@@ -136,7 +137,7 @@ export default function GeneralChat() {
               <Box
                 sx={{
                   bgcolor: m.role === "user" ? "primary.light" : "grey.100",
-                  color: (theme) =>
+                  color: (theme: Theme) =>
                     m.role === "user"
                       ? theme.palette.getContrastText(theme.palette.primary.light)
                       : theme.palette.text.primary,


### PR DESCRIPTION
## Summary
- import Theme type for styling in GeneralChat markdown messages
- annotate theme parameter to satisfy TypeScript when rendering ReactMarkdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f95d2b6248325a3296de01f87a5cc