### PR TITLE
Add prompt manager UI to Comfy page

### DIFF
--- a/src/components/PromptManager.tsx
+++ b/src/components/PromptManager.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+
+export default function PromptManager() {
+  const [open, setOpen] = useState(false);
+  const [prompt, setPrompt] = useState("");
+
+  const handleVideo = () => {
+    console.log("Video Prompt:", prompt);
+  };
+
+  const handleImage = () => {
+    console.log("Image Prompt:", prompt);
+  };
+
+  return (
+    <div style={{ position: "relative" }}>
+      <button onClick={() => setOpen((o) => !o)} style={styles.btn}>
+        Prompt Manager
+      </button>
+      {open && (
+        <div style={styles.panel}>
+          <textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            style={styles.textarea}
+            placeholder="Enter prompt"
+          />
+          <div style={styles.actions}>
+            <button onClick={handleVideo} style={styles.actionBtn}>
+              Video Prompt
+            </button>
+            <button onClick={handleImage} style={styles.actionBtn}>
+              Image Prompt
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  btn: {
+    padding: "8px 12px",
+    borderRadius: 8,
+    border: "none",
+    background: "#3a82f6",
+    color: "#fff",
+    cursor: "pointer",
+  },
+  panel: {
+    position: "absolute",
+    top: "100%",
+    right: 0,
+    marginTop: 8,
+    padding: 12,
+    background: "#121214",
+    border: "1px solid #333",
+    borderRadius: 10,
+    width: 300,
+    zIndex: 10,
+  },
+  textarea: {
+    width: "100%",
+    minHeight: 80,
+    marginBottom: 8,
+    borderRadius: 8,
+    border: "1px solid #333",
+    background: "#1e1e1e",
+    color: "#fff",
+    padding: 8,
+    resize: "vertical",
+  },
+  actions: {
+    display: "flex",
+    gap: 8,
+    justifyContent: "flex-end",
+  },
+  actionBtn: {
+    padding: "6px 10px",
+    borderRadius: 8,
+    border: "none",
+    background: "#3a82f6",
+    color: "#fff",
+    cursor: "pointer",
+  },
+};
+

--- a/src/pages/Comfy.tsx
+++ b/src/pages/Comfy.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useComfy } from "../features/comfy/useComfy";
+import PromptManager from "../components/PromptManager";
 
 export default function Comfy() {
   const [running, setRunning] = useState(false);
@@ -77,6 +78,9 @@ export default function Comfy() {
         </div>
       </div>
 
+      <div style={{ marginBottom: 12 }}>
+        <PromptManager />
+      </div>
       <div style={styles.grid}>
         <div style={styles.left}>
           {running && pingOk ? (


### PR DESCRIPTION
## Summary
- add PromptManager component with prompt text box and Video/Image actions
- integrate PromptManager into Comfy page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1130a00248325a7f5b065af6a72a6