### PR TITLE
Add NPC list page and deletion support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import GeneralChat from "./pages/GeneralChat";
 import BigBrotherUpdates from "./pages/BigBrotherUpdates";
 import WorldBuilder from "./pages/WorldBuilder";
 import NPCMaker from "./pages/NPCMaker";
+import NPCList from "./pages/NPCList";
 import Laser from "./pages/Laser";
 import Lofi from "./pages/Lofi";
 import NotFound from "./pages/NotFound";
@@ -33,6 +34,7 @@ export default function App() {
         <Route path="/assistant/general-chat" element={<GeneralChat />} />
         <Route path="/dnd/world-builder" element={<WorldBuilder />} />
         <Route path="/dnd/npc-maker" element={<NPCMaker />} />
+        <Route path="/dnd/npc-list" element={<NPCList />} />
         <Route
           path="/assistant/big-brother-updates"
           element={<BigBrotherUpdates />}

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -12,7 +12,7 @@ const features: Feature[] = [
   { label: "Journal" },
   { label: "NPC Maker", path: "/dnd/npc-maker" },
   { label: "World Builder", path: "/dnd/world-builder" },
-  { label: "NPC List" },
+  { label: "NPC List", path: "/dnd/npc-list" },
 ];
 
 export default function DND() {

--- a/src/pages/NPCList.tsx
+++ b/src/pages/NPCList.tsx
@@ -1,0 +1,53 @@
+import { Table, TableHead, TableBody, TableRow, TableCell, TableContainer, Paper, IconButton, Stack, Typography } from '@mui/material';
+import { TrashIcon } from '@heroicons/react/24/outline';
+import Center from './_Center';
+import { useNPCs } from '../store/npcs';
+
+export default function NPCList() {
+  const npcs = useNPCs((s) => s.npcs);
+  const removeNPC = useNPCs((s) => s.removeNPC);
+
+  return (
+    <Center>
+      <Stack spacing={2} sx={{ width: '100%', maxWidth: 900 }}>
+        <Typography variant="h4">NPC List</Typography>
+        {npcs.length === 0 ? (
+          <Typography>No NPCs saved.</Typography>
+        ) : (
+          <TableContainer component={Paper}>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Name</TableCell>
+                  <TableCell>Race</TableCell>
+                  <TableCell>Class</TableCell>
+                  <TableCell>Personality</TableCell>
+                  <TableCell>Background</TableCell>
+                  <TableCell>Appearance</TableCell>
+                  <TableCell>Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {npcs.map((npc, index) => (
+                  <TableRow key={index}>
+                    <TableCell>{npc.name}</TableCell>
+                    <TableCell>{npc.race}</TableCell>
+                    <TableCell>{npc.class}</TableCell>
+                    <TableCell>{npc.personality}</TableCell>
+                    <TableCell>{npc.background}</TableCell>
+                    <TableCell>{npc.appearance}</TableCell>
+                    <TableCell>
+                      <IconButton onClick={() => removeNPC(index)}>
+                        <TrashIcon className="h-5 w-5" />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </Stack>
+    </Center>
+  );
+}

--- a/src/store/npcs.ts
+++ b/src/store/npcs.ts
@@ -13,6 +13,7 @@ export interface NPC {
 interface NPCState {
   npcs: NPC[];
   addNPC: (npc: NPC) => void;
+  removeNPC: (index: number) => void;
 }
 
 export const useNPCs = create<NPCState>()(
@@ -20,6 +21,8 @@ export const useNPCs = create<NPCState>()(
     (set) => ({
       npcs: [],
       addNPC: (npc) => set((state) => ({ npcs: [...state.npcs, npc] })),
+      removeNPC: (index) =>
+        set((state) => ({ npcs: state.npcs.filter((_, i) => i !== index) })),
     }),
     { name: 'npc-store' }
   )


### PR DESCRIPTION
## Summary
- extend NPC store with removeNPC action
- add NPCList page to view and delete saved NPCs
- link NPC list from DND section and register route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a116263e0883259af358bc38051856