### PR TITLE
feat: centralize process logging

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,10 +1,10 @@
 // src-tauri/src/commands.rs
 use std::{
-  fs,
-  io::{BufRead, BufReader, Read},
-  path::PathBuf,
-  process::{Child, Command as PCommand, Stdio},
-  sync::{Mutex, OnceLock},
+    fs,
+    io::{BufRead, BufReader, Read},
+    path::PathBuf,
+    process::{Child, Command as PCommand, Stdio},
+    sync::{Mutex, OnceLock},
 };
 
 use chrono::Local;
@@ -14,538 +14,595 @@ use tauri::{AppHandle, Emitter, Manager, Runtime, Window};
 use ureq;
 
 /* ==============================
-   ComfyUI launcher (no extra crate)
-   ============================== */
+ComfyUI launcher (no extra crate)
+============================== */
 
 static COMFY_CHILD: OnceLock<Mutex<Option<Child>>> = OnceLock::new();
 static OLLAMA_CHILD: OnceLock<Mutex<Option<Child>>> = OnceLock::new();
 
 fn comfy_dir() -> PathBuf {
-  // TODO: put your ComfyUI repo folder here
-  // e.g.: PathBuf::from(r"C:\dev\ComfyUI")
-  PathBuf::from(r"C:\Comfy\ComfyUI")
+    // TODO: put your ComfyUI repo folder here
+    // e.g.: PathBuf::from(r"C:\dev\ComfyUI")
+    PathBuf::from(r"C:\Comfy\ComfyUI")
 }
 
 // Reuse our python path from below
 fn comfy_python() -> PathBuf {
-  conda_python()
+    conda_python()
+}
+
+/// Spawn a command and forward its stdout and stderr to the frontend.
+///
+/// The command will have its standard streams piped and lines from both
+/// streams will be emitted to the provided [`Window`] under `event_name`.
+/// `stdout` lines are prefixed with `[out]` and `stderr` lines with `[err]`.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::process::Command;
+/// use tauri::Window;
+/// # let window: Window<()> = unimplemented!();
+/// let mut cmd = Command::new("echo");
+/// cmd.arg("hello world");
+/// let _child = spawn_with_logging(&mut cmd, window, "echo_log").unwrap();
+/// ```
+fn spawn_with_logging<R: Runtime>(
+    cmd: &mut PCommand,
+    window: Window<R>,
+    event_name: &str,
+) -> Result<Child, String> {
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(|e| e.to_string())?;
+
+    let stdout = child.stdout.take().map(BufReader::new);
+    let stderr = child.stderr.take().map(BufReader::new);
+
+    if let Some(mut out) = stdout {
+        let w = window.clone();
+        let evt = event_name.to_string();
+        std::thread::spawn(move || {
+            let mut line = String::new();
+            loop {
+                line.clear();
+                let Ok(n) = out.read_line(&mut line) else {
+                    break;
+                };
+                if n == 0 {
+                    break;
+                }
+                let _ = w.emit(&evt, format!("[out] {}", line.trim_end()));
+            }
+        });
+    }
+
+    if let Some(mut err) = stderr {
+        let w = window.clone();
+        let evt = event_name.to_string();
+        std::thread::spawn(move || {
+            let mut line = String::new();
+            loop {
+                line.clear();
+                let Ok(n) = err.read_line(&mut line) else {
+                    break;
+                };
+                if n == 0 {
+                    break;
+                }
+                let _ = w.emit(&evt, format!("[err] {}", line.trim_end()));
+            }
+        });
+    }
+
+    Ok(child)
 }
 
 #[tauri::command]
 pub async fn comfy_status() -> Result<bool, String> {
-  let lock = COMFY_CHILD.get_or_init(|| Mutex::new(None)).lock().unwrap();
-  Ok(lock.as_ref().is_some())
+    let lock = COMFY_CHILD.get_or_init(|| Mutex::new(None)).lock().unwrap();
+    Ok(lock.as_ref().is_some())
 }
 
