### PR TITLE
pass app handle to big brother news

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
-            let handle = app.handle();
+            let handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 let _ = commands::fetch_big_brother_summary(handle, Some(true)).await;
             });


### PR DESCRIPTION
## Summary
- wire `AppHandle` into Big Brother news and summary commands
- use `general_chat` with provided handle and chain summary through news fetching
- launch summary on startup with cloned app handle

## Testing
- `npm test`
- `cargo check` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a0ecc3d40c8325a147ae37aaae1df8