### PR TITLE
Add notifications for scraped items

### DIFF
--- a/src/components/ScrapedItemsList.tsx
+++ b/src/components/ScrapedItemsList.tsx
@@ -1,0 +1,27 @@
+import { useScrapedItems } from '../features/scraper/useScrapedItems';
+
+export default function ScrapedItemsList() {
+  const items = useScrapedItems((s) => s.items);
+  if (items.length === 0) return null;
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 12,
+        left: 12,
+        zIndex: 50,
+        color: '#fff',
+        background: 'rgba(0,0,0,0.4)',
+        padding: '8px 12px',
+        borderRadius: 8,
+        maxWidth: 240,
+      }}
+    >
+      <ul style={{ margin: 0, paddingLeft: 20, fontSize: 14 }}>
+        {items.map((it) => (
+          <li key={it.id}>{it.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/scraper/useScrapedItems.ts
+++ b/src/features/scraper/useScrapedItems.ts
@@ -1,0 +1,61 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { isPermissionGranted, requestPermission, sendNotification } from '@tauri-apps/api/notification';
+import { listen } from '@tauri-apps/api/event';
+
+export interface ScrapedItem {
+  id: string;
+  title: string;
+  url?: string;
+}
+
+interface ScrapedState {
+  items: ScrapedItem[];
+  notificationsEnabled: boolean;
+  setNotificationsEnabled: (enabled: boolean) => Promise<void>;
+  addItems: (items: ScrapedItem[]) => Promise<void>;
+}
+
+export const useScrapedItems = create<ScrapedState>()(
+  persist(
+    (set, get) => ({
+      items: [],
+      notificationsEnabled: true,
+      async setNotificationsEnabled(enabled) {
+        set({ notificationsEnabled: enabled });
+        if (enabled) {
+          let granted = await isPermissionGranted();
+          if (!granted) {
+            granted = (await requestPermission()) === 'granted';
+          }
+        }
+      },
+      async addItems(items) {
+        set((state) => ({ items: [...items, ...state.items] }));
+        if (get().notificationsEnabled) {
+          let granted = await isPermissionGranted();
+          if (!granted) {
+            granted = (await requestPermission()) === 'granted';
+          }
+          if (granted) {
+            const body = items.length === 1
+              ? items[0].title
+              : `${items.length} new items available`;
+            sendNotification({ title: 'Blossom', body });
+          }
+        }
+      }
+    }),
+    { name: 'scraped-items-store' }
+  )
+);
+
+// Listen for backend events announcing new scraped items.
+if (typeof window !== 'undefined') {
+  listen<ScrapedItem[]>('scraper:new-items', (event) => {
+    useScrapedItems.getState().addItems(event.payload);
+  }).catch(() => {
+    // ignore if tauri event system isn't available (e.g. tests)
+  });
+}
+

--- a/src/pages/GeneralChat.test.tsx
+++ b/src/pages/GeneralChat.test.tsx
@@ -28,7 +28,8 @@ describe('GeneralChat', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
 
     await waitFor(() => expect(invoke).toHaveBeenCalledWith('general_chat', expect.anything()));
-    expect(screen.getByText('Hello')).toBeInTheDocument();
+    // message appears in a paragraph element; chat tab also uses the same text
+    expect(screen.getAllByText('Hello', { selector: 'p' })[0]).toBeInTheDocument();
     expect(await screen.findByText('Reply')).toBeInTheDocument();
   });
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,6 +6,7 @@ import HoverCircle from "../components/HoverCircle";
 import FeatureCarousel from "../components/FeatureCarousel";
 import VersionBadge from "../components/VersionBadge";
 import { Theme, useTheme } from "../features/theme/ThemeContext";
+import ScrapedItemsList from "../components/ScrapedItemsList";
 
 export default function Home() {
   const { theme } = useTheme();
@@ -70,6 +71,8 @@ export default function Home() {
 
       {/* Carousel icons */}
       <FeatureCarousel onHoverColor={setHoverColor} />
+      {/* List of scraped items */}
+      <ScrapedItemsList />
     </>
   );
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -6,13 +6,17 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  FormControlLabel,
+  Switch,
 } from "@mui/material";
 import { useCalendar } from "../features/calendar/useCalendar";
 import { Theme, useTheme } from "../features/theme/ThemeContext";
+import { useScrapedItems } from "../features/scraper/useScrapedItems";
 
 export default function Settings() {
   const { theme, setTheme } = useTheme();
   const { events, selectedCountdownId, setSelectedCountdownId } = useCalendar();
+  const { notificationsEnabled, setNotificationsEnabled } = useScrapedItems();
   const countdownEvents = events.filter(
     (e) => e.hasCountdown && e.status !== "canceled" && e.status !== "missed"
   );
@@ -23,6 +27,16 @@ export default function Settings() {
         <Typography variant="body2" color="text.secondary">
           Put toggles, theme, and module switches here.
         </Typography>
+        <FormControlLabel
+          sx={{ mt: 2 }}
+          control={
+            <Switch
+              checked={notificationsEnabled}
+              onChange={(e) => setNotificationsEnabled(e.target.checked)}
+            />
+          }
+          label="Enable Notifications"
+        />
         <FormControl fullWidth sx={{ mt: 3 }}>
           <InputLabel id="theme-label">Theme</InputLabel>
           <Select


### PR DESCRIPTION
## Summary
- integrate Tauri notification API to alert on newly scraped items
- display scraped items in Home page and store user toggle
- add settings toggle to enable/disable notifications
- stabilize GeneralChat test when identical text appears twice

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fa0835ac48325accb5ee5546f5a1c