### PR TITLE
feat: add Blossom system prompt

### DIFF
--- a/src/pages/GeneralChat.test.tsx
+++ b/src/pages/GeneralChat.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import GeneralChat from './GeneralChat';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
@@ -9,8 +9,13 @@ vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
 
 describe('GeneralChat', () => {
   beforeEach(() => {
-    localStorage.clear();
     vi.resetAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    localStorage.clear();
   });
 
   it('handles message flow', async () => {
@@ -27,9 +32,61 @@ describe('GeneralChat', () => {
     fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'Hello' } });
     fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
 
-    await waitFor(() => expect(invoke).toHaveBeenCalledWith('general_chat', expect.anything()));
+    await waitFor(() => {
+      const calls = (invoke as any).mock.calls.filter(([cmd]: [string]) => cmd === 'general_chat');
+      expect(calls).toHaveLength(1);
+      expect(calls[0][1]).toEqual({
+        messages: [
+          { role: 'system', content: 'You are Blossom, a helpful AI assistant.' },
+          { role: 'user', content: 'Hello' },
+        ],
+      });
+    });
     expect(screen.getAllByText('Hello')[0]).toBeInTheDocument();
     expect(await screen.findByText('Reply')).toBeInTheDocument();
+  });
+
+  it('inserts system prompt only once', async () => {
+    (invoke as any).mockImplementation((cmd: string) => {
+      if (cmd === 'start_ollama') return Promise.resolve();
+      if (cmd === 'general_chat') return Promise.resolve('Reply');
+      return Promise.resolve();
+    });
+    (listen as any).mockImplementation(() => Promise.resolve(() => {}));
+
+    render(<GeneralChat />);
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('start_ollama'));
+
+    // first message
+    fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'Hi' } });
+    fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
+    await waitFor(() => {
+      const calls = (invoke as any).mock.calls.filter(([cmd]: [string]) => cmd === 'general_chat');
+      expect(calls).toHaveLength(1);
+      expect(calls[0][1]).toEqual({
+        messages: [
+          { role: 'system', content: 'You are Blossom, a helpful AI assistant.' },
+          { role: 'user', content: 'Hi' },
+        ],
+      });
+    });
+    expect(await screen.findByText('Reply')).toBeInTheDocument();
+
+    // second message
+    fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'How are you?' } });
+    fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
+    await waitFor(() => {
+      const calls = (invoke as any).mock.calls.filter(([cmd]: [string]) => cmd === 'general_chat');
+      expect(calls).toHaveLength(2);
+      expect(calls[1][1]).toEqual({
+        messages: [
+          { role: 'system', content: 'You are Blossom, a helpful AI assistant.' },
+          { role: 'user', content: 'Hi' },
+          { role: 'assistant', content: 'Reply' },
+          { role: 'user', content: 'How are you?' },
+        ],
+      });
+    });
   });
 
   it('shows error when send fails', async () => {

--- a/src/pages/GeneralChat.tsx
+++ b/src/pages/GeneralChat.tsx
@@ -116,10 +116,19 @@ export default function GeneralChat() {
     if (!input.trim() || !currentChat) return;
     const userMsg: Message = { role: "user", content: input, ts: Date.now() };
     let name = currentChat.name;
-    if (currentChat.messages.length === 0) {
+    const existing = messages;
+    if (existing.filter((m) => m.role !== "system").length === 0) {
       name = input.trim().slice(0, 20) || name;
     }
-    const newMessages = [...messages, userMsg];
+    let newMessages = [...existing, userMsg];
+    if (!newMessages.some((m) => m.role === "system")) {
+      const systemMsg: Message = {
+        role: "system",
+        content: "You are Blossom, a helpful AI assistant.",
+        ts: Date.now(),
+      };
+      newMessages = [systemMsg, ...newMessages];
+    }
     updateChat(currentChat.id, newMessages, name);
     setInput("");
     setLoading(true);


### PR DESCRIPTION
## Summary
- ensure General Chat sends a Blossom system prompt once per session
- cover Blossom prompt behavior with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fbd6fc4bc8325b03640d235065888