### PR TITLE
feat: allow configuring ComfyUI folder path

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,11 @@ npm run tauri dev    # start the app in development mode
 npm run tauri build  # build a release bundle
 ```
 
-The Rust backend can launch local tools such as ComfyUI and Ollama. Update the
-paths in `src-tauri/src/commands.rs` to match your environment:
+The Rust backend can launch local tools such as ComfyUI and Ollama. Set the
+ComfyUI folder location in the app's Settings page and update the Python path in
+`src-tauri/src/commands.rs` if needed:
 
 ```rust
-fn comfy_dir() -> PathBuf {
-    // Path to your ComfyUI repository
-    PathBuf::from(r"C:\\Comfy\\ComfyUI")
-}
-
 fn conda_python() -> PathBuf {
     // Python interpreter to run the bundled scripts
     PathBuf::from(r"C:\\Users\\Owner\\.conda\\envs\\blossom-ml\\python.exe")
@@ -52,8 +48,9 @@ Activate your Python environment first. The high‑quality generator lives at
 
 ## Configuration and optional features
 
-- **Paths:** Edit `comfy_dir()` and `conda_python()` in `src-tauri/src/commands.rs`
-  so the app can find ComfyUI and your Python interpreter.
+- **Paths:** Set the ComfyUI directory in the Settings page and edit
+  `conda_python()` in `src-tauri/src/commands.rs` so the app can find your Python
+  interpreter.
 - **HQ feature flags:** `lofi_gpu_hq.py` supports `hq_stereo`, `hq_reverb`,
   `hq_sidechain`, and `hq_chorus` flags inside the `motif` object to enable or disable
   high‑quality processing.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -23,12 +23,6 @@ ComfyUI launcher (no extra crate)
 static COMFY_CHILD: OnceLock<Mutex<Option<Child>>> = OnceLock::new();
 static OLLAMA_CHILD: OnceLock<Mutex<Option<Child>>> = OnceLock::new();
 
-fn comfy_dir() -> PathBuf {
-    // TODO: put your ComfyUI repo folder here
-    // e.g.: PathBuf::from(r"C:\dev\ComfyUI")
-    PathBuf::from(r"C:\Comfy\ComfyUI")
-}
-
 // Reuse our python path from below
 fn comfy_python() -> PathBuf {
     conda_python()
@@ -108,7 +102,7 @@ pub async fn comfy_status() -> Result<bool, String> {
 }
 
 #[tauri::command]
-pub async fn comfy_start<R: Runtime>(window: Window<R>) -> Result<(), String> {
+pub async fn comfy_start<R: Runtime>(window: Window<R>, dir: String) -> Result<(), String> {
     {
         let lock = COMFY_CHILD.get_or_init(|| Mutex::new(None)).lock().unwrap();
         if lock.is_some() {
@@ -116,7 +110,7 @@ pub async fn comfy_start<R: Runtime>(window: Window<R>) -> Result<(), String> {
         }
     }
 
-    let dir = comfy_dir();
+    let dir = PathBuf::from(dir);
     if !dir.exists() {
         return Err(format!("ComfyUI folder not found at {}", dir.display()));
     }

--- a/src/features/comfy/useComfy.ts
+++ b/src/features/comfy/useComfy.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface ComfyState {
+  folder: string;
+  setFolder: (path: string) => void;
+}
+
+export const useComfy = create<ComfyState>()(
+  persist(
+    (set) => ({
+      folder: '',
+      setFolder: (path: string) => set({ folder: path })
+    }),
+    { name: 'comfy-store' }
+  )
+);

--- a/src/pages/Comfy.tsx
+++ b/src/pages/Comfy.tsx
@@ -2,11 +2,13 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { useComfy } from "../features/comfy/useComfy";
 
 export default function Comfy() {
   const [running, setRunning] = useState(false);
   const [log, setLog] = useState<string[]>([]);
   const [pingOk, setPingOk] = useState(false);
+  const { folder: comfyFolder } = useComfy();
 
   useEffect(() => {
     let unlisten: (() => void) | undefined;
@@ -37,8 +39,12 @@ export default function Comfy() {
   }, [running]);
 
   const start = async () => {
+    if (!comfyFolder) {
+      setLog((prev) => [...prev, "Set ComfyUI folder in Settings first."]);
+      return;
+    }
     try {
-      await invoke("comfy_start");
+      await invoke("comfy_start", { dir: comfyFolder });
       setRunning(true);
       setTimeout(() => setPingOk(true), 2000);
     } catch (e: any) {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -16,12 +16,15 @@ import { useCalendar } from "../features/calendar/useCalendar";
 import { Theme, useTheme } from "../features/theme/ThemeContext";
 import { useSettings } from "../features/settings/useSettings";
 import { useUsers } from "../features/users/useUsers";
+import { useComfy } from "../features/comfy/useComfy";
+import { open } from "@tauri-apps/plugin-dialog";
 
 export default function Settings() {
   const { theme, setTheme } = useTheme();
   const { events, selectedCountdownId, setSelectedCountdownId } = useCalendar();
   const { modules, toggleModule } = useSettings();
   const { users, currentUserId, addUser, switchUser } = useUsers();
+  const { folder: comfyFolder, setFolder: setComfyFolder } = useComfy();
   const [newUser, setNewUser] = useState("");
   const userList = Object.values(users);
   const countdownEvents = events.filter(
@@ -94,6 +97,24 @@ export default function Settings() {
               label={label}
             />
           ))}
+        </Box>
+        <Box sx={{ mt: 3 }}>
+          <TextField
+            label="ComfyUI Folder"
+            value={comfyFolder}
+            onChange={(e) => setComfyFolder(e.target.value)}
+            fullWidth
+          />
+          <Button
+            variant="outlined"
+            sx={{ mt: 1 }}
+            onClick={async () => {
+              const dir = await open({ directory: true });
+              if (typeof dir === "string") setComfyFolder(dir);
+            }}
+          >
+            Browse
+          </Button>
         </Box>
         <FormControl fullWidth sx={{ mt: 3 }}>
           <InputLabel id="theme-label">Theme</InputLabel>


### PR DESCRIPTION
## Summary
- add persistent store for ComfyUI folder
- expose ComfyUI folder selector in Settings and pass to backend
- make backend `comfy_start` command accept folder path
- update README to mention setting path via UI

## Testing
- `npm test -- --run`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d4bc2dc48325bd3029693456fa3d