### PR TITLE
Cache Big Brother news and add manual refresh

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,6 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
-once_cell = "1"
 
 [dependencies]
 tauri = { version = "2", features = ["protocol-asset"] }
@@ -27,4 +26,5 @@ serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ureq = { version = "2", features = ["json"] }
 rss = "2"
+once_cell = "1"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,6 +6,12 @@ mod commands;
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
+        .setup(|_app| {
+            tauri::async_runtime::spawn(async {
+                let _ = commands::fetch_big_brother_news(Some(true)).await;
+            });
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             commands::lofi_generate_gpu,
             commands::lofi_generate_gpu_stream,


### PR DESCRIPTION
## Summary
- cache Big Brother news in Tauri backend and load at startup
- expose manual refresh button and client-side cache with timestamp
- prime backend cache on launch to avoid repeated network requests

## Testing
- `cargo test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fa97a67a0832595585a03ba7da290