### PR TITLE
feat(settings): add multi-user support

### DIFF
--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -1,41 +1,12 @@
-import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { useUsers, defaultModules, type ModuleKey } from "../users/useUsers";
 
-type ModuleKey =
-  | 'objects'
-  | 'music'
-  | 'calendar'
-  | 'comfy'
-  | 'assistant'
-  | 'laser'
-  | 'dnd';
-
-type ModulesState = Record<ModuleKey, boolean>;
-
-interface SettingsState {
-  modules: ModulesState;
-  toggleModule: (key: ModuleKey) => void;
+export function useSettings() {
+  const modules = useUsers((state) => {
+    const id = state.currentUserId;
+    return id ? state.users[id].modules : defaultModules;
+  });
+  const toggleModule = useUsers((state) => state.toggleModule);
+  return { modules, toggleModule };
 }
-
-export const useSettings = create<SettingsState>()(
-  persist(
-    (set) => ({
-      modules: {
-        objects: true,
-        music: true,
-        calendar: true,
-        comfy: true,
-        assistant: true,
-        laser: true,
-        dnd: true,
-      },
-      toggleModule: (key) =>
-        set((state) => ({
-          modules: { ...state.modules, [key]: !state.modules[key] },
-        })),
-    }),
-    { name: 'settings-store' }
-  )
-);
 
 export type { ModuleKey };

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect } from "react";
+import { useUsers } from "../users/useUsers";
 
 export type Theme = "default" | "ocean" | "forest" | "sunset" | "sakura";
 
@@ -10,19 +11,16 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(() => {
-    const stored = localStorage.getItem("theme");
-    if (stored === "ocean" || stored === "forest" || stored === "sunset" || stored === "sakura") {
-      return stored;
-    }
-    return "default";
+  const theme = useUsers((state) => {
+    const id = state.currentUserId;
+    return id ? state.users[id].theme : "default";
   });
+  const setTheme = useUsers((state) => state.setTheme);
 
   useEffect(() => {
     const classes = ["theme-default", "theme-ocean", "theme-forest", "theme-sunset", "theme-sakura"];
     document.body.classList.remove(...classes);
     document.body.classList.add(`theme-${theme}`);
-    localStorage.setItem("theme", theme);
   }, [theme]);
 
   return (

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -1,0 +1,89 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { Theme } from '../theme/ThemeContext';
+
+type ModuleKey =
+  | 'objects'
+  | 'music'
+  | 'calendar'
+  | 'comfy'
+  | 'assistant'
+  | 'laser'
+  | 'dnd';
+
+type ModulesState = Record<ModuleKey, boolean>;
+
+const defaultModules: ModulesState = {
+  objects: true,
+  music: true,
+  calendar: true,
+  comfy: true,
+  assistant: true,
+  laser: true,
+  dnd: true,
+};
+
+interface User {
+  id: string;
+  name: string;
+  theme: Theme;
+  modules: ModulesState;
+}
+
+interface UsersState {
+  users: Record<string, User>;
+  currentUserId: string | null;
+  addUser: (name: string) => void;
+  switchUser: (id: string) => void;
+  setTheme: (theme: Theme) => void;
+  toggleModule: (key: ModuleKey) => void;
+}
+
+export const useUsers = create<UsersState>()(
+  persist(
+    (set, get) => ({
+      users: {},
+      currentUserId: null,
+      addUser: (name) => {
+        const id = Date.now().toString();
+        set((state) => ({
+          users: {
+            ...state.users,
+            [id]: { id, name, theme: 'default', modules: { ...defaultModules } },
+          },
+          currentUserId: id,
+        }));
+      },
+      switchUser: (id) => set(() => ({ currentUserId: id })),
+      setTheme: (theme) => {
+        const id = get().currentUserId;
+        if (!id) return;
+        set((state) => ({
+          users: {
+            ...state.users,
+            [id]: { ...state.users[id], theme },
+          },
+        }));
+      },
+      toggleModule: (key) => {
+        const id = get().currentUserId;
+        if (!id) return;
+        set((state) => {
+          const user = state.users[id];
+          return {
+            users: {
+              ...state.users,
+              [id]: {
+                ...user,
+                modules: { ...user.modules, [key]: !user.modules[key] },
+              },
+            },
+          };
+        });
+      },
+    }),
+    { name: 'user-store' }
+  )
+);
+
+export { type ModuleKey, type ModulesState, defaultModules };

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -8,15 +8,22 @@ import {
   MenuItem,
   FormControlLabel,
   Switch,
+  TextField,
+  Button,
 } from "@mui/material";
+import { useState } from "react";
 import { useCalendar } from "../features/calendar/useCalendar";
 import { Theme, useTheme } from "../features/theme/ThemeContext";
 import { useSettings } from "../features/settings/useSettings";
+import { useUsers } from "../features/users/useUsers";
 
 export default function Settings() {
   const { theme, setTheme } = useTheme();
   const { events, selectedCountdownId, setSelectedCountdownId } = useCalendar();
   const { modules, toggleModule } = useSettings();
+  const { users, currentUserId, addUser, switchUser } = useUsers();
+  const [newUser, setNewUser] = useState("");
+  const userList = Object.values(users);
   const countdownEvents = events.filter(
     (e) => e.hasCountdown && e.status !== "canceled" && e.status !== "missed"
   );
@@ -27,6 +34,42 @@ export default function Settings() {
         <Typography variant="body2" color="text.secondary">
           Put toggles, theme, and module switches here.
         </Typography>
+
+        <FormControl fullWidth sx={{ mt: 2 }}>
+          <InputLabel id="user-label">User</InputLabel>
+          <Select
+            labelId="user-label"
+            label="User"
+            value={currentUserId ?? ""}
+            onChange={(e) => switchUser(e.target.value as string)}
+          >
+            {userList.map((u) => (
+              <MenuItem key={u.id} value={u.id}>
+                {u.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Box sx={{ display: "flex", gap: 1, mt: 2 }}>
+          <TextField
+            label="New User"
+            value={newUser}
+            onChange={(e) => setNewUser(e.target.value)}
+            fullWidth
+          />
+          <Button
+            variant="contained"
+            onClick={() => {
+              const name = newUser.trim();
+              if (name) {
+                addUser(name);
+                setNewUser("");
+              }
+            }}
+          >
+            Add
+          </Button>
+        </Box>
 
         <Box sx={{ mt: 2 }}>
           {(


### PR DESCRIPTION
## Summary
- add Zustand user store with profile-specific theme and module settings
- wire ThemeProvider and settings page to use per-user preferences
- allow creating and switching between users

## Testing
- `npm test`
- `npm run build` *(fails: TS errors in existing test files)*

------
https://chatgpt.com/codex/tasks/task_e_68a02c1132f483259f68023030baf4df