### PR TITLE
Respect robots.txt before fetching news feeds

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -350,6 +350,7 @@ version = "0.1.5"
 dependencies = [
  "chrono",
  "once_cell",
+ "robotstxt",
  "rss",
  "serde",
  "serde_json",
@@ -358,6 +359,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "ureq",
+ "url",
 ]
 
 [[package]]
@@ -3178,6 +3180,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "robotstxt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc52377db80e3fec3a2c748ca603b8b6cacdd34ff89ff4b742a635361d4b4a7"
 
 [[package]]
 name = "rss"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,4 +27,6 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ureq = { version = "2", features = ["json"] }
 rss = "2"
 once_cell = "1"
+url = "2"
+robotstxt = "0.3"
 


### PR DESCRIPTION
## Summary
- Check news feed URLs against each site's robots.txt before fetching
- Add `url` and `robotstxt` dependencies for parsing and policy checks

## Testing
- `cargo test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb5f812208325ab12562d6e997189