### PR TITLE
Use app handle when prefetching Big Brother summary

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -563,7 +563,10 @@ pub async fn general_chat<R: Runtime>(
     messages: Vec<ChatMessage>,
 ) -> Result<String, String> {
     let mut msgs = messages.clone();
-    let query = messages.last().map(|m| m.content.clone()).unwrap_or_default();
+    let query = messages
+        .last()
+        .map(|m| m.content.clone())
+        .unwrap_or_default();
     if !query.is_empty() {
         if let Ok(results) = pdf_search(app.clone(), query, None).await {
             if !results.is_empty() {
@@ -708,7 +711,10 @@ pub async fn fetch_big_brother_news(force: Option<bool>) -> Result<Vec<NewsArtic
 }
 
 #[tauri::command]
-pub async fn fetch_big_brother_summary(force: Option<bool>) -> Result<String, String> {
+pub async fn fetch_big_brother_summary<R: Runtime>(
+    _app: AppHandle<R>,
+    force: Option<bool>,
+) -> Result<String, String> {
     let force = force.unwrap_or(false);
 
     {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,9 +6,10 @@ mod commands;
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
-        .setup(|_app| {
-            tauri::async_runtime::spawn(async {
-                let _ = commands::fetch_big_brother_summary(Some(true)).await;
+        .setup(|app| {
+            let handle = app.handle();
+            tauri::async_runtime::spawn(async move {
+                let _ = commands::fetch_big_brother_summary(handle, Some(true)).await;
             });
             Ok(())
         })


### PR DESCRIPTION
## Summary
- capture app handle in Tauri setup and call `fetch_big_brother_summary` with it
- adjust `fetch_big_brother_summary` command signature to accept an `AppHandle`

## Testing
- `npm test`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e219d4e88325927041c137d340a7