### PR TITLE
Allow custom chords per song section

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -202,6 +202,7 @@ Serde-mapped types (camelCase)
 pub struct Section {
     pub name: String,
     pub bars: u32,
+    pub chords: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -52,7 +52,9 @@ describe('SongForm', () => {
 
     fireEvent.click(screen.getByText(/render songs/i));
 
-    await waitFor(() => expect(invoke).toHaveBeenCalledWith('run_lofi_song', expect.anything()));
+    await waitFor(() => expect(invoke).toHaveBeenCalled());
+    const call = (invoke as any).mock.calls.find(([c]: any) => c === 'run_lofi_song');
+    expect(call[1].spec.structure[0]).toHaveProperty('chords');
     await waitFor(() => expect(listen).toHaveBeenCalledTimes(2));
 
     progressCb({ payload: JSON.stringify({ stage: 'render', message: '30%' }) });


### PR DESCRIPTION
## Summary
- Add `chords` field to song sections and expose a text input for editing them
- Include section chords in the job spec sent to `run_lofi_song`
- Allow Python renderer to honor per-section chords, falling back to progression banks when omitted

## Testing
- `npm test`
- `python -m py_compile src-tauri/python/lofi_gpu_hq.py`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fba48cfd4832580af2517df36d4b8