### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blossom",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blossom",
-      "version": "0.1.3",
+      "version": "0.1.5",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blossom",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='blossom-audio',
-    version='0.1.0',
+    version='0.1.5',
     install_requires=[
         'scipy>=1.9.0',
         'pyloudnorm>=0.1.0',

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "blossom"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blossom"
-version = "0.1.3"
+version = "0.1.5"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "blossom",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "identifier": "com.owner.blossom",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/HeaderOverlay.tsx
+++ b/src/components/HeaderOverlay.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import appVersion from "../version";
 
 type Props = {
   appName?: string;
@@ -8,7 +9,7 @@ type Props = {
 
 export default function HeaderOverlay({
   appName = "Blossom",
-  version = "0.1.3",
+  version = appVersion,
   align = "center",
 }: Props) {
   const base: React.CSSProperties = {

--- a/src/components/VersionBadge.tsx
+++ b/src/components/VersionBadge.tsx
@@ -1,9 +1,10 @@
 // src/components/VersionBadge.tsx
 import React from "react";
+import appVersion from "../version";
 
 export default function VersionBadge({
   name = "Blossom",
-  version = "0.1.3",
+  version = appVersion,
 }: {
   name?: string;
   version?: string;

--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -23,7 +23,7 @@ export default function Music() {
           pointerEvents: "none",
         }}
       >
-        <VersionBadge version="0.1.3" />
+        <VersionBadge />
       </div>
 
       {/* Checkbox Song Builder only */}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,6 @@
+// Expose the application version from package.json
+import { version } from "../package.json";
+
+export const appVersion = version;
+export default appVersion;
+


### PR DESCRIPTION
## Summary
- bump project version to 0.1.5 across configs
- centralize version constant and use it in UI components

## Testing
- `npm test`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fa44357188325a83c707a9aa38555