### PR TITLE
Add module toggles in settings

### DIFF
--- a/src/components/FeatureCarousel.tsx
+++ b/src/components/FeatureCarousel.tsx
@@ -1,6 +1,6 @@
 
 import type { ReactNode } from "react";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { IconButton } from "@mui/material";
 import {
   FaMusic,
@@ -11,33 +11,42 @@ import {
   FaCalendarAlt,
 } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
+import { useSettings } from "../features/settings/useSettings";
 
-type Item = { icon: ReactNode; label: string; path: string };
+import type { ModuleKey } from "../features/settings/useSettings";
+
+type Item = { key: ModuleKey; icon: ReactNode; label: string; path: string };
 export default function FeatureCarousel({
   onHoverColor,
 }: { onHoverColor: (c: string) => void }) {
   const nav = useNavigate();
+  const { modules } = useSettings();
 
   const ACCENT = "#00bcd4";
 
   const items: Item[] = useMemo(
     () => [
-      { icon: <FaCubes />, label: "3D Object", path: "/objects" },
-      { icon: <FaMusic />, label: "Lo‑Fi Music", path: "/music" },
-      { icon: <FaCalendarAlt />, label: "Calendar", path: "/calendar" },
-      { icon: <FaCameraRetro />, label: "ComfyUI", path: "/comfy" },
-      { icon: <FaRobot />, label: "AI Assistant", path: "/assistant" },
-      { icon: <FaBolt />, label: "Laser Lab", path: "/laser" },
+      { key: "objects", icon: <FaCubes />, label: "3D Object", path: "/objects" },
+      { key: "music", icon: <FaMusic />, label: "Lo‑Fi Music", path: "/music" },
+      { key: "calendar", icon: <FaCalendarAlt />, label: "Calendar", path: "/calendar" },
+      { key: "comfy", icon: <FaCameraRetro />, label: "ComfyUI", path: "/comfy" },
+      { key: "assistant", icon: <FaRobot />, label: "AI Assistant", path: "/assistant" },
+      { key: "laser", icon: <FaBolt />, label: "Laser Lab", path: "/laser" },
     ],
     []
   );
+  const enabled = items.filter((it) => modules[it.key]);
 
   // index of the centered item
   const [i, setI] = useState(0);
-  const len = items.length;
+  const len = enabled.length;
   const mod = (n:number, m:number) => ((n % m) + m) % m;
 
   const go = (dir: 1 | -1) => setI(v => mod(v + dir, len));
+
+  useEffect(() => {
+    if (i >= len) setI(0);
+  }, [len, i]);
 
   const wheelLock = useRef(0);
   // scroll with mouse wheel (throttle to one item per tick)
@@ -68,9 +77,9 @@ export default function FeatureCarousel({
     >
       {/* items */}
       <div style={{ position: "relative", width: "100%", height: 240 }}>
-        {[-2, -1, 0, 1, 2].map((offset) => {
+        {len > 0 && [-2, -1, 0, 1, 2].map((offset) => {
           const idx = mod(i + offset, len);
-          const it = items[idx];
+          const it = enabled[idx];
           const center = offset === 0;
           const x = offset * GAP;
 

--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type ModuleKey = 'objects' | 'music' | 'calendar' | 'comfy' | 'assistant' | 'laser';
+
+type ModulesState = Record<ModuleKey, boolean>;
+
+interface SettingsState {
+  modules: ModulesState;
+  toggleModule: (key: ModuleKey) => void;
+}
+
+export const useSettings = create<SettingsState>()(
+  persist(
+    (set) => ({
+      modules: {
+        objects: true,
+        music: true,
+        calendar: true,
+        comfy: true,
+        assistant: true,
+        laser: true,
+      },
+      toggleModule: (key) =>
+        set((state) => ({
+          modules: { ...state.modules, [key]: !state.modules[key] },
+        })),
+    }),
+    { name: 'settings-store' }
+  )
+);
+
+export type { ModuleKey };

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -6,13 +6,17 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  FormControlLabel,
+  Switch,
 } from "@mui/material";
 import { useCalendar } from "../features/calendar/useCalendar";
 import { Theme, useTheme } from "../features/theme/ThemeContext";
+import { useSettings } from "../features/settings/useSettings";
 
 export default function Settings() {
   const { theme, setTheme } = useTheme();
   const { events, selectedCountdownId, setSelectedCountdownId } = useCalendar();
+  const { modules, toggleModule } = useSettings();
   const countdownEvents = events.filter(
     (e) => e.hasCountdown && e.status !== "canceled" && e.status !== "missed"
   );
@@ -23,6 +27,30 @@ export default function Settings() {
         <Typography variant="body2" color="text.secondary">
           Put toggles, theme, and module switches here.
         </Typography>
+
+        <Box sx={{ mt: 2 }}>
+          {(
+            [
+              ["objects", "3D Objects"],
+              ["music", "Lo-Fi Music"],
+              ["calendar", "Calendar"],
+              ["comfy", "ComfyUI"],
+              ["assistant", "AI Assistant"],
+              ["laser", "Laser Lab"],
+            ] as const
+          ).map(([key, label]) => (
+            <FormControlLabel
+              key={key}
+              control={
+                <Switch
+                  checked={modules[key]}
+                  onChange={() => toggleModule(key)}
+                />
+              }
+              label={label}
+            />
+          ))}
+        </Box>
         <FormControl fullWidth sx={{ mt: 3 }}>
           <InputLabel id="theme-label">Theme</InputLabel>
           <Select


### PR DESCRIPTION
## Summary
- allow enabling/disabling feature modules via new settings store
- hide disabled modules from home carousel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a00b3941a48325bcbfacbefd161ebd