### PR TITLE
Allow custom output folder

### DIFF
--- a/src-tauri/python/pdf_tools.py
+++ b/src-tauri/python/pdf_tools.py
@@ -10,7 +10,23 @@ import pdfplumber
 import pytesseract
 
 
-BASE_DIR = Path(__file__).resolve().parents[2] / "Knowledge"
+def _base_dir() -> Path:
+    env_dir = os.environ.get("BLOSSOM_OUTPUT_DIR")
+    if env_dir:
+        return Path(env_dir)
+    settings_file = Path.home() / ".blossom_settings.json"
+    if settings_file.exists():
+        try:
+            data = json.loads(settings_file.read_text())
+            out = data.get("output_folder")
+            if out:
+                return Path(out)
+        except Exception:
+            pass
+    return Path(__file__).resolve().parents[2] / "Knowledge"
+
+
+BASE_DIR = _base_dir()
 PDF_DIR = BASE_DIR / "PDFs"
 INDEX_DIR = BASE_DIR / "Index"
 EMBED_DIM = 512

--- a/src/features/output/useOutput.ts
+++ b/src/features/output/useOutput.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface OutputState {
+  folder: string;
+  setFolder: (path: string) => void;
+}
+
+export const useOutput = create<OutputState>()(
+  persist(
+    (set) => ({
+      folder: '',
+      setFolder: (path: string) => set({ folder: path })
+    }),
+    { name: 'output-store' }
+  )
+);

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -17,6 +17,7 @@ import { Theme, useTheme } from "../features/theme/ThemeContext";
 import { useSettings } from "../features/settings/useSettings";
 import { useUsers } from "../features/users/useUsers";
 import { useComfy } from "../features/comfy/useComfy";
+import { useOutput } from "../features/output/useOutput";
 import { open } from "@tauri-apps/plugin-dialog";
 
 export default function Settings() {
@@ -25,6 +26,7 @@ export default function Settings() {
   const { modules, toggleModule } = useSettings();
   const { users, currentUserId, addUser, switchUser } = useUsers();
   const { folder: comfyFolder, setFolder: setComfyFolder } = useComfy();
+  const { folder: outputFolder, setFolder: setOutputFolder } = useOutput();
   const [newUser, setNewUser] = useState("");
   const userList = Object.values(users);
   const countdownEvents = events.filter(
@@ -111,6 +113,24 @@ export default function Settings() {
             onClick={async () => {
               const dir = await open({ directory: true });
               if (typeof dir === "string") setComfyFolder(dir);
+            }}
+          >
+            Browse
+          </Button>
+        </Box>
+        <Box sx={{ mt: 3 }}>
+          <TextField
+            label="Output Folder"
+            value={outputFolder}
+            onChange={(e) => setOutputFolder(e.target.value)}
+            fullWidth
+          />
+          <Button
+            variant="outlined"
+            sx={{ mt: 1 }}
+            onClick={async () => {
+              const dir = await open({ directory: true });
+              if (typeof dir === "string") setOutputFolder(dir);
             }}
           >
             Browse


### PR DESCRIPTION
## Summary
- Load PDF base directory from environment or settings JSON
- Add persistent output folder store
- Add Settings control to choose output folder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0d7bd3b7c8325951388fe34674c35