### PR TITLE
Add DND world builder with dynamic world creation

### DIFF
--- a/DND_Lore_Knowledge/.gitkeep
+++ b/DND_Lore_Knowledge/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to track DND lore data

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Laser from "./pages/Laser";
 import Lofi from "./pages/Lofi";
 import NotFound from "./pages/NotFound";
 import DND from "./pages/DND";
+import WorldBuilder from "./pages/WorldBuilder";
 
 export default function App() {
   return (
@@ -36,6 +37,7 @@ export default function App() {
         <Route path="/laser" element={<Laser />} />
         <Route path="/lofi" element={<Lofi />} />
         <Route path="/dnd" element={<DND />} />
+        <Route path="/dnd/world-builder" element={<WorldBuilder />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </>

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -11,7 +11,7 @@ const features: Feature[] = [
   { label: "Lore" },
   { label: "Journal" },
   { label: "NPC Maker" },
-  { label: "World Builder" },
+  { label: "World Builder", path: "/dnd/world-builder" },
   { label: "NPC List" },
 ];
 

--- a/src/pages/WorldBuilder.tsx
+++ b/src/pages/WorldBuilder.tsx
@@ -1,0 +1,56 @@
+import { useState, useEffect } from "react";
+import { Button, Stack, TextField } from "@mui/material";
+import Center from "./_Center";
+
+export default function WorldBuilder() {
+  const [worlds, setWorlds] = useState<string[]>(() => {
+    const saved = localStorage.getItem("dnd_worlds");
+    return saved ? JSON.parse(saved) : [];
+    });
+  const [creating, setCreating] = useState(false);
+  const [worldName, setWorldName] = useState("");
+
+  useEffect(() => {
+    localStorage.setItem("dnd_worlds", JSON.stringify(worlds));
+  }, [worlds]);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const name = worldName.trim();
+    if (!name) return;
+    setWorlds([...worlds, name]);
+    setWorldName("");
+    setCreating(false);
+  };
+
+  return (
+    <Center>
+      <Stack spacing={2} sx={{ width: "100%", maxWidth: 400 }}>
+        {worlds.map((world) => (
+          <Button key={world} variant="contained">
+            {world}
+          </Button>
+        ))}
+        {creating ? (
+          <form onSubmit={handleSubmit}>
+            <Stack direction="row" spacing={1}>
+              <TextField
+                fullWidth
+                label="World Name"
+                value={worldName}
+                onChange={(e) => setWorldName(e.target.value)}
+              />
+              <Button type="submit" variant="contained">
+                Submit
+              </Button>
+            </Stack>
+          </form>
+        ) : (
+          <Button variant="contained" onClick={() => setCreating(true)}>
+            Create New World
+          </Button>
+        )}
+      </Stack>
+    </Center>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder folder for DND lore knowledge
- add WorldBuilder page with form to create new worlds and persist names
- wire World Builder navigation and route from DND section

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a027fbff7c8325ae962ed370ce2e09