### PR TITLE
fix: clean up audio listeners

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -182,10 +182,14 @@ export default function SongForm() {
   // one audio element
   useEffect(() => {
     const a = new Audio();
-    a.addEventListener("ended", () => setIsPlaying(false));
-    a.addEventListener("error", () => setErr("Audio playback error"));
+    const handleEnded = () => setIsPlaying(false);
+    const handleError = () => setErr("Audio playback error");
+    a.addEventListener("ended", handleEnded);
+    a.addEventListener("error", handleError);
     audioRef.current = a;
     return () => {
+      a.removeEventListener("ended", handleEnded);
+      a.removeEventListener("error", handleError);
       a.pause();
       audioRef.current = null;
     };


### PR DESCRIPTION
## Summary
- remove audio element event listeners on cleanup to prevent memory leaks

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a0093f92048325bc31f1d9787e6619