### PR TITLE
Add stop_ollama command to terminate background Ollama server

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -523,6 +523,15 @@ pub async fn start_ollama<R: Runtime>(app: AppHandle<R>, window: Window<R>) -> R
 }
 
 #[tauri::command]
+pub async fn stop_ollama() -> Result<(), String> {
+  let mut lock = OLLAMA_CHILD.get_or_init(|| Mutex::new(None)).lock().unwrap();
+  if let Some(mut child) = lock.take() {
+    let _ = child.kill();
+  }
+  Ok(())
+}
+
+#[tauri::command]
 pub async fn general_chat(messages: Vec<ChatMessage>) -> Result<String, String> {
   let resp = ureq::post("http://127.0.0.1:11434/api/chat")
     .set("Content-Type", "application/json")

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,6 +16,7 @@ fn main() {
       commands::comfy_stop,
       // Ollama general chat:
       commands::start_ollama,
+      commands::stop_ollama,
       commands::general_chat,
       // Blender:
       commands::blender_run_script,


### PR DESCRIPTION
## Summary
- add stop_ollama command to terminate running Ollama process
- register stop_ollama Tauri command

## Testing
- `cargo test` *(fails: glib-2.0 not found)*
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689f962675288325bd26650065372e85