### PR TITLE
Refine lofi synth routing for clearer audio

### DIFF
--- a/src/features/lofi/tests/SongForm.test.ts
+++ b/src/features/lofi/tests/SongForm.test.ts
@@ -14,15 +14,40 @@ describe('Song form hook', () => {
         start: vi.fn(),
         stop: vi.fn(),
       };
-      const mkSynth = () =>
-        ({ toDestination: () => ({ connect: () => ({}) }), connect: () => ({}), triggerAttackRelease: vi.fn() });
+      const mkSynth = () => {
+        const obj: any = {
+          toDestination: vi.fn().mockReturnThis(),
+          connect: vi.fn().mockReturnThis(),
+          triggerAttackRelease: vi.fn(),
+        };
+        return obj;
+      };
       const MonoSynth = vi.fn().mockImplementation(() => mkSynth());
       const NoiseSynth = vi.fn().mockImplementation(() => mkSynth());
       const MembraneSynth = vi.fn().mockImplementation(() => mkSynth());
       const PolySynth = vi.fn().mockImplementation(() => mkSynth());
-      const Reverb = vi.fn().mockImplementation(() => ({ toDestination: () => ({ connect: () => ({}) }) }));
-      const Volume = vi.fn().mockImplementation(() => ({ connect: vi.fn() }));
-      const Filter = vi.fn().mockImplementation(() => ({ connect: vi.fn() }));
+      const Reverb = vi.fn().mockImplementation(() => {
+        const obj: any = {
+          connect: vi.fn().mockReturnThis(),
+          toDestination: vi.fn().mockReturnThis(),
+        };
+        return obj;
+      });
+      const Volume = vi.fn().mockImplementation(() => {
+        const obj: any = { connect: vi.fn().mockReturnThis() };
+        return obj;
+      });
+      const Filter = vi.fn().mockImplementation(() => {
+        const obj: any = { connect: vi.fn().mockReturnThis() };
+        return obj;
+      });
+      const Gain = vi.fn().mockImplementation(() => {
+        const obj: any = {
+          connect: vi.fn().mockReturnThis(),
+          toDestination: vi.fn().mockReturnThis(),
+        };
+        return obj;
+      });
       const Loop = vi
         .fn()
         .mockImplementation(() => ({ start: vi.fn(), stop: vi.fn() }));
@@ -42,6 +67,7 @@ describe('Song form hook', () => {
         Reverb,
         Volume,
         Filter,
+        Gain,
         Loop,
         Frequency,
         Synth,


### PR DESCRIPTION
## Summary
- Route lofi generator instruments through a master bus with a parallel reverb send to eliminate distant "speaker" tone.
- Update lofi SongForm tests to mock newly used Tone nodes like Gain and improved connect chaining.

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a11c3dfa548325a05171664e6b4137