### PR TITLE
feat: persist generated NPCs to local storage

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -458,6 +458,44 @@ fn blender_path() -> PathBuf {
 }
 
 /* ==============================
+NPC storage
+============================== */
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NPCData {
+    pub name: String,
+    pub race: String,
+    pub class: String,
+    pub personality: String,
+    pub background: String,
+    pub appearance: String,
+}
+
+fn npc_storage_dir<R: Runtime>(app: &AppHandle<R>) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|_| "app data dir".to_string())?
+        .join("npc-storage");
+    fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    Ok(dir)
+}
+
+#[tauri::command]
+pub async fn save_npc<R: Runtime>(app: AppHandle<R>, npc: NPCData) -> Result<(), String> {
+    let dir = npc_storage_dir(&app)?;
+    let file_name = format!(
+        "{}_{}.json",
+        npc.name.replace(' ', "_"),
+        Local::now().format("%Y%m%d%H%M%S")
+    );
+    let path = dir.join(file_name);
+    let json = serde_json::to_string_pretty(&npc).map_err(|e| e.to_string())?;
+    fs::write(path, json).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/* ==============================
 Ollama general chat
 ============================== */
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -31,6 +31,7 @@ fn main() {
             commands::pdf_search,
             // Blender:
             commands::blender_run_script,
+            commands::save_npc,
             // News scraping:
             commands::fetch_big_brother_news,
             commands::fetch_big_brother_summary,

--- a/src/pages/NPCMaker.tsx
+++ b/src/pages/NPCMaker.tsx
@@ -61,16 +61,21 @@ export default function NPCMaker() {
     setNpc((prev) => ({ ...prev, [field]: value }));
   }
 
-  function save() {
-    addNPC(npc);
-    setNpc({
-      name: '',
-      race: '',
-      class: '',
-      personality: '',
-      background: '',
-      appearance: '',
-    });
+  async function save() {
+    try {
+      await invoke('save_npc', { npc });
+      addNPC(npc);
+      setNpc({
+        name: '',
+        race: '',
+        class: '',
+        personality: '',
+        background: '',
+        appearance: '',
+      });
+    } catch (e) {
+      setError(String(e));
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- add backend command to store NPCs as JSON files
- invoke NPC save command from NPC Maker UI
- scaffold npc-storage directory for saved characters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a10780b2ec8325a36a04c32cb18166