### PR TITLE
Accept app handle in Big Brother commands

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,9 +6,10 @@ mod commands;
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
-        .setup(|_app| {
-            tauri::async_runtime::spawn(async {
-                let _ = commands::fetch_big_brother_summary(Some(true)).await;
+        .setup(|app| {
+            let handle = app.handle();
+            tauri::async_runtime::spawn(async move {
+                let _ = commands::fetch_big_brother_summary(handle, Some(true)).await;
             });
             Ok(())
         })


### PR DESCRIPTION
## Summary
- pass AppHandle into `fetch_big_brother_news` and `fetch_big_brother_summary`
- ensure Big Brother news/summary use `general_chat` with app handle and chain news fetching
- update main setup to call summary command with an AppHandle

## Testing
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e219453083258f97cdccddf1a2a3