### PR TITLE
feat: expand lofi chord vocabulary

### DIFF
--- a/src/features/lofi/SongForm.test.ts
+++ b/src/features/lofi/SongForm.test.ts
@@ -3,10 +3,9 @@ import { chordFromDegree, voiceLeadChords } from './SongForm';
 import * as Tone from 'tone';
 
 describe('chordFromDegree', () => {
-  it('adds a 9th extension for richer harmony', () => {
+  it('builds a maj7 chord for the I degree', () => {
     const chord = chordFromDegree(1, 'C');
-    expect(chord.length).toBe(5);
-    expect(chord[4]).toBe('D5');
+    expect(chord).toEqual(['C4', 'E4', 'G4', 'B4']);
   });
 });
 

--- a/src/features/lofi/SongForm.ts
+++ b/src/features/lofi/SongForm.ts
@@ -33,16 +33,34 @@ let chordStep = 0;
 
 let chords: string[][] = [];
 
-type ChordType = 'maj7' | 'min7' | 'dom7';
+type ChordType =
+  | 'maj7'
+  | 'min7'
+  | 'dom7'
+  | 'maj9'
+  | 'min9'
+  | 'add9'
+  | 'sus2'
+  | 'sus4';
 type RhythmCell = 'on' | 'rest' | 'sync';
 
 export function buildChord(root: string, type: ChordType) {
   const intervals =
     type === 'maj7'
-      ? [0, 4, 7, 11, 14]
+      ? [0, 4, 7, 11]
       : type === 'min7'
-        ? [0, 3, 7, 10, 14]
-        : [0, 4, 7, 10, 14];
+        ? [0, 3, 7, 10]
+        : type === 'dom7'
+          ? [0, 4, 7, 10]
+          : type === 'maj9'
+            ? [0, 4, 7, 11, 14]
+            : type === 'min9'
+              ? [0, 3, 7, 10, 14]
+              : type === 'add9'
+                ? [0, 4, 7, 14]
+                : type === 'sus2'
+                  ? [0, 2, 7]
+                  : [0, 5, 7];
   return intervals.map((i) => Tone.Frequency(root).transpose(i).toNote());
 }
 


### PR DESCRIPTION
## Summary
- broaden chord parsing in HQ renderer with support for suspended, seventh, and add9/9th chords
- add matching chord interval logic in TS lofi preview utilities and adjust tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a167cb38b883259e62be0297dbc8db