### PR TITLE
feat: show Big Brother summaries with link

### DIFF
--- a/src/pages/BigBrotherUpdates.tsx
+++ b/src/pages/BigBrotherUpdates.tsx
@@ -63,29 +63,30 @@ export default function BigBrotherUpdates() {
       </Box>
       <List>
         {articles.map((article, idx) => (
-          <ListItem
-            key={idx}
-            divider
-            component="a"
-            href={article.link}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <ListItem key={idx} divider alignItems="flex-start">
             <ListItemText
               primary={article.title}
               secondary={
                 <>
+                  {article.summary && (
+                    <>
+                      {article.summary}
+                      <br />
+                    </>
+                  )}
                   {`${article.source}${
                     article.pub_date
                       ? ` - ${new Date(article.pub_date).toLocaleString()}`
                       : ""
                   }`}
-                  {article.summary && (
-                    <>
-                      <br />
-                      {article.summary}
-                    </>
-                  )}
+                  <br />
+                  <a
+                    href={article.link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Read more
+                  </a>
                 </>
               }
             />


### PR DESCRIPTION
## Summary
- display backend-provided summaries for Big Brother articles
- add explicit "Read more" link for each article

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fb06adbdc8325a1b598120086df5a