### PR TITLE
Add persistent IDs for NPCs

### DIFF
--- a/src/pages/NPCList.tsx
+++ b/src/pages/NPCList.tsx
@@ -28,8 +28,8 @@ export default function NPCList() {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {npcs.map((npc, index) => (
-                  <TableRow key={index}>
+                {npcs.map((npc) => (
+                  <TableRow key={npc.id}>
                     <TableCell>{npc.name}</TableCell>
                     <TableCell>{npc.race}</TableCell>
                     <TableCell>{npc.class}</TableCell>
@@ -37,7 +37,7 @@ export default function NPCList() {
                     <TableCell>{npc.background}</TableCell>
                     <TableCell>{npc.appearance}</TableCell>
                     <TableCell>
-                      <IconButton onClick={() => removeNPC(index)}>
+                      <IconButton onClick={() => removeNPC(npc.id)}>
                         <TrashIcon className="h-5 w-5" />
                       </IconButton>
                     </TableCell>

--- a/src/pages/NPCMaker.tsx
+++ b/src/pages/NPCMaker.tsx
@@ -9,7 +9,7 @@ const systemPrompt =
   'You are a creative assistant that generates random D&D NPCs. Respond only with JSON having keys name, race, class, personality, background, appearance.';
 
 export default function NPCMaker() {
-  const [npc, setNpc] = useState<NPC>({
+  const [npc, setNpc] = useState<Omit<NPC, 'id'>>({
     name: '',
     race: '',
     class: '',
@@ -57,7 +57,7 @@ export default function NPCMaker() {
     }
   }
 
-  function handleChange(field: keyof NPC, value: string) {
+  function handleChange(field: keyof Omit<NPC, 'id'>, value: string) {
     setNpc((prev) => ({ ...prev, [field]: value }));
   }
 

--- a/src/store/npcs.ts
+++ b/src/store/npcs.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export interface NPC {
+  id: string;
   name: string;
   race: string;
   class: string;
@@ -12,17 +13,20 @@ export interface NPC {
 
 interface NPCState {
   npcs: NPC[];
-  addNPC: (npc: NPC) => void;
-  removeNPC: (index: number) => void;
+  addNPC: (npc: Omit<NPC, 'id'>) => void;
+  removeNPC: (id: string) => void;
 }
 
 export const useNPCs = create<NPCState>()(
   persist(
     (set) => ({
       npcs: [],
-      addNPC: (npc) => set((state) => ({ npcs: [...state.npcs, npc] })),
-      removeNPC: (index) =>
-        set((state) => ({ npcs: state.npcs.filter((_, i) => i !== index) })),
+      addNPC: (npc) =>
+        set((state) => ({
+          npcs: [...state.npcs, { id: crypto.randomUUID(), ...npc }],
+        })),
+      removeNPC: (id) =>
+        set((state) => ({ npcs: state.npcs.filter((npc) => npc.id !== id) })),
     }),
     { name: 'npc-store' }
   )


### PR DESCRIPTION
## Summary
- Extend NPC store with unique `id` field and ID-based add/remove logic
- Use NPC `id` for keys and deletion in NPC list
- Update NPC maker to work with new `id` field

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a11d1356948325a795bd51ea618da7