### PR TITLE
feat: add analog tape saturation and wow flutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,6 @@ Activate your Python environment first. The high‑quality generator lives at
   high‑quality processing.
 - **Limiter drive:** Add `limiter_drive` to the song JSON to control soft
   clipping intensity (values around `1.0` keep saturation subtle).
+- **Analog polish:** Finishing chain adds tape-style saturation and subtle
+  wow/flutter for vintage warmth.
 


### PR DESCRIPTION
## Summary
- add tape-style saturation and wow/flutter effects
- wire analog polish into final processing chain
- document analog polish option in README

## Testing
- `python -m py_compile src-tauri/python/lofi_gpu_hq.py`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a01b4613d48325b2f7203d6a2f3208