### PR TITLE
feat: expose limiter drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ python src-tauri/python/lofi_gpu.py --song-json '{"bpm":80,"seed":123}' --out ou
 {
   "hq_stereo": true,
   "hq_reverb": true,
-  "hq_sidechain": true
+  "hq_sidechain": true,
+  "limiter_drive": 1.0
 }
 ```
 
@@ -86,6 +87,8 @@ libraries are missing.
 - **HQ feature flags:** `lofi_gpu_hq.py` supports `hq_stereo`, `hq_reverb`, and
   `hq_sidechain` flags inside the `motif` object to enable or disable
   high‑quality processing.
+- **Limiter drive:** Add `limiter_drive` to the song JSON to control soft
+  clipping intensity (values around `1.0` keep saturation subtle).
 - **Streaming model:** `lofi_gpu_stream.py` accepts `--chunk`, `--bpm`,
   `--style`, and `--seed` options and prints `PROG <percent>` while generating.
 


### PR DESCRIPTION
## Summary
- allow overriding soft limiter drive in `enhanced_post_process_chain`
- wire `limiter_drive` through CLI/motif and update docs

## Testing
- `python -m py_compile src-tauri/python/lofi_gpu_hq.py`
- `npm test` *(fails: Waiting for file changes but tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_689f9bcfb0d88325ae3dd2f6fd47e368