### PR TITLE
feat: persist worlds across sessions

### DIFF
--- a/src/pages/WorldBuilder.test.tsx
+++ b/src/pages/WorldBuilder.test.tsx
@@ -1,15 +1,26 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
 import WorldBuilder from "./WorldBuilder";
+import { useWorlds } from "../store/worlds";
 
 describe("WorldBuilder", () => {
-  it("adds a world after submitting", () => {
-    render(<WorldBuilder />);
+  afterEach(() => {
+    cleanup();
+    useWorlds.setState({ worlds: [] });
+    useWorlds.persist.clearStorage();
+    localStorage.clear();
+  });
+
+  it("persists worlds across remounts", () => {
+    const { unmount } = render(<WorldBuilder />);
     fireEvent.click(screen.getByText("Create New World"));
     fireEvent.change(screen.getByLabelText("World Name"), {
       target: { value: "Faerun" },
     });
     fireEvent.click(screen.getByText("Submit"));
+    expect(screen.getByText("Faerun")).toBeInTheDocument();
+    unmount();
+    render(<WorldBuilder />);
     expect(screen.getByText("Faerun")).toBeInTheDocument();
   });
 });

--- a/src/pages/WorldBuilder.tsx
+++ b/src/pages/WorldBuilder.tsx
@@ -1,16 +1,18 @@
 import { useState } from "react";
 import { Button, Stack, TextField } from "@mui/material";
 import Center from "./_Center";
+import { useWorlds } from "../store/worlds";
 
 export default function WorldBuilder() {
-  const [worlds, setWorlds] = useState<string[]>([]);
+  const worlds = useWorlds((s) => s.worlds);
+  const addWorld = useWorlds((s) => s.addWorld);
   const [creating, setCreating] = useState(false);
   const [name, setName] = useState("");
 
   function submit() {
     const trimmed = name.trim();
     if (!trimmed) return;
-    setWorlds((prev) => [...prev, trimmed]);
+    addWorld(trimmed);
     setName("");
     setCreating(false);
   }

--- a/src/store/worlds.ts
+++ b/src/store/worlds.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface WorldState {
+  worlds: string[];
+  addWorld: (world: string) => void;
+}
+
+export const useWorlds = create<WorldState>()(
+  persist(
+    (set) => ({
+      worlds: [],
+      addWorld: (world) =>
+        set((state) => ({ worlds: [...state.worlds, world] })),
+    }),
+    { name: 'world-store' }
+  )
+);


### PR DESCRIPTION
## Summary
- add worlds zustand store with persistence
- wire WorldBuilder to use persistent worlds store
- test that worlds persist after remount

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1162e72dc8325a2d9c6143e7adcbd