### PR TITLE
Add NotFound page and route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Assistant from "./pages/Assistant";
 import GeneralChat from "./pages/GeneralChat";
 import Laser from "./pages/Laser";
 import Lofi from "./pages/Lofi";
+import NotFound from "./pages/NotFound";
 
 export default function App() {
   return (
@@ -28,6 +29,7 @@ export default function App() {
         <Route path="/assistant/general-chat" element={<GeneralChat />} />
         <Route path="/laser" element={<Laser />} />
         <Route path="/lofi" element={<Lofi />} />
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </>
   );

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,12 @@
+import { Link } from "react-router-dom";
+
+export default function NotFound() {
+  return (
+    <div style={{ textAlign: "center", padding: "2rem" }}>
+      <h1>404 - Not Found</h1>
+      <p>The page you're looking for doesn't exist.</p>
+      <Link to="/">Back to Home</Link>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create NotFound page with link back home
- handle unmatched routes in App

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f9a0525688325b67a7bfb9288c1f1