### PR TITLE
feat: enhance big brother updates UI

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -502,6 +502,7 @@ pub struct NewsArticle {
     pub pub_date: Option<String>,
     pub source: String,
     pub summary: Option<String>,
+    pub tags: Vec<String>,
 }
 
 static NEWS_CACHE: Lazy<Mutex<Option<(Instant, Vec<NewsArticle>)>>> =
@@ -563,6 +564,11 @@ pub async fn fetch_big_brother_news(force: Option<bool>) -> Result<Vec<NewsArtic
             let link = item.link().unwrap_or("").to_string();
             let pub_date = item.pub_date().map(|s| s.to_string());
             let description = item.description().unwrap_or("");
+            let tags = item
+                .categories()
+                .iter()
+                .map(|c| c.name().to_string())
+                .collect::<Vec<_>>();
 
             let prompt = format!(
                 "Summarize this Big Brother article in one or two sentences.\nTitle: {title}\nDescription: {description}"
@@ -584,6 +590,7 @@ pub async fn fetch_big_brother_news(force: Option<bool>) -> Result<Vec<NewsArtic
                 pub_date,
                 source: source.to_string(),
                 summary,
+                tags,
             });
         }
     }

--- a/src/pages/BigBrotherUpdates.tsx
+++ b/src/pages/BigBrotherUpdates.tsx
@@ -1,33 +1,73 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { Box, Button, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  Chip,
+  Skeleton,
+  Stack,
+  Typography,
+} from "@mui/material";
 import { FiRefreshCcw } from "react-icons/fi";
 
-export default function BigBrotherUpdates() {
-  const [summary, setSummary] = useState(() => {
-    return localStorage.getItem("bigBrotherSummary") || "";
+interface Article {
+  title: string;
+  link: string;
+  pub_date?: string;
+  source: string;
+  summary?: string;
+  tags: string[];
+}
+
+function formatDate(dateStr?: string) {
+  if (!dateStr) return "";
+  const date = new Date(dateStr);
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
   });
+}
+
+function timeAgo(dateStr?: string) {
+  if (!dateStr) return "";
+  const date = new Date(dateStr).getTime();
+  const diff = Date.now() - date;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export default function BigBrotherUpdates() {
+  const [articles, setArticles] = useState<Article[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
 
   const fetchData = async (force = false) => {
     setLoading(true);
+    setError("");
     try {
-      const data = await invoke<string>("fetch_big_brother_summary", { force });
-      setSummary(data);
-      localStorage.setItem("bigBrotherSummary", data);
-      localStorage.setItem("bigBrotherSummaryTimestamp", Date.now().toString());
+      const data = await invoke<Article[]>("fetch_big_brother_news", { force });
+      setArticles(data);
     } catch (err) {
-      console.error("Failed to fetch summary", err);
+      setError(String(err));
     }
     setLoading(false);
   };
 
   useEffect(() => {
-    const last = localStorage.getItem("bigBrotherSummaryTimestamp");
-    if (!last || Date.now() - parseInt(last, 10) > 86400 * 1000) {
-      fetchData();
-    }
+    fetchData();
   }, []);
+
+  const handleRetry = () => fetchData(true);
+
+  const openLink = (link: string) => {
+    window.open(link, "_blank", "noopener,noreferrer");
+  };
 
   return (
     <Box sx={{ maxWidth: 1200, mx: "auto", px: 2, py: 3 }}>
@@ -51,23 +91,114 @@ export default function BigBrotherUpdates() {
           Refresh
         </Button>
       </Box>
-      {summary && (
-        <Box
-          sx={{
-            p: 2,
-            borderRadius: 3,
-            bgcolor: "background.paper",
-            color: "text.primary",
-            border: 1,
-            borderColor: "divider",
-          }}
-        >
-          <Typography variant="body1" sx={{ whiteSpace: "pre-line" }}>
-            {summary}
-          </Typography>
-        </Box>
+
+      {loading && (
+        <Stack spacing={2}>
+          {[0, 1, 2].map((i) => (
+            <Box
+              key={i}
+              sx={{ border: 1, borderColor: "divider", p: 2, borderRadius: 2 }}
+            >
+              <Skeleton variant="text" width="60%" />
+              <Skeleton variant="text" width="40%" />
+              <Skeleton variant="rectangular" height={60} sx={{ mt: 1 }} />
+            </Box>
+          ))}
+        </Stack>
+      )}
+
+      {!loading && error && (
+        <Stack spacing={2} alignItems="flex-start">
+          <Typography color="error">Failed to load updates.</Typography>
+          <Button variant="outlined" onClick={handleRetry} startIcon={<FiRefreshCcw />}>
+            Retry
+          </Button>
+        </Stack>
+      )}
+
+      {!loading && !error && articles.length === 0 && (
+        <Typography>No updates available right now.</Typography>
+      )}
+
+      {!loading && !error && (
+        <Stack spacing={2}>
+          {articles.map((a) => (
+            <Box
+              key={a.link}
+              onClick={() => openLink(a.link)}
+              tabIndex={0}
+              role="link"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  openLink(a.link);
+                }
+              }}
+              sx={{
+                p: 2,
+                border: 1,
+                borderColor: "divider",
+                borderRadius: 2,
+                cursor: "pointer",
+                transition: "box-shadow 0.2s, transform 0.2s, border-color 0.2s",
+                '&:hover': {
+                  boxShadow: 3,
+                  borderColor: 'primary.main',
+                  '& a': { textDecoration: 'underline' },
+                  transform: 'translateY(-2px)',
+                },
+                '&:active': {
+                  transform: 'scale(0.98)',
+                },
+                '&:focus-visible': {
+                  outline: '2px solid',
+                  outlineColor: 'primary.main',
+                },
+              }}
+            >
+              <Typography variant="h6" sx={{ mb: 1 }}>
+                {a.title}
+              </Typography>
+              {a.summary && (
+                <Typography variant="body2" sx={{ mb: 1 }}>
+                  {a.summary}
+                </Typography>
+              )}
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                sx={{ color: "text.secondary", fontSize: 14, flexWrap: 'wrap' }}
+              >
+                <img
+                  src={`https://www.google.com/s2/favicons?domain=${new URL(a.link).origin}`}
+                  width={16}
+                  height={16}
+                  style={{ marginRight: 4 }}
+                />
+                <span>{a.source}</span>
+                {a.pub_date && (
+                  <span>
+                    • {formatDate(a.pub_date)} ({timeAgo(a.pub_date)})
+                  </span>
+                )}
+              </Stack>
+              {a.tags.length > 0 && (
+                <Box sx={{ mt: 1, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                  {a.tags.map((tag) => (
+                    <Chip
+                      key={tag}
+                      label={tag}
+                      size="small"
+                      onClick={(e) => e.stopPropagation()}
+                    />
+                  ))}
+                </Box>
+              )}
+            </Box>
+          ))}
+        </Stack>
       )}
     </Box>
   );
 }
-


### PR DESCRIPTION
## Summary
- display Big Brother news as interactive cards with hover and focus states
- add skeleton loading, error, and empty states
- include human-readable dates, source icons, and optional tags from RSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a01c1d6130832588a43a77cdb20ee8