### PR TITLE
feat: add pdf management and search

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -25,6 +25,11 @@ fn main() {
             commands::general_chat,
             // Blender:
             commands::blender_run_script,
+            // PDF tools:
+            commands::pdf_add,
+            commands::pdf_remove,
+            commands::pdf_list,
+            commands::pdf_search,
             // News scraping:
             commands::fetch_big_brother_news,
             commands::fetch_big_brother_summary,

--- a/src/pages/GeneralChat.test.tsx
+++ b/src/pages/GeneralChat.test.tsx
@@ -21,6 +21,7 @@ describe('GeneralChat', () => {
   it('handles message flow', async () => {
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === 'start_ollama') return Promise.resolve();
+      if (cmd === 'pdf_search') return Promise.resolve([]);
       if (cmd === 'general_chat') return Promise.resolve('Reply');
       return Promise.resolve();
     });
@@ -33,6 +34,9 @@ describe('GeneralChat', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
 
     await waitFor(() => {
+      const searchCalls = (invoke as any).mock.calls.filter(([cmd]: [string]) => cmd === 'pdf_search');
+      expect(searchCalls).toHaveLength(1);
+      expect(searchCalls[0][1]).toEqual({ query: 'Hello' });
       const calls = (invoke as any).mock.calls.filter(([cmd]: [string]) => cmd === 'general_chat');
       expect(calls).toHaveLength(1);
       expect(calls[0][1]).toEqual({
@@ -49,6 +53,7 @@ describe('GeneralChat', () => {
   it('inserts system prompt only once', async () => {
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === 'start_ollama') return Promise.resolve();
+      if (cmd === 'pdf_search') return Promise.resolve([]);
       if (cmd === 'general_chat') return Promise.resolve('Reply');
       return Promise.resolve();
     });
@@ -61,6 +66,8 @@ describe('GeneralChat', () => {
     fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'Hi' } });
     fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
     await waitFor(() => {
+      const searchCalls = (invoke as any).mock.calls.filter(([cmd]: [string]) => cmd === 'pdf_search');
+      expect(searchCalls).toHaveLength(1);
       const calls = (invoke as any).mock.calls.filter(([cmd]: [string]) => cmd === 'general_chat');
       expect(calls).toHaveLength(1);
       expect(calls[0][1]).toEqual({
@@ -76,6 +83,8 @@ describe('GeneralChat', () => {
     fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'How are you?' } });
     fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
     await waitFor(() => {
+      const searchCalls = (invoke as any).mock.calls.filter(([cmd]: [string]) => cmd === 'pdf_search');
+      expect(searchCalls).toHaveLength(2);
       const calls = (invoke as any).mock.calls.filter(([cmd]: [string]) => cmd === 'general_chat');
       expect(calls).toHaveLength(2);
       expect(calls[1][1]).toEqual({
@@ -92,6 +101,7 @@ describe('GeneralChat', () => {
   it('shows error when send fails', async () => {
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === 'start_ollama') return Promise.resolve();
+      if (cmd === 'pdf_search') return Promise.resolve([]);
       if (cmd === 'general_chat') return Promise.reject('fail');
       return Promise.resolve();
     });


### PR DESCRIPTION
## Summary
- add pdf add/remove/list/search commands and expose via Tauri
- integrate document management panel into Settings
- perform PDF search on chat queries before responding

## Testing
- `npm test`
- `cargo check` *(fails: The system library `gio-2.0` required by crate `gio-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d7bc151c8325a0e132e6f139eca4