### PR TITLE
Add tests for lofi engine and chat components

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SongForm from './SongForm';
+import { open } from '@tauri-apps/plugin-dialog';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+  convertFileSrc: (p: string) => p,
+}));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+
+describe('SongForm', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetAllMocks();
+    Object.defineProperty(global.HTMLMediaElement.prototype, 'play', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(global.HTMLMediaElement.prototype, 'pause', {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it('adds a job and shows progress', async () => {
+    (open as any).mockResolvedValue('/tmp/out');
+    let resolveRun: (p: string) => void;
+    (invoke as any).mockImplementation((cmd: string) => {
+      if (cmd === 'run_lofi_song') {
+        return new Promise<string>((res) => {
+          resolveRun = res;
+        });
+      }
+      return Promise.resolve('');
+    });
+    let progressCb: any;
+    (listen as any).mockImplementation((_e: string, cb: any) => {
+      progressCb = cb;
+      return Promise.resolve(() => {});
+    });
+
+    render(<SongForm />);
+    fireEvent.click(screen.getByText(/choose folder/i));
+    await screen.findByText('/tmp/out');
+
+    const autoPlay = screen.getByText(/Auto‑play last successful render/).previousSibling as HTMLInputElement;
+    fireEvent.click(autoPlay);
+
+    fireEvent.click(screen.getByText(/render songs/i));
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('run_lofi_song', expect.anything()));
+    await waitFor(() => expect(listen).toHaveBeenCalledTimes(2));
+
+    progressCb({ payload: JSON.stringify({ stage: 'render', message: '30%' }) });
+    expect(await screen.findByText(/render: 30%/i)).toBeInTheDocument();
+
+    resolveRun!('/tmp/out/song.wav');
+    expect(await screen.findByText('done')).toBeInTheDocument();
+    expect(screen.getByText('Play')).toBeInTheDocument();
+  });
+});
+

--- a/src/features/lofi/tests/useLofiEngine.test.ts
+++ b/src/features/lofi/tests/useLofiEngine.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+
+let useLofi: any;
+let tone: any;
+
+describe('useLofi engine', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.doMock('tone', () => {
+      const start = vi.fn().mockResolvedValue(undefined);
+      const Transport = {
+        bpm: { value: 80, rampTo: vi.fn() },
+        start: vi.fn(),
+        stop: vi.fn(),
+      };
+      const mkSynth = () =>
+        ({ toDestination: () => ({ connect: () => ({}) }), connect: () => ({}), triggerAttackRelease: vi.fn() });
+      const MonoSynth = vi.fn().mockImplementation(() => mkSynth());
+      const NoiseSynth = vi.fn().mockImplementation(() => mkSynth());
+      const Reverb = vi.fn().mockImplementation(() => ({ toDestination: () => ({ connect: () => ({}) }) }));
+      const Loop = vi
+        .fn()
+        .mockImplementation(() => ({ start: vi.fn(), stop: vi.fn() }));
+      const Frequency = (n: string) => ({ transpose: () => ({ toNote: () => n }) });
+      return { start, Transport, MonoSynth, NoiseSynth, Reverb, Loop, Frequency };
+    });
+    ({ useLofi } = await import('../useLofiEngine'));
+    tone = await import('tone');
+  });
+
+  it('plays and stops', async () => {
+    await useLofi.getState().play();
+    const loopInstance = (tone.Loop as Mock).mock.results[0].value;
+    expect(tone.start).toHaveBeenCalled();
+    expect(tone.Transport.start).toHaveBeenCalled();
+    expect(loopInstance.start).toHaveBeenCalled();
+    expect(useLofi.getState().isPlaying).toBe(true);
+    useLofi.getState().stop();
+    expect(tone.Transport.stop).toHaveBeenCalled();
+    expect(loopInstance.stop).toHaveBeenCalled();
+    expect(useLofi.getState().isPlaying).toBe(false);
+  });
+
+  it('handles seed changes', async () => {
+    useLofi.getState().setSeed(123);
+    expect(useLofi.getState().seed).toBe(123);
+    useLofi.setState({ seed: 42 });
+    await useLofi.getState().play();
+    expect(useLofi.getState().seed).toBe(42);
+  });
+});
+

--- a/src/pages/GeneralChat.test.tsx
+++ b/src/pages/GeneralChat.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import GeneralChat from './GeneralChat';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+
+describe('GeneralChat', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetAllMocks();
+  });
+
+  it('handles message flow', async () => {
+    (invoke as any).mockImplementation((cmd: string) => {
+      if (cmd === 'start_ollama') return Promise.resolve();
+      if (cmd === 'general_chat') return Promise.resolve('Reply');
+      return Promise.resolve();
+    });
+    (listen as any).mockImplementation(() => Promise.resolve(() => {}));
+
+    render(<GeneralChat />);
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('start_ollama'));
+
+    fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'Hello' } });
+    fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('general_chat', expect.anything()));
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(await screen.findByText('Reply')).toBeInTheDocument();
+  });
+
+  it('shows error when send fails', async () => {
+    (invoke as any).mockImplementation((cmd: string) => {
+      if (cmd === 'start_ollama') return Promise.resolve();
+      if (cmd === 'general_chat') return Promise.reject('fail');
+      return Promise.resolve();
+    });
+    (listen as any).mockImplementation(() => Promise.resolve(() => {}));
+
+    render(<GeneralChat />);
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('start_ollama'));
+
+    fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'Hi' } });
+    fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
+
+    await waitFor(() => expect(screen.getByText('fail')).toBeInTheDocument());
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for lofi engine store covering play/stop and seed changes
- add component tests for GeneralChat handling message flow and error state
- add interaction test for SongForm including job creation and progress updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f99e1db548325b0f610dd7342f873