### PR TITLE
refactor: centralize status colors for calendar events

### DIFF
--- a/src/components/CalendarDay.tsx
+++ b/src/components/CalendarDay.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { statusColors } from '../features/calendar/statusColors';
 import type { CalendarEvent } from '../features/calendar/types';
 
 interface Props {
@@ -11,13 +12,6 @@ interface Props {
   isSelected: boolean;
   holiday?: string | null;
 }
-
-const statusColors: Record<CalendarEvent['status'], string> = {
-  scheduled: 'bg-blue-500',
-  canceled: 'bg-red-500',
-  missed: 'bg-amber-500',
-  completed: 'bg-emerald-500',
-};
 
 const CalendarDay = React.memo(
   ({

--- a/src/features/calendar/statusColors.ts
+++ b/src/features/calendar/statusColors.ts
@@ -1,0 +1,8 @@
+import type { CalendarEvent } from './types';
+
+export const statusColors: Record<CalendarEvent['status'], string> = {
+  scheduled: 'bg-blue-500',
+  canceled: 'bg-red-500',
+  missed: 'bg-amber-500',
+  completed: 'bg-emerald-500',
+};

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -3,6 +3,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/solid";
 import CalendarDay from "../components/CalendarDay";
 import TagStats from "../components/TagStats";
 import { useCalendar } from "../features/calendar/useCalendar";
+import { statusColors } from "../features/calendar/statusColors";
 import type { CalendarEvent } from "../features/calendar/types";
 
 function pad(n: number) {
@@ -15,13 +16,6 @@ const HOLIDAYS = [
   { month: 10, day: 31, title: "Halloween" },
   { month: 11, day: 25, title: "Christmas Day" },
 ];
-
-const statusColors: Record<string, string> = {
-  scheduled: "bg-blue-500",
-  canceled: "bg-red-500",
-  missed: "bg-amber-500",
-  completed: "bg-emerald-500",
-};
 
 export default function Calendar() {
   const [current, setCurrent] = useState(new Date());


### PR DESCRIPTION
## Summary
- add shared statusColors map for calendar events
- use statusColors in Calendar and CalendarDay via imports

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a10f5245a483258e64d4c78c4f2acc