### PR TITLE
Move World Builder access to DND section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ export default function App() {
         <Route path="/comfy" element={<Comfy />} />
         <Route path="/assistant" element={<Assistant />} />
         <Route path="/assistant/general-chat" element={<GeneralChat />} />
-        <Route path="/assistant/world-builder" element={<WorldBuilder />} />
+        <Route path="/dnd/world-builder" element={<WorldBuilder />} />
         <Route
           path="/assistant/big-brother-updates"
           element={<BigBrotherUpdates />}

--- a/src/pages/Assistant.tsx
+++ b/src/pages/Assistant.tsx
@@ -15,7 +15,6 @@ const features: Feature[] = [
   { label: "Orchestration" },
   { label: "RAG" },
   { label: "General Chat", path: "/assistant/general-chat" },
-  { label: "World Builder", path: "/assistant/world-builder" },
   { label: "Big Brother updates", path: "/assistant/big-brother-updates" },
 ];
 

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -11,7 +11,7 @@ const features: Feature[] = [
   { label: "Lore" },
   { label: "Journal" },
   { label: "NPC Maker" },
-  { label: "World Builder" },
+  { label: "World Builder", path: "/dnd/world-builder" },
   { label: "NPC List" },
 ];
 


### PR DESCRIPTION
## Summary
- remove World Builder button from AI Assistant menu
- link DND World Builder button to new /dnd/world-builder route
- update routing to mount WorldBuilder page under DND path

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a0d37fbb408325ab051be8c3af4c1a