### PR TITLE
Expose edit and delete options in calendar agenda

### DIFF
--- a/src/pages/Calendar.test.tsx
+++ b/src/pages/Calendar.test.tsx
@@ -114,7 +114,7 @@ describe('Calendar time validation', () => {
 
     fireEvent.click(screen.getByTestId('day-1'));
     fireEvent.click(screen.getByTestId('quick-add-overlay'));
-    fireEvent.click(screen.getByText('Meeting'));
+    fireEvent.click(screen.getByLabelText('Edit event'));
 
     const titleInput = screen.getByLabelText('Title') as HTMLInputElement;
     expect(titleInput.value).toBe('Meeting');

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useState } from "react";
-import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/solid";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  PencilIcon,
+  TrashIcon,
+} from "@heroicons/react/24/solid";
 import CalendarDay from "../components/CalendarDay";
 import TagStats from "../components/TagStats";
 import WeekView from "../components/WeekView";
@@ -294,12 +299,14 @@ export default function Calendar() {
                         >
                           {ev.status}
                         </span>
+                        <span className="flex-1">{ev.title}</span>
                         <button
                           type="button"
-                          className="flex-1 text-left"
+                          aria-label="Edit event"
+                          className="text-blue-500"
                           onClick={() => startEdit(ev)}
                         >
-                          {ev.title}
+                          <PencilIcon className="w-4 h-4" />
                         </button>
                         <button
                           type="button"
@@ -307,7 +314,7 @@ export default function Calendar() {
                           className="text-red-500"
                           onClick={() => removeEvent(ev.id)}
                         >
-                          ×
+                          <TrashIcon className="w-4 h-4" />
                         </button>
                       </li>
                     ))}


### PR DESCRIPTION
## Summary
- add visible edit and delete icon buttons for each agenda item
- update calendar tests to use new edit button

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a11db5e4748325b486efefe768c7b7