### PR TITLE
Expose limiter drive in song builder

### DIFF
--- a/src-tauri/python/lofi_gpu_hq.py
+++ b/src-tauri/python/lofi_gpu_hq.py
@@ -1195,6 +1195,7 @@ def main():
 
     try:
         limiter_drive = float(spec.get("limiter_drive", 1.02))
+        limiter_drive = float(np.clip(limiter_drive, 0.5, 2.0))
     except Exception:
         limiter_drive = 1.02
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -297,6 +297,8 @@ pub struct SongSpec {
     pub hq_sidechain: Option<bool>,
     #[serde(rename = "hq_chorus", skip_serializing_if = "Option::is_none")]
     pub hq_chorus: Option<bool>,
+    #[serde(rename = "limiter_drive", skip_serializing_if = "Option::is_none")]
+    pub limiter_drive: Option<f32>,
 }
 
 /* ==============================

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -70,6 +70,7 @@ describe('SongForm', () => {
       hq_reverb: true,
       hq_sidechain: true,
       hq_chorus: true,
+      limiter_drive: 1.02,
     });
     await waitFor(() => expect(listen).toHaveBeenCalledTimes(2));
 

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -25,6 +25,7 @@ type SongSpec = {
   hq_reverb?: boolean;
   hq_sidechain?: boolean;
   hq_chorus?: boolean;
+  limiter_drive?: number;
 };
 
 type Job = {
@@ -172,6 +173,7 @@ export default function SongForm() {
   const [hqReverb, setHqReverb] = useState(true);
   const [hqSidechain, setHqSidechain] = useState(true);
   const [hqChorus, setHqChorus] = useState(true);
+  const [limiterDrive, setLimiterDrive] = useState(1.02);
 
   // UI state
   const [busy, setBusy] = useState(false);
@@ -313,6 +315,7 @@ export default function SongForm() {
       hq_reverb: hqReverb,
       hq_sidechain: hqSidechain,
       hq_chorus: hqChorus,
+      limiter_drive: Math.max(0.5, Math.min(2, limiterDrive)),
     };
   }
 
@@ -665,6 +668,19 @@ export default function SongForm() {
               <span style={S.small}>Chorus</span>
             </div>
             <div style={{ ...S.small, marginTop: 6 }}>These map to engine flags in <code>lofi_gpu_hq.py</code>.</div>
+          </div>
+          <div style={S.panel}>
+            <label style={S.label}>Limiter Drive</label>
+            <input
+              type="range"
+              min={0.5}
+              max={2}
+              step={0.01}
+              value={limiterDrive}
+              onChange={(e) => setLimiterDrive(Number(e.target.value))}
+              style={S.slider}
+            />
+            <div style={S.small}>{limiterDrive.toFixed(2)}× saturation</div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Add limiter drive slider to SongForm and include the value in generated SongSpec
- Wire limiter_drive through Rust SongSpec to the Python engine
- Clamp limiter_drive range in Python engine for safety

## Testing
- `python -m py_compile src-tauri/python/lofi_gpu_hq.py`
- `npm test`
- `cargo test` *(fails: The system library `libsoup-3.0` required by crate `soup3-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fcfc19fc832587d6f29c46e66e57