### PR TITLE
feat(lofi): add jazz voice leading

### DIFF
--- a/src/features/lofi/tests/useLofiEngine.test.ts
+++ b/src/features/lofi/tests/useLofiEngine.test.ts
@@ -26,7 +26,11 @@ describe('useLofi engine', () => {
       const Loop = vi
         .fn()
         .mockImplementation(() => ({ start: vi.fn(), stop: vi.fn() }));
-      const Frequency = (n: string) => ({ transpose: () => ({ toNote: () => n }) });
+      const Frequency = (n: any) => ({
+        transpose: () => ({ toNote: () => n }),
+        toMidi: () => (typeof n === 'number' ? n : 60),
+        toNote: () => (typeof n === 'number' ? 'C4' : n),
+      });
       const Synth = vi.fn();
       return {
         start,

--- a/src/features/lofi/useLofiEngine.test.ts
+++ b/src/features/lofi/useLofiEngine.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { chordFromDegree, voiceLeadChords } from './useLofiEngine';
+import * as Tone from 'tone';
+
+describe('chordFromDegree', () => {
+  it('adds a 9th extension for richer harmony', () => {
+    const chord = chordFromDegree(1, 'C');
+    expect(chord.length).toBe(5);
+    expect(chord[4]).toBe('D5');
+  });
+});
+
+describe('voiceLeadChords', () => {
+  it('minimizes root movement between chords', () => {
+    const prog = [chordFromDegree(1, 'C'), chordFromDegree(5, 'C')];
+    const voiced = voiceLeadChords(prog);
+    const prevRoot = Tone.Frequency(voiced[0][0]).toMidi();
+    const rawRoot = Tone.Frequency(prog[1][0]).toMidi();
+    const voicedRoot = Tone.Frequency(voiced[1][0]).toMidi();
+    expect(Math.abs(voicedRoot - prevRoot)).toBeLessThan(Math.abs(rawRoot - prevRoot));
+  });
+});


### PR DESCRIPTION
## Summary
- enrich chords with 9th extensions and varied progression patterns
- add voice leading algorithm for smoother transitions
- test advanced harmony utilities and update Tone mocks

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a0214baa748325989c468fa715c5f9