### PR TITLE
feat: list NPCs from storage

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -32,6 +32,7 @@ fn main() {
             // Blender:
             commands::blender_run_script,
             commands::save_npc,
+            commands::list_npcs,
             // News scraping:
             commands::fetch_big_brother_news,
             commands::fetch_big_brother_summary,

--- a/src/pages/NPCList.tsx
+++ b/src/pages/NPCList.tsx
@@ -1,4 +1,5 @@
 import { Table, TableHead, TableBody, TableRow, TableCell, TableContainer, Paper, IconButton, Stack, Typography } from '@mui/material';
+import { useEffect } from 'react';
 import { TrashIcon } from '@heroicons/react/24/outline';
 import Center from './_Center';
 import { useNPCs } from '../store/npcs';
@@ -6,6 +7,11 @@ import { useNPCs } from '../store/npcs';
 export default function NPCList() {
   const npcs = useNPCs((s) => s.npcs);
   const removeNPC = useNPCs((s) => s.removeNPC);
+  const loadNPCs = useNPCs((s) => s.loadNPCs);
+
+  useEffect(() => {
+    loadNPCs();
+  }, [loadNPCs]);
 
   return (
     <Center>

--- a/src/store/npcs.ts
+++ b/src/store/npcs.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { invoke } from '@tauri-apps/api/core';
 
 export interface NPC {
   name: string;
@@ -14,6 +15,7 @@ interface NPCState {
   npcs: NPC[];
   addNPC: (npc: NPC) => void;
   removeNPC: (index: number) => void;
+  loadNPCs: () => Promise<void>;
 }
 
 export const useNPCs = create<NPCState>()(
@@ -23,6 +25,14 @@ export const useNPCs = create<NPCState>()(
       addNPC: (npc) => set((state) => ({ npcs: [...state.npcs, npc] })),
       removeNPC: (index) =>
         set((state) => ({ npcs: state.npcs.filter((_, i) => i !== index) })),
+      loadNPCs: async () => {
+        try {
+          const saved: NPC[] = await invoke('list_npcs');
+          set((state) => ({ npcs: [...state.npcs, ...saved] }));
+        } catch (e) {
+          console.error(e);
+        }
+      },
     }),
     { name: 'npc-store' }
   )


### PR DESCRIPTION
## Summary
- add `list_npcs` command to read NPC JSON files
- call new command from Zustand store and NPC list page
- register `list_npcs` within Tauri command handlers

## Testing
- `npm test`
- `cargo test --manifest-path src-tauri/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68a11d0bb3dc8325a5a6819cae6e62d0