### PR TITLE
feat: expand instrument options

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -66,6 +66,14 @@ const INSTR = [
   "piano",
   "clean electric guitar",
   "airy pads",
+  "vinyl sounds",
+  "acoustic guitar",
+  "violin",
+  "cello",
+  "flute",
+  "saxophone",
+  "trumpet",
+  "synth lead",
 ];
 const AMBI = ["rain", "cafe"];
 const DRUM_PATS = [


### PR DESCRIPTION
## Summary
- support vinyl sounds, acoustic guitar, violin, cello, flute, saxophone, trumpet and synth lead instruments
- add acoustic guitar chord synthesis, lead timbre shaping and vinyl crackle option
- expose new instruments in the song form UI

## Testing
- `python -m py_compile src-tauri/python/lofi_gpu_hq.py`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a153d8cf148325a5df68a6c48fdb77