### PR TITLE
Add status indicator and refine NPC Maker UI

### DIFF
--- a/src/pages/NPCMaker.tsx
+++ b/src/pages/NPCMaker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { Button, Stack, TextField, Typography } from '@mui/material';
+import { Button, Stack, TextField, Typography, Alert, CircularProgress } from '@mui/material';
+import { CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/react/24/outline';
 import Center from './_Center';
 import { useNPCs, NPC } from '../store/npcs';
 
@@ -18,6 +19,7 @@ export default function NPCMaker() {
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
 
   const addNPC = useNPCs((s) => s.addNPC);
 
@@ -35,6 +37,7 @@ export default function NPCMaker() {
   async function generate() {
     setLoading(true);
     setError('');
+    setStatus('loading');
     try {
       const reply: string = await invoke('general_chat', {
         messages: [
@@ -45,8 +48,10 @@ export default function NPCMaker() {
       const jsonMatch = reply.match(/```json\n([\s\S]*?)```/);
       const data = JSON.parse(jsonMatch ? jsonMatch[1] : reply);
       setNpc((prev) => ({ ...prev, ...data }));
+      setStatus('success');
     } catch (e) {
       setError(String(e));
+      setStatus('error');
     } finally {
       setLoading(false);
     }
@@ -71,8 +76,17 @@ export default function NPCMaker() {
   return (
     <Center>
       <Stack spacing={2} sx={{ width: '100%', maxWidth: 500 }}>
-        <Typography variant="h4">NPC Maker</Typography>
-        {error && <Typography color="error">{error}</Typography>}
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Typography variant="h4">NPC Maker</Typography>
+          {status === 'loading' && <CircularProgress size={24} />}
+          {status === 'success' && (
+            <CheckCircleIcon className="h-6 w-6 text-green-500" />
+          )}
+          {status === 'error' && (
+            <ExclamationCircleIcon className="h-6 w-6 text-red-500" />
+          )}
+        </Stack>
+        {error && <Alert severity="error">{error}</Alert>}
         <Button variant="contained" onClick={generate} disabled={loading}>
           Generate NPC
         </Button>
@@ -80,34 +94,40 @@ export default function NPCMaker() {
           label="Name"
           value={npc.name}
           onChange={(e) => handleChange('name', e.target.value)}
+          fullWidth
         />
         <TextField
           label="Race"
           value={npc.race}
           onChange={(e) => handleChange('race', e.target.value)}
+          fullWidth
         />
         <TextField
           label="Class"
           value={npc.class}
           onChange={(e) => handleChange('class', e.target.value)}
+          fullWidth
         />
         <TextField
           label="Personality"
           multiline
           value={npc.personality}
           onChange={(e) => handleChange('personality', e.target.value)}
+          fullWidth
         />
         <TextField
           label="Background"
           multiline
           value={npc.background}
           onChange={(e) => handleChange('background', e.target.value)}
+          fullWidth
         />
         <TextField
           label="Appearance"
           multiline
           value={npc.appearance}
           onChange={(e) => handleChange('appearance', e.target.value)}
+          fullWidth
         />
         <Button variant="contained" onClick={save} disabled={loading}>
           Save NPC


### PR DESCRIPTION
## Summary
- add heroicon-based status indicator to NPC generator
- improve layout using MUI Alert and full-width fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a102dd800483258428882a8a4f3b0d