### PR TITLE
refactor: centralize reusable sx styles

### DIFF
--- a/src/components/FeatureCarousel.tsx
+++ b/src/components/FeatureCarousel.tsx
@@ -1,7 +1,7 @@
 
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { IconButton } from "@mui/material";
+import { IconButton, Box } from "@mui/material";
 import {
   FaMusic,
   FaCubes,
@@ -13,6 +13,13 @@ import {
 } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import { useSettings } from "../features/settings/useSettings";
+import {
+  carouselContainerSx,
+  carouselItemsWrapperSx,
+  carouselItemSx,
+  carouselIconButtonSx,
+  carouselLabelSx,
+} from "./sx";
 
 import type { ModuleKey } from "../features/settings/useSettings";
 
@@ -65,74 +72,31 @@ export default function FeatureCarousel({
   const SCALE_MID = 1.05; // center scale
   const SCALE_SIDE = 0.7; // side scale
 
-  return (
-    <div
-      onWheel={onWheel}
-      style={{
-        height: "100vh",
-        display: "grid",
-        placeItems: "center",
-        position: "relative",
-        overflow: "hidden",
-        zIndex: 1
-      }}
-    >
-      {/* items */}
-      <div style={{ position: "relative", width: "100%", height: 240 }}>
-        {len > 0 && [-2, -1, 0, 1, 2].map((offset) => {
-          const idx = mod(i + offset, len);
-          const it = enabled[idx];
-          const center = offset === 0;
-          const x = offset * GAP;
+    return (
+      <Box onWheel={onWheel} sx={carouselContainerSx}>
+        {/* items */}
+        <Box sx={carouselItemsWrapperSx}>
+          {len > 0 && [-2, -1, 0, 1, 2].map((offset) => {
+            const idx = mod(i + offset, len);
+            const it = enabled[idx];
+            const center = offset === 0;
 
-          return (
-            <div
-              key={`${idx}-${offset}`}
-              style={{
-                position: "absolute",
-                left: "50%",
-                top: "50%",
-                transform: `translate(-50%, -50%) translateX(${x}px) scale(${center ? SCALE_MID : SCALE_SIDE})`,
-                transition: "transform 280ms ease, opacity 280ms ease, color 180ms ease",
-                textAlign: "center",
-                opacity: center ? 1 : 0.6,
-                userSelect: "none",
-                width: 180,
-              }}
-            >
-              <IconButton
-                sx={{
-                  fontSize: "3rem",
-                  color: center ? ACCENT : "white",
-                  boxShadow: center ? `0 0 20px 6px ${ACCENT}55` : "none",
-                  transition:
-                    "transform 280ms ease, color 180ms ease, box-shadow 180ms ease",
-                  "&:hover": {
-                    color: ACCENT,
-                    transform: "scale(1.05)",
-                    boxShadow: `0 0 20px 6px ${ACCENT}55`,
-                  },
-                }}
-                onMouseEnter={() => onHoverColor(`${ACCENT}55`)}
-                onMouseLeave={() => onHoverColor("rgba(255,255,255,0.22)")}
-                onClick={() => (center ? nav(it.path) : setI(idx))}
-                aria-label={it.label}
-              >
-                {it.icon}
-              </IconButton>
-              <div
-                style={{
-                  color: center ? ACCENT : "white",
-                  marginTop: 12,
-                  fontSize: 14,
-                }}
-              >
-                {it.label}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
+            return (
+              <Box key={`${idx}-${offset}`} sx={carouselItemSx(offset, center, GAP, SCALE_MID, SCALE_SIDE)}>
+                <IconButton
+                  sx={carouselIconButtonSx(center, ACCENT)}
+                  onMouseEnter={() => onHoverColor(`${ACCENT}55`)}
+                  onMouseLeave={() => onHoverColor("rgba(255,255,255,0.22)")}
+                  onClick={() => (center ? nav(it.path) : setI(idx))}
+                  aria-label={it.label}
+                >
+                  {it.icon}
+                </IconButton>
+                <Box sx={carouselLabelSx(center, ACCENT)}>{it.label}</Box>
+              </Box>
+            );
+          })}
+        </Box>
+      </Box>
+    );
 }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,11 +1,13 @@
 import { IconButton } from "@mui/material";
+import type { SxProps } from "@mui/material";
+import { fixedIconButtonSx } from "./sx";
 import { FaHome, FaWrench } from "react-icons/fa";
 import { useNavigate, useLocation } from "react-router-dom";
 
 export default function TopBar() {
   const nav = useNavigate();
   const { pathname } = useLocation();
-  const activeStyles = (p: string) =>
+  const activeSx = (p: string): SxProps =>
     pathname === p
       ? { color: "#000", backgroundColor: "#fff", borderRadius: 4 }
       : { color: "white" };
@@ -14,7 +16,7 @@ export default function TopBar() {
     <>
       <IconButton
         onClick={() => nav("/")}
-        style={{ position: "fixed", top: 12, left: 12, zIndex: 2, ...activeStyles("/") }}
+        sx={{ ...fixedIconButtonSx, left: 12, ...activeSx("/") }}
         aria-label="Home"
         aria-current={pathname === "/" ? "page" : undefined}
       >
@@ -23,7 +25,7 @@ export default function TopBar() {
 
       <IconButton
         onClick={() => nav("/settings")}
-        style={{ position: "fixed", top: 12, right: 12, zIndex: 2, ...activeStyles("/settings") }}
+        sx={{ ...fixedIconButtonSx, right: 12, ...activeSx("/settings") }}
         aria-label="Settings"
         aria-current={pathname === "/settings" ? "page" : undefined}
       >

--- a/src/components/sx.ts
+++ b/src/components/sx.ts
@@ -1,0 +1,58 @@
+import type { SxProps } from "@mui/material";
+
+export const fixedIconButtonSx: SxProps = {
+  position: "fixed",
+  top: 12,
+  zIndex: 2,
+};
+
+export const carouselContainerSx: SxProps = {
+  height: "100vh",
+  display: "grid",
+  placeItems: "center",
+  position: "relative",
+  overflow: "hidden",
+  zIndex: 1,
+};
+
+export const carouselItemsWrapperSx: SxProps = {
+  position: "relative",
+  width: "100%",
+  height: 240,
+};
+
+export const carouselItemSx = (
+  offset: number,
+  center: boolean,
+  gap: number,
+  scaleMid: number,
+  scaleSide: number
+): SxProps => ({
+  position: "absolute",
+  left: "50%",
+  top: "50%",
+  transform: `translate(-50%, -50%) translateX(${offset * gap}px) scale(${center ? scaleMid : scaleSide})`,
+  transition: "transform 280ms ease, opacity 280ms ease, color 180ms ease",
+  textAlign: "center",
+  opacity: center ? 1 : 0.6,
+  userSelect: "none",
+  width: 180,
+});
+
+export const carouselIconButtonSx = (center: boolean, accent: string): SxProps => ({
+  fontSize: "3rem",
+  color: center ? accent : "white",
+  boxShadow: center ? `0 0 20px 6px ${accent}55` : "none",
+  transition: "transform 280ms ease, color 180ms ease, box-shadow 180ms ease",
+  "&:hover": {
+    color: accent,
+    transform: "scale(1.05)",
+    boxShadow: `0 0 20px 6px ${accent}55`,
+  },
+});
+
+export const carouselLabelSx = (center: boolean, accent: string): SxProps => ({
+  color: center ? accent : "white",
+  mt: 1.5,
+  fontSize: 14,
+});


### PR DESCRIPTION
## Summary
- extract reusable MUI `sx` variants for fixed icon buttons and carousel layout
- refactor TopBar and FeatureCarousel to use shared styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a111e216908325a3b4f232de043651