### PR TITLE
feat: add HQ audio options

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -287,7 +287,16 @@ pub struct SongSpec {
     pub ambience_level: Option<f32>,
     pub seed: u64,
     pub variety: Option<u32>,
+    #[serde(rename = "drum_pattern", skip_serializing_if = "Option::is_none")]
     pub drum_pattern: Option<String>,
+    #[serde(rename = "hq_stereo", skip_serializing_if = "Option::is_none")]
+    pub hq_stereo: Option<bool>,
+    #[serde(rename = "hq_reverb", skip_serializing_if = "Option::is_none")]
+    pub hq_reverb: Option<bool>,
+    #[serde(rename = "hq_sidechain", skip_serializing_if = "Option::is_none")]
+    pub hq_sidechain: Option<bool>,
+    #[serde(rename = "hq_chorus", skip_serializing_if = "Option::is_none")]
+    pub hq_chorus: Option<bool>,
 }
 
 /* ==============================

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -65,6 +65,12 @@ describe('SongForm', () => {
     await waitFor(() => expect(invoke).toHaveBeenCalled());
     const call = (invoke as any).mock.calls.find(([c]: any) => c === 'run_lofi_song');
     expect(call[1].spec.structure[0]).toHaveProperty('chords');
+    expect(call[1].spec).toMatchObject({
+      hq_stereo: true,
+      hq_reverb: true,
+      hq_sidechain: true,
+      hq_chorus: true,
+    });
     await waitFor(() => expect(listen).toHaveBeenCalledTimes(2));
 
     progressCb({ payload: JSON.stringify({ stage: 'render', message: '30%' }) });


### PR DESCRIPTION
## Summary
- expose optional HQ mix flags in `SongSpec`
- verify HQ flags passed from UI

## Testing
- `npm test`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68a0f926163083258196e6d8e5ccaeed