### PR TITLE
feat: add DND module

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import BigBrotherUpdates from "./pages/BigBrotherUpdates";
 import Laser from "./pages/Laser";
 import Lofi from "./pages/Lofi";
 import NotFound from "./pages/NotFound";
+import DND from "./pages/DND";
 
 export default function App() {
   return (
@@ -34,6 +35,7 @@ export default function App() {
         />
         <Route path="/laser" element={<Laser />} />
         <Route path="/lofi" element={<Lofi />} />
+        <Route path="/dnd" element={<DND />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </>

--- a/src/components/FeatureCarousel.tsx
+++ b/src/components/FeatureCarousel.tsx
@@ -9,6 +9,7 @@ import {
   FaRobot,
   FaBolt,
   FaCalendarAlt,
+  FaDiceD20,
 } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import { useSettings } from "../features/settings/useSettings";
@@ -32,6 +33,7 @@ export default function FeatureCarousel({
       { key: "comfy", icon: <FaCameraRetro />, label: "ComfyUI", path: "/comfy" },
       { key: "assistant", icon: <FaRobot />, label: "AI Assistant", path: "/assistant" },
       { key: "laser", icon: <FaBolt />, label: "Laser Lab", path: "/laser" },
+      { key: "dnd", icon: <FaDiceD20 />, label: "DND", path: "/dnd" },
     ],
     []
   );

--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -1,7 +1,14 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-type ModuleKey = 'objects' | 'music' | 'calendar' | 'comfy' | 'assistant' | 'laser';
+type ModuleKey =
+  | 'objects'
+  | 'music'
+  | 'calendar'
+  | 'comfy'
+  | 'assistant'
+  | 'laser'
+  | 'dnd';
 
 type ModulesState = Record<ModuleKey, boolean>;
 
@@ -20,6 +27,7 @@ export const useSettings = create<SettingsState>()(
         comfy: true,
         assistant: true,
         laser: true,
+        dnd: true,
       },
       toggleModule: (key) =>
         set((state) => ({

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -1,0 +1,35 @@
+import { Button, Stack } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+import Center from "./_Center";
+
+interface Feature {
+  label: string;
+  path?: string;
+}
+
+const features: Feature[] = [
+  { label: "Lore" },
+  { label: "Journal" },
+  { label: "NPC Maker" },
+  { label: "World Builder" },
+  { label: "NPC List" },
+];
+
+export default function DND() {
+  const navigate = useNavigate();
+  return (
+    <Center>
+      <Stack spacing={2} sx={{ width: "100%", maxWidth: 400 }}>
+        {features.map((feature) => (
+          <Button
+            key={feature.label}
+            variant="contained"
+            onClick={() => feature.path && navigate(feature.path)}
+          >
+            {feature.label}
+          </Button>
+        ))}
+      </Stack>
+    </Center>
+  );
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -37,6 +37,7 @@ export default function Settings() {
               ["comfy", "ComfyUI"],
               ["assistant", "AI Assistant"],
               ["laser", "Laser Lab"],
+              ["dnd", "DND"],
             ] as const
           ).map(([key, label]) => (
             <FormControlLabel


### PR DESCRIPTION
## Summary
- add DND module to home carousel
- add DND settings toggle and route
- create DND page with Lore, Journal, NPC Maker, World Builder, NPC List

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a02064d328832590836bd2d9f9e5e7