### PR TITLE
feat: highlight active top bar icons for accessibility

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -5,22 +5,27 @@ import { useNavigate, useLocation } from "react-router-dom";
 export default function TopBar() {
   const nav = useNavigate();
   const { pathname } = useLocation();
-  const activeColor = (p: string) => (pathname === p ? "#111" : "white");
+  const activeStyles = (p: string) =>
+    pathname === p
+      ? { color: "#000", backgroundColor: "#fff", borderRadius: 4 }
+      : { color: "white" };
 
   return (
     <>
       <IconButton
         onClick={() => nav("/")}
-        style={{ position: "fixed", top: 12, left: 12, zIndex: 2, color: activeColor("/") }}
+        style={{ position: "fixed", top: 12, left: 12, zIndex: 2, ...activeStyles("/") }}
         aria-label="Home"
+        aria-current={pathname === "/" ? "page" : undefined}
       >
         <FaHome />
       </IconButton>
 
       <IconButton
         onClick={() => nav("/settings")}
-        style={{ position: "fixed", top: 12, right: 12, zIndex: 2, color: activeColor("/settings") }}
+        style={{ position: "fixed", top: 12, right: 12, zIndex: 2, ...activeStyles("/settings") }}
         aria-label="Settings"
+        aria-current={pathname === "/settings" ? "page" : undefined}
       >
         <FaWrench />
       </IconButton>


### PR DESCRIPTION
## Summary
- highlight active TopBar icons with high-contrast background
- add aria-current to indicate active page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0d957b1588325a8dd37f1dd96b4b2