### PR TITLE
feat: add daily big brother summary

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .setup(|_app| {
             tauri::async_runtime::spawn(async {
-                let _ = commands::fetch_big_brother_news(Some(true)).await;
+                let _ = commands::fetch_big_brother_summary(Some(true)).await;
             });
             Ok(())
         })
@@ -28,6 +28,7 @@ fn main() {
             commands::blender_run_script,
             // News scraping:
             commands::fetch_big_brother_news,
+            commands::fetch_big_brother_summary,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Summary
- Replace Big Brother updates RSS feed list with a single GPT-based daily summary box.
- Add backend command to generate and cache daily Big Brother summaries.
- Register new command in Tauri and preload summary on startup.

## Testing
- `npm test -- --run`
- `cargo test` *(fails: system library `gio-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fdd9846388325be13bba7cfd00da7