### PR TITLE
feat: add NPC listing command

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -32,6 +32,7 @@ fn main() {
             // Blender:
             commands::blender_run_script,
             commands::save_npc,
+            commands::list_npcs,
             // News scraping:
             commands::fetch_big_brother_news,
             commands::fetch_big_brother_summary,

--- a/src/pages/NPCList.tsx
+++ b/src/pages/NPCList.tsx
@@ -1,4 +1,5 @@
 import { Table, TableHead, TableBody, TableRow, TableCell, TableContainer, Paper, IconButton, Stack, Typography } from '@mui/material';
+import { useEffect } from 'react';
 import { TrashIcon } from '@heroicons/react/24/outline';
 import Center from './_Center';
 import { useNPCs } from '../store/npcs';
@@ -6,6 +7,11 @@ import { useNPCs } from '../store/npcs';
 export default function NPCList() {
   const npcs = useNPCs((s) => s.npcs);
   const removeNPC = useNPCs((s) => s.removeNPC);
+  const loadNPCs = useNPCs((s) => s.loadNPCs);
+
+  useEffect(() => {
+    loadNPCs();
+  }, [loadNPCs]);
 
   return (
     <Center>

--- a/src/store/npcs.ts
+++ b/src/store/npcs.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { invoke } from '@tauri-apps/api/core';
 
 export interface NPC {
   id: string;
@@ -15,6 +16,7 @@ interface NPCState {
   npcs: NPC[];
   addNPC: (npc: Omit<NPC, 'id'>) => void;
   removeNPC: (id: string) => void;
+  loadNPCs: () => Promise<void>;
 }
 
 export const useNPCs = create<NPCState>()(
@@ -27,6 +29,10 @@ export const useNPCs = create<NPCState>()(
         })),
       removeNPC: (id) =>
         set((state) => ({ npcs: state.npcs.filter((npc) => npc.id !== id) })),
+      loadNPCs: async () => {
+        const npcs = await invoke<NPC[]>('list_npcs');
+        set({ npcs });
+      },
     }),
     { name: 'npc-store' }
   )


### PR DESCRIPTION
## Summary
- add `list_npcs` command to load NPC JSON files
- load NPCs via Zustand store and NPC list page
- register new command in Tauri handlers

## Testing
- `npm test`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a1212b37e48325bb1ac4ea55343da2