### PR TITLE
feat: ask about news items

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Calendar from "./pages/Calendar";
 import Comfy from "./pages/Comfy";
 import Assistant from "./pages/Assistant";
 import GeneralChat from "./pages/GeneralChat";
+import News from "./pages/News";
 import Laser from "./pages/Laser";
 import Lofi from "./pages/Lofi";
 import NotFound from "./pages/NotFound";
@@ -27,6 +28,7 @@ export default function App() {
         <Route path="/comfy" element={<Comfy />} />
         <Route path="/assistant" element={<Assistant />} />
         <Route path="/assistant/general-chat" element={<GeneralChat />} />
+        <Route path="/assistant/news" element={<News />} />
         <Route path="/laser" element={<Laser />} />
         <Route path="/lofi" element={<Lofi />} />
         <Route path="*" element={<NotFound />} />

--- a/src/pages/Assistant.tsx
+++ b/src/pages/Assistant.tsx
@@ -16,7 +16,7 @@ const features: Feature[] = [
   { label: "RAG" },
   { label: "General Chat", path: "/assistant/general-chat" },
   { label: "World Builder" },
-  { label: "Big Brother updates" },
+  { label: "News", path: "/assistant/news" },
 ];
 
 export default function Assistant() {

--- a/src/pages/GeneralChat.test.tsx
+++ b/src/pages/GeneralChat.test.tsx
@@ -28,7 +28,7 @@ describe('GeneralChat', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
 
     await waitFor(() => expect(invoke).toHaveBeenCalledWith('general_chat', expect.anything()));
-    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getAllByText('Hello').length).toBeGreaterThan(0);
     expect(await screen.findByText('Reply')).toBeInTheDocument();
   });
 

--- a/src/pages/News.test.tsx
+++ b/src/pages/News.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import News from './News';
+import { invoke } from '@tauri-apps/api/core';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+describe('News', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve([{ id: 1, title: 'Title', summary: 'Summary' }]),
+    }) as any;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('forwards article text to general_chat with context', async () => {
+    (invoke as any).mockResolvedValue('Answer');
+
+    render(<News />);
+
+    await screen.findByText('Title');
+    const btn = screen.getByRole('button', { name: /ask about this/i });
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledTimes(1));
+    expect(invoke).toHaveBeenCalledWith('general_chat', {
+      messages: [{ role: 'user', content: expect.stringContaining('Summary') }],
+    });
+
+    fireEvent.click(btn);
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledTimes(2));
+    const secondCall = (invoke as any).mock.calls[1][1];
+    expect(secondCall.messages.length).toBe(3);
+  });
+});
+

--- a/src/pages/News.tsx
+++ b/src/pages/News.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Box, Button, Stack, Typography } from "@mui/material";
+import Center from "./_Center";
+
+interface Article {
+  id: number;
+  title: string;
+  summary: string;
+}
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export default function News() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [context, setContext] = useState<ChatMessage[]>([]);
+  const [answers, setAnswers] = useState<Record<number, string>>({});
+
+  useEffect(() => {
+    fetch("https://api.spaceflightnewsapi.net/v3/articles?_limit=5")
+      .then((res) => res.json())
+      .then((data) => setArticles(data));
+  }, []);
+
+  async function ask(article: Article) {
+    const userMsg: ChatMessage = {
+      role: "user",
+      content: `${article.title}\n\n${article.summary}`,
+    };
+    const messages = [...context, userMsg];
+    const reply: string = await invoke("general_chat", { messages });
+    setContext([...messages, { role: "assistant", content: reply }]);
+    setAnswers((prev) => ({ ...prev, [article.id]: reply }));
+  }
+
+  return (
+    <Center>
+      <Stack spacing={2} sx={{ width: "100%", maxWidth: 600 }}>
+        {articles.map((a) => (
+          <Box
+            key={a.id}
+            sx={{
+              border: "1px solid",
+              borderColor: "divider",
+              p: 2,
+              borderRadius: 1,
+            }}
+          >
+            <Typography variant="h6" gutterBottom>
+              {a.title}
+            </Typography>
+            <Typography variant="body2" sx={{ mb: 1 }}>
+              {a.summary}
+            </Typography>
+            <Button variant="contained" onClick={() => ask(a)}>
+              Ask about this
+            </Button>
+            {answers[a.id] && (
+              <Typography variant="body2" sx={{ mt: 1 }}>
+                {answers[a.id]}
+              </Typography>
+            )}
+          </Box>
+        ))}
+      </Stack>
+    </Center>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add News page that fetches articles and lets users query the LLM about them
- wire News into assistant menu and routing
- cover news flow with tests and fix GeneralChat tests

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689fa083a78083258d44aa9a1595146d