### PR TITLE
validate calendar event end time before updating

### DIFF
--- a/src/features/calendar/tests/useCalendar.test.ts
+++ b/src/features/calendar/tests/useCalendar.test.ts
@@ -34,6 +34,21 @@ describe('useCalendar store', () => {
     expect(useCalendar.getState().events[0].title).toBe('New');
   });
 
+  it('rejects invalid updates', () => {
+    useCalendar.getState().addEvent({
+      title: 'Original',
+      date: '2024-01-01T09:00',
+      end: '2024-01-01T10:00',
+      tags: [],
+      status: 'scheduled',
+      hasCountdown: false,
+    });
+    const id = useCalendar.getState().events[0].id;
+    useCalendar.getState().updateEvent(id, { end: '2024-01-01T08:00' });
+    const event = useCalendar.getState().events[0];
+    expect(event.end).toBe('2024-01-01T10:00');
+  });
+
   it('removes an event', () => {
     useCalendar.getState().addEvent({
       title: 'Remove',

--- a/src/features/calendar/useCalendar.ts
+++ b/src/features/calendar/useCalendar.ts
@@ -43,8 +43,15 @@ export const useCalendar = create<CalendarState & Actions>()(
         },
         updateEvent: (id, patch) =>
           set((state) => {
-            const events = state.events.map((ev) =>
-              ev.id === id ? { ...ev, ...patch } : ev
+            const ev = state.events.find((e) => e.id === id);
+            if (!ev) return state;
+            if (patch.end !== undefined) {
+              const start = new Date(patch.date ?? ev.date).getTime();
+              const end = new Date(patch.end).getTime();
+              if (end <= start) return state;
+            }
+            const events = state.events.map((e) =>
+              e.id === id ? { ...e, ...patch } : e
             );
             return { events, tagTotals: recalc(events) };
           }),


### PR DESCRIPTION
## Summary
- ensure calendar updates only apply if new end time is after the start
- ignore invalid calendar event patches that would invert start/end times
- test that invalid event updates are rejected

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a110cd2588832587d92d1e6a1bbcf0