### PR TITLE
feat: add chorus effect to GPU HQ engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ libraries are missing.
 
 - **Paths:** Edit `comfy_dir()` and `conda_python()` in `src-tauri/src/commands.rs`
   so the app can find ComfyUI and your Python interpreter.
-- **HQ feature flags:** `lofi_gpu_hq.py` supports `hq_stereo`, `hq_reverb`, and
-  `hq_sidechain` flags inside the `motif` object to enable or disable
+- **HQ feature flags:** `lofi_gpu_hq.py` supports `hq_stereo`, `hq_reverb`,
+  `hq_sidechain`, and `hq_chorus` flags inside the `motif` object to enable or disable
   high‑quality processing.
 - **Limiter drive:** Add `limiter_drive` to the song JSON to control soft
   clipping intensity (values around `1.0` keep saturation subtle).

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -23,6 +23,7 @@ type SongSpec = {
   hq_stereo?: boolean;
   hq_reverb?: boolean;
   hq_sidechain?: boolean;
+  hq_chorus?: boolean;
 };
 
 type Job = {
@@ -169,6 +170,7 @@ export default function SongForm() {
   const [hqStereo, setHqStereo] = useState(true);
   const [hqReverb, setHqReverb] = useState(true);
   const [hqSidechain, setHqSidechain] = useState(true);
+  const [hqChorus, setHqChorus] = useState(true);
 
   // UI state
   const [busy, setBusy] = useState(false);
@@ -297,6 +299,7 @@ export default function SongForm() {
       hq_stereo: hqStereo,
       hq_reverb: hqReverb,
       hq_sidechain: hqSidechain,
+      hq_chorus: hqChorus,
     };
   }
 
@@ -643,6 +646,10 @@ export default function SongForm() {
             <div style={S.toggle}>
               <input type="checkbox" checked={hqSidechain} onChange={(e) => setHqSidechain(e.target.checked)} />
               <span style={S.small}>Sidechain (kick)</span>
+            </div>
+            <div style={S.toggle}>
+              <input type="checkbox" checked={hqChorus} onChange={(e) => setHqChorus(e.target.checked)} />
+              <span style={S.small}>Chorus</span>
             </div>
             <div style={{ ...S.small, marginTop: 6 }}>These map to engine flags in <code>lofi_gpu_hq.py</code>.</div>
           </div>


### PR DESCRIPTION
## Summary
- add optional chorus processor to lofi_gpu_hq with new `hq_chorus` flag
- expose chorus toggle and flag wiring in SongForm UI
- document new HQ flag in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fdf197ec8832586b7cf381492c3d9