### PR TITLE
Add NPC maker with AI generation and local storage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Assistant from "./pages/Assistant";
 import GeneralChat from "./pages/GeneralChat";
 import BigBrotherUpdates from "./pages/BigBrotherUpdates";
 import WorldBuilder from "./pages/WorldBuilder";
+import NPCMaker from "./pages/NPCMaker";
 import Laser from "./pages/Laser";
 import Lofi from "./pages/Lofi";
 import NotFound from "./pages/NotFound";
@@ -31,6 +32,7 @@ export default function App() {
         <Route path="/assistant" element={<Assistant />} />
         <Route path="/assistant/general-chat" element={<GeneralChat />} />
         <Route path="/dnd/world-builder" element={<WorldBuilder />} />
+        <Route path="/dnd/npc-maker" element={<NPCMaker />} />
         <Route
           path="/assistant/big-brother-updates"
           element={<BigBrotherUpdates />}

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -10,7 +10,7 @@ interface Feature {
 const features: Feature[] = [
   { label: "Lore" },
   { label: "Journal" },
-  { label: "NPC Maker" },
+  { label: "NPC Maker", path: "/dnd/npc-maker" },
   { label: "World Builder", path: "/dnd/world-builder" },
   { label: "NPC List" },
 ];

--- a/src/pages/NPCMaker.tsx
+++ b/src/pages/NPCMaker.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { Button, Stack, TextField, Typography } from '@mui/material';
+import Center from './_Center';
+import { useNPCs, NPC } from '../store/npcs';
+
+const systemPrompt =
+  'You are a creative assistant that generates random D&D NPCs. Respond only with JSON having keys name, race, class, personality, background, appearance.';
+
+export default function NPCMaker() {
+  const [npc, setNpc] = useState<NPC>({
+    name: '',
+    race: '',
+    class: '',
+    personality: '',
+    background: '',
+    appearance: '',
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>('');
+
+  const addNPC = useNPCs((s) => s.addNPC);
+
+  useEffect(() => {
+    async function start() {
+      try {
+        await invoke('start_ollama');
+      } catch (e) {
+        setError(String(e));
+      }
+    }
+    start();
+  }, []);
+
+  async function generate() {
+    setLoading(true);
+    setError('');
+    try {
+      const reply: string = await invoke('general_chat', {
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: 'Generate a random NPC.' },
+        ],
+      });
+      const jsonMatch = reply.match(/```json\n([\s\S]*?)```/);
+      const data = JSON.parse(jsonMatch ? jsonMatch[1] : reply);
+      setNpc((prev) => ({ ...prev, ...data }));
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleChange(field: keyof NPC, value: string) {
+    setNpc((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function save() {
+    addNPC(npc);
+    setNpc({
+      name: '',
+      race: '',
+      class: '',
+      personality: '',
+      background: '',
+      appearance: '',
+    });
+  }
+
+  return (
+    <Center>
+      <Stack spacing={2} sx={{ width: '100%', maxWidth: 500 }}>
+        <Typography variant="h4">NPC Maker</Typography>
+        {error && <Typography color="error">{error}</Typography>}
+        <Button variant="contained" onClick={generate} disabled={loading}>
+          Generate NPC
+        </Button>
+        <TextField
+          label="Name"
+          value={npc.name}
+          onChange={(e) => handleChange('name', e.target.value)}
+        />
+        <TextField
+          label="Race"
+          value={npc.race}
+          onChange={(e) => handleChange('race', e.target.value)}
+        />
+        <TextField
+          label="Class"
+          value={npc.class}
+          onChange={(e) => handleChange('class', e.target.value)}
+        />
+        <TextField
+          label="Personality"
+          multiline
+          value={npc.personality}
+          onChange={(e) => handleChange('personality', e.target.value)}
+        />
+        <TextField
+          label="Background"
+          multiline
+          value={npc.background}
+          onChange={(e) => handleChange('background', e.target.value)}
+        />
+        <TextField
+          label="Appearance"
+          multiline
+          value={npc.appearance}
+          onChange={(e) => handleChange('appearance', e.target.value)}
+        />
+        <Button variant="contained" onClick={save} disabled={loading}>
+          Save NPC
+        </Button>
+      </Stack>
+    </Center>
+  );
+}

--- a/src/store/npcs.ts
+++ b/src/store/npcs.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface NPC {
+  name: string;
+  race: string;
+  class: string;
+  personality: string;
+  background: string;
+  appearance: string;
+}
+
+interface NPCState {
+  npcs: NPC[];
+  addNPC: (npc: NPC) => void;
+}
+
+export const useNPCs = create<NPCState>()(
+  persist(
+    (set) => ({
+      npcs: [],
+      addNPC: (npc) => set((state) => ({ npcs: [...state.npcs, npc] })),
+    }),
+    { name: 'npc-store' }
+  )
+);


### PR DESCRIPTION
## Summary
- add NPC Maker page with form to generate and save NPCs
- store NPCs in a persisted Zustand store
- wire up /dnd/npc-maker route from DND page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0fb45197883259f5233942857cfe6