### PR TITLE
feat(audio): add dithering control for 16-bit export

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,7 @@ Activate your Python environment first. The high‑quality generator lives at
   clipping intensity (values around `1.0` keep saturation subtle).
 - **Analog polish:** Finishing chain adds tape-style saturation and subtle
   wow/flutter for vintage warmth.
+- **Dithering:** Exported 16‑bit WAVs now include low-level triangular dither.
+  Tune the noise floor with an optional `dither_amount` value in the song JSON
+  (`1.0` for standard dithering, `0` to disable).
 


### PR DESCRIPTION
## Summary
- add `apply_dither` helper and invoke before reducing WAV bit depth
- allow callers to set `dither_amount` and document the option
- thread `dither_amount` through post-processing and CLI spec

## Testing
- `python -m py_compile src-tauri/python/lofi_gpu_hq.py`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a1274f102083258b24925cf793380e