-  #[tauri::command]
-  pub async fn comfy_start<R: Runtime>(window: Window<R>) -> Result<(), String> {
+#[tauri::command]
+pub async fn comfy_start<R: Runtime>(window: Window<R>) -> Result<(), String> {
     {
-      let lock = COMFY_CHILD.get_or_init(|| Mutex::new(None)).lock().unwrap();
-      if lock.is_some() {
-        return Ok(()); // already running
-      }
+        let lock = COMFY_CHILD.get_or_init(|| Mutex::new(None)).lock().unwrap();
+        if lock.is_some() {
+            return Ok(()); // already running
+        }
     }
 
-  let dir = comfy_dir();
-  if !dir.exists() {
-    return Err(format!("ComfyUI folder not found at {}", dir.display()));
-  }
-
-  let py = comfy_python();
-  if !py.exists() {
-    return Err(format!("Python not found at {}", py.display()));
-  }
-
-  let mut cmd = PCommand::new(&py);
-  cmd.current_dir(&dir)
-     .arg("main.py")
-     .arg("--port").arg("8188")
-     .arg("--listen") // remove if you only want localhost
-     .stdout(Stdio::piped())
-     .stderr(Stdio::piped());
-
-  let mut child = cmd.spawn().map_err(|e| format!("Failed to start ComfyUI: {e}"))?;
-
-  // stream logs
-  let mut stdout = BufReader::new(child.stdout.take().unwrap());
-  let mut stderr = BufReader::new(child.stderr.take().unwrap());
-  let w1 = window.clone();
-  let w2 = window.clone();
-
-  std::thread::spawn(move || {
-    let mut line = String::new();
-    loop {
-      line.clear();
-      let Ok(n) = stdout.read_line(&mut line) else { break };
-      if n == 0 { break; }
-      let _ = w1.emit("comfy_log", format!("[out] {}", line.trim_end()));
+    let dir = comfy_dir();
+    if !dir.exists() {
+        return Err(format!("ComfyUI folder not found at {}", dir.display()));
     }
-  });
 
-  std::thread::spawn(move || {
-    let mut line = String::new();
-    loop {
-      line.clear();
-      let Ok(n) = stderr.read_line(&mut line) else { break };
-      if n == 0 { break; }
-      let _ = w2.emit("comfy_log", format!("[err] {}", line.trim_end()));
+    let py = comfy_python();
+    if !py.exists() {
+        return Err(format!("Python not found at {}", py.display()));
     }
-  });
 
-  {
-    let mut lock = COMFY_CHILD.get_or_init(|| Mutex::new(None)).lock().unwrap();
-    *lock = Some(child);
-  }
+    let mut cmd = PCommand::new(&py);
+    cmd.current_dir(&dir)
+        .arg("main.py")
+        .arg("--port")
+        .arg("8188")
+        .arg("--listen"); // remove if you only want localhost
 
-  Ok(())
+    let child = spawn_with_logging(&mut cmd, window, "comfy_log")
+        .map_err(|e| format!("Failed to start ComfyUI: {e}"))?;
+
+    {
+        let mut lock = COMFY_CHILD.get_or_init(|| Mutex::new(None)).lock().unwrap();
+        *lock = Some(child);
+    }
+
+    Ok(())
 }
 
 #[tauri::command]
 pub async fn comfy_stop() -> Result<(), String> {
-  let mut lock = COMFY_CHILD.get_or_init(|| Mutex::new(None)).lock().unwrap();
-  if let Some(mut child) = lock.take() {
-    let _ = child.kill();
-  }
-  Ok(())
+    let mut lock = COMFY_CHILD.get_or_init(|| Mutex::new(None)).lock().unwrap();
+    if let Some(mut child) = lock.take() {
+        let _ = child.kill();
+    }
+    Ok(())
 }
 
 /* ==============================
-   Python paths
-   ============================== */
+Python paths
+============================== */
 
 /// Absolute path to your conda env's python.exe.
 fn conda_python() -> PathBuf {
-  PathBuf::from(r"C:\Users\Owner\.conda\envs\blossom-ml\python.exe")
+    PathBuf::from(r"C:\Users\Owner\.conda\envs\blossom-ml\python.exe")
 }
 
 /// Resolve path to the HQ non-stream script (dev -> repo path; prod -> Resources).
 fn script_path<R: Runtime>(app: &AppHandle<R>) -> PathBuf {
-  if let Ok(cwd) = std::env::current_dir() {
-    let dev = cwd
-      .join("src-tauri")
-      .join("python")
-      .join("lofi_gpu_hq.py");
-    if dev.exists() {
-      return dev;
+    if let Ok(cwd) = std::env::current_dir() {
+        let dev = cwd.join("src-tauri").join("python").join("lofi_gpu_hq.py");
+        if dev.exists() {
+            return dev;
+        }
     }
-  }
-  app
-    .path()
-    .resource_dir()
-    .expect("resource dir")
-    .join("python")
-    .join("lofi_gpu_hq.py")
+    app.path()
+        .resource_dir()
+        .expect("resource dir")
+        .join("python")
+        .join("lofi_gpu_hq.py")
 }
 
 /// Resolve path to the stream script.
 fn script_stream_path<R: Runtime>(app: &AppHandle<R>) -> PathBuf {
-  if let Ok(cwd) = std::env::current_dir() {
-    let dev = cwd.join("src-tauri").join("python").join("lofi_gpu_stream.py");
-    if dev.exists() {
-      return dev;
+    if let Ok(cwd) = std::env::current_dir() {
+        let dev = cwd
+            .join("src-tauri")
+            .join("python")
+            .join("lofi_gpu_stream.py");
+        if dev.exists() {
+            return dev;
+        }
     }
-  }
-  app.path()
-    .resource_dir()
-    .expect("resource dir")
-    .join("python")
-    .join("lofi_gpu_stream.py")
+    app.path()
+        .resource_dir()
+        .expect("resource dir")
+        .join("python")
+        .join("lofi_gpu_stream.py")
 }
 
 /* ==============================
-   Serde-mapped types (camelCase)
-   ============================== */
+Serde-mapped types (camelCase)
+============================== */
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Section {
-  pub name: String,
-  pub bars: u32,
+    pub name: String,
+    pub bars: u32,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")] // outDir -> out_dir, etc
 pub struct SongSpec {
-  pub title: String,
-  pub out_dir: String,
-  pub bpm: u32,
-  pub key: String,
-  pub structure: Vec<Section>,
-  pub mood: Vec<String>,
-  pub instruments: Vec<String>,
-  pub ambience: Vec<String>,
-  pub ambience_level: Option<f32>,
-  pub seed: u64,
-  pub variety: Option<u32>,
-  pub drum_pattern: Option<String>,
+    pub title: String,
+    pub out_dir: String,
+    pub bpm: u32,
+    pub key: String,
+    pub structure: Vec<Section>,
+    pub mood: Vec<String>,
+    pub instruments: Vec<String>,
+    pub ambience: Vec<String>,
+    pub ambience_level: Option<f32>,
+    pub seed: u64,
+    pub variety: Option<u32>,
+    pub drum_pattern: Option<String>,
 }
 
 /* ==============================
-   Audio commands
-   ============================== */
+Audio commands
+============================== */
 
 /// Non‑streaming generate (no progress). Returns a single wav path.
 #[tauri::command]
 pub async fn lofi_generate_gpu<R: Runtime>(
-  app: AppHandle<R>,
-  prompt: String,
-  duration: Option<u32>,
-  seed: Option<u64>,
+    app: AppHandle<R>,
+    prompt: String,
+    duration: Option<u32>,
+    seed: Option<u64>,
 ) -> Result<String, String> {
-  let py = conda_python();
-  if !py.exists() {
-    return Err(format!("Python not found at {}", py.display()));
-  }
+    let py = conda_python();
+    if !py.exists() {
+        return Err(format!("Python not found at {}", py.display()));
+    }
 
-  let script = script_path(&app);
-  if !script.exists() {
-    return Err(format!("Script not found at {}", script.display()));
-  }
+    let script = script_path(&app);
+    if !script.exists() {
+        return Err(format!("Script not found at {}", script.display()));
+    }
 
-  let dur = duration.unwrap_or(12);
-  let seed = seed.unwrap_or(42);
+    let dur = duration.unwrap_or(12);
+    let seed = seed.unwrap_or(42);
 
-  let output = PCommand::new(&py)
-    .arg("-u")
-    .arg(&script)
-    .arg("--prompt").arg(&prompt)
-    .arg("--duration").arg(dur.to_string())
-    .arg("--seed").arg(seed.to_string())
-    .output()
-    .map_err(|e| format!("Failed to start python: {e}"))?;
+    let output = PCommand::new(&py)
+        .arg("-u")
+        .arg(&script)
+        .arg("--prompt")
+        .arg(&prompt)
+        .arg("--duration")
+        .arg(dur.to_string())
+        .arg("--seed")
+        .arg(seed.to_string())
+        .output()
+        .map_err(|e| format!("Failed to start python: {e}"))?;
 
-  if !output.status.success() {
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    return Err(format!("Python exited with status {}:\n{}", output.status, stderr));
-  }
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "Python exited with status {}:\n{}",
+            output.status, stderr
+        ));
+    }
 
-  let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-  if stdout.is_empty() {
-    return Err("Python returned no path".into());
-  }
-  Ok(stdout)
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if stdout.is_empty() {
+        return Err("Python returned no path".into());
+    }
+    Ok(stdout)
 }
 
 /// Streaming generate (emits "lofi_progress" events). Returns the final wav path.
 #[tauri::command]
 pub async fn lofi_generate_gpu_stream<R: Runtime>(
-  window: Window<R>,
-  app: AppHandle<R>,
-  prompt: String,
-  total_seconds: u32,
-  bpm: Option<u32>,
-  style: Option<String>,
-  seed: Option<u64>,
-  out_dir: Option<String>,
+    window: Window<R>,
+    app: AppHandle<R>,
+    prompt: String,
+    total_seconds: u32,
+    bpm: Option<u32>,
+    style: Option<String>,
+    seed: Option<u64>,
+    out_dir: Option<String>,
 ) -> Result<String, String> {
-  let py = conda_python();
-  if !py.exists() {
-    return Err(format!("Python not found at {}", py.display()));
-  }
-
-  let script = script_stream_path(&app);
-  if !script.exists() {
-    return Err(format!("Script not found at {}", script.display()));
-  }
-
-  // Build the python process
-  let mut cmd = PCommand::new(py);
-  cmd.arg("-u")
-     .arg(&script)
-     .arg("--prompt").arg(&prompt)
-     .arg("--total-seconds").arg(total_seconds.to_string())
-     .arg("--seed").arg(seed.unwrap_or(42).to_string());
-
-  if let Some(b) = bpm { cmd.arg("--bpm").arg(b.to_string()); }
-  if let Some(s) = style { if !s.is_empty() { cmd.arg("--style").arg(s); } }
-
-  let mut child = cmd.stdout(Stdio::piped()).stderr(Stdio::piped())
-    .spawn()
-    .map_err(|e| format!("Failed to start python: {e}"))?;
-
-  // Read line-by-line from stdout; emit progress; capture FILE path
-  let mut stdout = BufReader::new(child.stdout.take().unwrap());
-  let mut final_path: Option<String> = None;
-
-  let mut line = String::new();
-  loop {
-    line.clear();
-    let read = stdout.read_line(&mut line).map_err(|e| e.to_string())?;
-    if read == 0 { break; }
-    let t = line.trim();
-
-    if let Some(rest) = t.strip_prefix("PROG ") {
-      if let Ok(p) = rest.parse::<u8>() {
-        let _ = window.emit("lofi_progress", p);
-      }
-    } else if let Some(rest) = t.strip_prefix("FILE ") {
-      final_path = Some(rest.to_string());
-    } else {
-      let _ = window.emit("lofi_progress", t.to_string());
+    let py = conda_python();
+    if !py.exists() {
+        return Err(format!("Python not found at {}", py.display()));
     }
-  }
 
-  // Drain stderr if needed
-  let mut stderr_s = String::new();
-  if let Some(mut e) = child.stderr.take() {
-    let _ = e.read_to_string(&mut stderr_s);
-  }
-
-  let status = child.wait().map_err(|e| e.to_string())?;
-  if !status.success() {
-    return Err(format!("Python exited with {status}: {stderr_s}"));
-  }
-
-  let mut path = match final_path {
-    Some(p) => PathBuf::from(p),
-    None => return Err("No FILE line received from python".into()),
-  };
-
-  if let Some(dir) = out_dir {
-    let dir_path = PathBuf::from(&dir);
-    fs::create_dir_all(&dir_path).map_err(|e| e.to_string())?;
-    if let Some(name) = path.file_name() {
-      let target = dir_path.join(name);
-      fs::rename(&path, &target).map_err(|e| e.to_string())?;
-      path = target;
+    let script = script_stream_path(&app);
+    if !script.exists() {
+        return Err(format!("Script not found at {}", script.display()));
     }
-  }
 
-  Ok(path.to_string_lossy().to_string())
+    // Build the python process
+    let mut cmd = PCommand::new(py);
+    cmd.arg("-u")
+        .arg(&script)
+        .arg("--prompt")
+        .arg(&prompt)
+        .arg("--total-seconds")
+        .arg(total_seconds.to_string())
+        .arg("--seed")
+        .arg(seed.unwrap_or(42).to_string());
+
+    if let Some(b) = bpm {
+        cmd.arg("--bpm").arg(b.to_string());
+    }
+    if let Some(s) = style {
+        if !s.is_empty() {
+            cmd.arg("--style").arg(s);
+        }
+    }
+
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("Failed to start python: {e}"))?;
+
+    // Read line-by-line from stdout; emit progress; capture FILE path
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    let mut final_path: Option<String> = None;
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let read = stdout.read_line(&mut line).map_err(|e| e.to_string())?;
+        if read == 0 {
+            break;
+        }
+        let t = line.trim();
+
+        if let Some(rest) = t.strip_prefix("PROG ") {
+            if let Ok(p) = rest.parse::<u8>() {
+                let _ = window.emit("lofi_progress", p);
+            }
+        } else if let Some(rest) = t.strip_prefix("FILE ") {
+            final_path = Some(rest.to_string());
+        } else {
+            let _ = window.emit("lofi_progress", t.to_string());
+        }
+    }
+
+    // Drain stderr if needed
+    let mut stderr_s = String::new();
+    if let Some(mut e) = child.stderr.take() {
+        let _ = e.read_to_string(&mut stderr_s);
+    }
+
+    let status = child.wait().map_err(|e| e.to_string())?;
+    if !status.success() {
+        return Err(format!("Python exited with {status}: {stderr_s}"));
+    }
+
+    let mut path = match final_path {
+        Some(p) => PathBuf::from(p),
+        None => return Err("No FILE line received from python".into()),
+    };
+
+    if let Some(dir) = out_dir {
+        let dir_path = PathBuf::from(&dir);
+        fs::create_dir_all(&dir_path).map_err(|e| e.to_string())?;
+        if let Some(name) = path.file_name() {
+            let target = dir_path.join(name);
+            fs::rename(&path, &target).map_err(|e| e.to_string())?;
+            path = target;
+        }
+    }
+
+    Ok(path.to_string_lossy().to_string())
 }
 
 /// Run full-song generation based on a structured spec (typed, camelCase-friendly).
 #[tauri::command]
 pub async fn run_lofi_song<R: Runtime>(
-  window: Window<R>,
-  app: AppHandle<R>,
-  spec: SongSpec,
+    window: Window<R>,
+    app: AppHandle<R>,
+    spec: SongSpec,
 ) -> Result<String, String> {
-  let py = conda_python();
-  if !py.exists() {
-    return Err(format!("Python not found at {}", py.display()));
-  }
+    let py = conda_python();
+    if !py.exists() {
+        return Err(format!("Python not found at {}", py.display()));
+    }
 
-  let script = script_path(&app);
-  if !script.exists() {
-    return Err(format!("Script not found at {}", script.display()));
-  }
+    let script = script_path(&app);
+    if !script.exists() {
+        return Err(format!("Script not found at {}", script.display()));
+    }
 
-  // Ensure the output directory exists
-  let out_dir = PathBuf::from(&spec.out_dir);
-  fs::create_dir_all(&out_dir).map_err(|e| e.to_string())?;
+    // Ensure the output directory exists
+    let out_dir = PathBuf::from(&spec.out_dir);
+    fs::create_dir_all(&out_dir).map_err(|e| e.to_string())?;
 
-  // Build outfile name
-  let stamp = Local::now().format("%Y%m%d_%H%M%S").to_string();
-  let file_name = format!("{} - {stamp}.wav", spec.title);
-  let out_path = out_dir.join(file_name);
+    // Build outfile name
+    let stamp = Local::now().format("%Y%m%d_%H%M%S").to_string();
+    let file_name = format!("{} - {stamp}.wav", spec.title);
+    let out_path = out_dir.join(file_name);
 
-  // Serialize spec to JSON for Python
-  let json_str = serde_json::to_string(&spec).map_err(|e| e.to_string())?;
+    // Serialize spec to JSON for Python
+    let json_str = serde_json::to_string(&spec).map_err(|e| e.to_string())?;
 
-  // Launch Python
-  let mut cmd = PCommand::new(&py);
-  cmd.arg("-u")
-    .arg(&script)
-    .arg("--song-json").arg(json_str)
-    .arg("--out").arg(&out_path)
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped());
+    // Launch Python
+    let mut cmd = PCommand::new(&py);
+    cmd.arg("-u")
+        .arg(&script)
+        .arg("--song-json")
+        .arg(json_str)
+        .arg("--out")
+        .arg(&out_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
 
-  window.emit("lofi_progress", r#"{"stage":"start","message":"starting"}"#).ok();
+    window
+        .emit("lofi_progress", r#"{"stage":"start","message":"starting"}"#)
+        .ok();
 
-  let mut child = cmd.spawn().map_err(|e| format!("Failed to start python: {e}"))?;
-  let mut stdout = BufReader::new(child.stdout.take().unwrap());
-  let mut line = String::new();
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to start python: {e}"))?;
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+    let mut line = String::new();
 
-  // Forward JSON status lines printed by Python to the UI
-  loop {
-    line.clear();
-    let read = stdout.read_line(&mut line).map_err(|e| e.to_string())?;
-    if read == 0 { break; }
-    let _ = window.emit("lofi_progress", line.trim().to_string());
-  }
+    // Forward JSON status lines printed by Python to the UI
+    loop {
+        line.clear();
+        let read = stdout.read_line(&mut line).map_err(|e| e.to_string())?;
+        if read == 0 {
+            break;
+        }
+        let _ = window.emit("lofi_progress", line.trim().to_string());
+    }
 
-  // Gather stderr on failure
-  let mut stderr_s = String::new();
-  if let Some(mut e) = child.stderr.take() {
-    let _ = e.read_to_string(&mut stderr_s);
-  }
+    // Gather stderr on failure
+    let mut stderr_s = String::new();
+    if let Some(mut e) = child.stderr.take() {
+        let _ = e.read_to_string(&mut stderr_s);
+    }
 
-  let status = child.wait().map_err(|e| e.to_string())?;
-  if !status.success() {
-    return Err(format!("Python exited with {status}: {stderr_s}"));
-  }
+    let status = child.wait().map_err(|e| e.to_string())?;
+    if !status.success() {
+        return Err(format!("Python exited with {status}: {stderr_s}"));
+    }
 
-  window.emit("lofi_progress", r#"{"stage":"done","message":"saved"}"#).ok();
-  Ok(out_path.to_string_lossy().to_string())
+    window
+        .emit("lofi_progress", r#"{"stage":"done","message":"saved"}"#)
+        .ok();
+    Ok(out_path.to_string_lossy().to_string())
 }
 
 /* ==============================
-   Blender integration
-   ============================== */
+Blender integration
+============================== */
 
 #[tauri::command]
 pub async fn blender_run_script(code: String) -> Result<(), String> {
-  let tmp = std::env::temp_dir().join("blossom_bpy_script.py");
-  fs::write(&tmp, code).map_err(|e| e.to_string())?;
+    let tmp = std::env::temp_dir().join("blossom_bpy_script.py");
+    fs::write(&tmp, code).map_err(|e| e.to_string())?;
 
-  let status = PCommand::new(blender_path())
-    .arg("--background")
-    .arg("--python")
-    .arg(&tmp)
-    .status()
-    .map_err(|e| format!("failed to run blender: {e}"))?;
+    let status = PCommand::new(blender_path())
+        .arg("--background")
+        .arg("--python")
+        .arg(&tmp)
+        .status()
+        .map_err(|e| format!("failed to run blender: {e}"))?;
 
-  if status.success() {
-    Ok(())
-  } else {
-    Err(format!("blender exited with status {status}"))
-  }
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("blender exited with status {status}"))
+    }
 }
 
 fn blender_path() -> PathBuf {
-  PathBuf::from("blender")
+    PathBuf::from("blender")
 }
 
 /* ==============================
-   Ollama general chat
-   ============================== */
+Ollama general chat
+============================== */
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ChatMessage {
-  pub role: String,
-  pub content: String,
+    pub role: String,
+    pub content: String,
 }
 
 fn models_dir<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf, String> {
-  let dir = app
-    .path()
-    .app_data_dir()
-    .map_err(|_| "app data dir".to_string())?
-    .join("ollama-models");
-  fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
-  Ok(dir)
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|_| "app data dir".to_string())?
+        .join("ollama-models");
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    Ok(dir)
 }
 
 #[tauri::command]
 pub async fn start_ollama<R: Runtime>(app: AppHandle<R>, window: Window<R>) -> Result<(), String> {
-  // check if already running
-  if ureq::get("http://127.0.0.1:11434/")
-    .timeout(std::time::Duration::from_millis(500))
-    .call()
-    .is_ok()
-  {
-    return Ok(());
-  }
-
-  let dir = models_dir(&app)?;
-
-  // spawn serve
-  let mut cmd = PCommand::new("ollama");
-  cmd.arg("serve")
-    .env("OLLAMA_MODELS", &dir)
-    .stdout(Stdio::null())
-    .stderr(Stdio::null());
-  let child = cmd.spawn().map_err(|e| format!("failed to start ollama: {e}"))?;
-  {
-    let mut lock = OLLAMA_CHILD.get_or_init(|| Mutex::new(None)).lock().unwrap();
-    *lock = Some(child);
-  }
-
-  // wait for server
-  for _ in 0..20 {
+    // check if already running
     if ureq::get("http://127.0.0.1:11434/")
-      .timeout(std::time::Duration::from_millis(500))
-      .call()
-      .is_ok()
+        .timeout(std::time::Duration::from_millis(500))
+        .call()
+        .is_ok()
     {
-      break;
+        return Ok(());
     }
-    std::thread::sleep(std::time::Duration::from_millis(500));
-  }
 
-  if ureq::get("http://127.0.0.1:11434/")
-    .timeout(std::time::Duration::from_millis(500))
-    .call()
-    .is_err()
-  {
-    return Err("Ollama did not start".into());
-  }
+    let dir = models_dir(&app)?;
 
-  // check model
-  let resp = ureq::get("http://127.0.0.1:11434/api/tags")
-    .call()
-    .map_err(|e| e.to_string())?;
-  let json: Value = resp.into_json().map_err(|e| e.to_string())?;
-  let has = json["models"].as_array().map(|arr| {
-    arr.iter().any(|m| m["name"].as_str() == Some("gpt-oss:20b"))
-  }).unwrap_or(false);
-
-  if !has {
-    let mut pull = PCommand::new("ollama");
-    pull
-      .arg("pull")
-      .arg("gpt-oss:20b")
-      .env("OLLAMA_MODELS", &dir)
-      .stdout(Stdio::piped())
-      .stderr(Stdio::piped());
-    let mut child = pull.spawn().map_err(|e| format!("ollama pull failed: {e}"))?;
-    let mut stdout = BufReader::new(child.stdout.take().unwrap());
-    let mut stderr = BufReader::new(child.stderr.take().unwrap());
-    let w1 = window.clone();
-    let w2 = window.clone();
-    std::thread::spawn(move || {
-      let mut line = String::new();
-      loop {
-        line.clear();
-        let Ok(n) = stdout.read_line(&mut line) else { break };
-        if n == 0 { break; }
-        let _ = w1.emit("ollama_log", line.trim_end().to_string());
-      }
-    });
-    std::thread::spawn(move || {
-      let mut line = String::new();
-      loop {
-        line.clear();
-        let Ok(n) = stderr.read_line(&mut line) else { break };
-        if n == 0 { break; }
-        let _ = w2.emit("ollama_log", line.trim_end().to_string());
-      }
-    });
-    let status = child.wait().map_err(|e| e.to_string())?;
-    if !status.success() {
-      return Err("ollama pull failed".into());
+    // spawn serve
+    let mut cmd = PCommand::new("ollama");
+    cmd.arg("serve")
+        .env("OLLAMA_MODELS", &dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let child = cmd
+        .spawn()
+        .map_err(|e| format!("failed to start ollama: {e}"))?;
+    {
+        let mut lock = OLLAMA_CHILD
+            .get_or_init(|| Mutex::new(None))
+            .lock()
+            .unwrap();
+        *lock = Some(child);
     }
-  }
 
-  Ok(())
+    // wait for server
+    for _ in 0..20 {
+        if ureq::get("http://127.0.0.1:11434/")
+            .timeout(std::time::Duration::from_millis(500))
+            .call()
+            .is_ok()
+        {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+
+    if ureq::get("http://127.0.0.1:11434/")
+        .timeout(std::time::Duration::from_millis(500))
+        .call()
+        .is_err()
+    {
+        return Err("Ollama did not start".into());
+    }
+
+    // check model
+    let resp = ureq::get("http://127.0.0.1:11434/api/tags")
+        .call()
+        .map_err(|e| e.to_string())?;
+    let json: Value = resp.into_json().map_err(|e| e.to_string())?;
+    let has = json["models"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .any(|m| m["name"].as_str() == Some("gpt-oss:20b"))
+        })
+        .unwrap_or(false);
+
+    if !has {
+        let mut pull = PCommand::new("ollama");
+        pull.arg("pull")
+            .arg("gpt-oss:20b")
+            .env("OLLAMA_MODELS", &dir);
+        let mut child = spawn_with_logging(&mut pull, window, "ollama_log")
+            .map_err(|e| format!("ollama pull failed: {e}"))?;
+        let status = child.wait().map_err(|e| e.to_string())?;
+        if !status.success() {
+            return Err("ollama pull failed".into());
+        }
+    }
+
+    Ok(())
 }
 
 #[tauri::command]
 pub async fn stop_ollama() -> Result<(), String> {
-  let mut lock = OLLAMA_CHILD.get_or_init(|| Mutex::new(None)).lock().unwrap();
-  if let Some(mut child) = lock.take() {
-    let _ = child.kill();
-  }
-  Ok(())
+    let mut lock = OLLAMA_CHILD
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap();
+    if let Some(mut child) = lock.take() {
+        let _ = child.kill();
+    }
+    Ok(())
 }
 
 #[tauri::command]
 pub async fn general_chat(messages: Vec<ChatMessage>) -> Result<String, String> {
-  let resp = ureq::post("http://127.0.0.1:11434/api/chat")
-    .set("Content-Type", "application/json")
-    .send_json(ureq::json!({
-      "model": "gpt-oss:20b",
-      "stream": false,
-      "messages": messages,
-    }))
-    .map_err(|e| e.to_string())?;
+    let resp = ureq::post("http://127.0.0.1:11434/api/chat")
+        .set("Content-Type", "application/json")
+        .send_json(ureq::json!({
+          "model": "gpt-oss:20b",
+          "stream": false,
+          "messages": messages,
+        }))
+        .map_err(|e| e.to_string())?;
 
-  let json: Value = resp.into_json().map_err(|e| e.to_string())?;
-  let content = json["message"]["content"]
-    .as_str()
-    .or_else(|| json["content"].as_str())
-    .ok_or("no content")?;
-  Ok(content.to_string())
+    let json: Value = resp.into_json().map_err(|e| e.to_string())?;
+    let content = json["message"]["content"]
+        .as_str()
+        .or_else(|| json["content"].as_str())
+        .ok_or("no content")?;
+    Ok(content.to_string())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -4,23 +4,23 @@
 mod commands;
 
 fn main() {
-  tauri::Builder::default()
-    .plugin(tauri_plugin_dialog::init())
-    .invoke_handler(tauri::generate_handler![
-      commands::lofi_generate_gpu,
-      commands::lofi_generate_gpu_stream,
-      commands::run_lofi_song,
-      // ComfyUI:
-      commands::comfy_status,
-      commands::comfy_start,
-      commands::comfy_stop,
-      // Ollama general chat:
-      commands::start_ollama,
-      commands::stop_ollama,
-      commands::general_chat,
-      // Blender:
-      commands::blender_run_script,
-    ])
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
+        .invoke_handler(tauri::generate_handler![
+            commands::lofi_generate_gpu,
+            commands::lofi_generate_gpu_stream,
+            commands::run_lofi_song,
+            // ComfyUI:
+            commands::comfy_status,
+            commands::comfy_start,
+            commands::comfy_stop,
+            // Ollama general chat:
+            commands::start_ollama,
+            commands::stop_ollama,
+            commands::general_chat,
+            // Blender:
+            commands::blender_run_script,
+        ])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }


### PR DESCRIPTION
## Summary
- add `spawn_with_logging` helper for commands emitting stdout/stderr
- use helper to remove duplicate log-handling in `comfy_start` and `start_ollama`
- document usage with example

## Testing
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found.)*
- `npm test` *(cancelled after watch mode started; tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_689f99f2fa9083258c5c271c792f6dd5