### PR TITLE
Add GPT summaries to Big Brother news

### DIFF
--- a/src/pages/BigBrotherUpdates.tsx
+++ b/src/pages/BigBrotherUpdates.tsx
@@ -13,6 +13,7 @@ interface Article {
   link: string;
   pub_date?: string;
   source: string;
+  summary?: string;
 }
 
 export default function BigBrotherUpdates() {
@@ -49,11 +50,21 @@ export default function BigBrotherUpdates() {
           >
             <ListItemText
               primary={article.title}
-              secondary={`${article.source}${
-                article.pub_date
-                  ? ` - ${new Date(article.pub_date).toLocaleString()}`
-                  : ""
-              }`}
+              secondary={
+                <>
+                  {`${article.source}${
+                    article.pub_date
+                      ? ` - ${new Date(article.pub_date).toLocaleString()}`
+                      : ""
+                  }`}
+                  {article.summary && (
+                    <>
+                      <br />
+                      {article.summary}
+                    </>
+                  )}
+                </>
+              }
             />
           </ListItem>
         ))}


### PR DESCRIPTION
## Summary
- Summarize each RSS article using the existing GPT-OSS client and return the summary in `fetch_big_brother_news`
- Display article summaries in the Big Brother updates page

## Testing
- `npm test -- --run`
- `cargo test` *(fails: missing `javascriptcoregtk-4.1` system library)*

------
https://chatgpt.com/codex/tasks/task_e_689fa975b2d48325a1f595c0aecd9ae4