### PR TITLE
Add DND world builder page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Comfy from "./pages/Comfy";
 import Assistant from "./pages/Assistant";
 import GeneralChat from "./pages/GeneralChat";
 import BigBrotherUpdates from "./pages/BigBrotherUpdates";
+import WorldBuilder from "./pages/WorldBuilder";
 import Laser from "./pages/Laser";
 import Lofi from "./pages/Lofi";
 import NotFound from "./pages/NotFound";
@@ -28,6 +29,7 @@ export default function App() {
         <Route path="/comfy" element={<Comfy />} />
         <Route path="/assistant" element={<Assistant />} />
         <Route path="/assistant/general-chat" element={<GeneralChat />} />
+        <Route path="/assistant/world-builder" element={<WorldBuilder />} />
         <Route
           path="/assistant/big-brother-updates"
           element={<BigBrotherUpdates />}

--- a/src/pages/Assistant.tsx
+++ b/src/pages/Assistant.tsx
@@ -15,7 +15,7 @@ const features: Feature[] = [
   { label: "Orchestration" },
   { label: "RAG" },
   { label: "General Chat", path: "/assistant/general-chat" },
-  { label: "World Builder" },
+  { label: "World Builder", path: "/assistant/world-builder" },
   { label: "Big Brother updates", path: "/assistant/big-brother-updates" },
 ];
 

--- a/src/pages/WorldBuilder.test.tsx
+++ b/src/pages/WorldBuilder.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import WorldBuilder from "./WorldBuilder";
+
+describe("WorldBuilder", () => {
+  it("adds a world after submitting", () => {
+    render(<WorldBuilder />);
+    fireEvent.click(screen.getByText("Create New World"));
+    fireEvent.change(screen.getByLabelText("World Name"), {
+      target: { value: "Faerun" },
+    });
+    fireEvent.click(screen.getByText("Submit"));
+    expect(screen.getByText("Faerun")).toBeInTheDocument();
+  });
+});

--- a/src/pages/WorldBuilder.tsx
+++ b/src/pages/WorldBuilder.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { Button, Stack, TextField } from "@mui/material";
+import Center from "./_Center";
+
+export default function WorldBuilder() {
+  const [worlds, setWorlds] = useState<string[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [name, setName] = useState("");
+
+  function submit() {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setWorlds((prev) => [...prev, trimmed]);
+    setName("");
+    setCreating(false);
+  }
+
+  return (
+    <Center>
+      <Stack spacing={2} sx={{ width: "100%", maxWidth: 400 }}>
+        {worlds.map((w) => (
+          <Button key={w} variant="outlined">
+            {w}
+          </Button>
+        ))}
+        {creating ? (
+          <>
+            <TextField
+              label="World Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <Button variant="contained" onClick={submit}>
+              Submit
+            </Button>
+          </>
+        ) : (
+          <Button variant="contained" onClick={() => setCreating(true)}>
+            Create New World
+          </Button>
+        )}
+      </Stack>
+    </Center>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder DND lore folder
- introduce World Builder page with local world creation
- expose World Builder in assistant menu and router

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a01f6a4a348325bf3e55c26e138c9b