### PR TITLE
Display formatted times in calendar views

### DIFF
--- a/src/components/AgendaView.tsx
+++ b/src/components/AgendaView.tsx
@@ -15,11 +15,24 @@ export default function AgendaView({ events }: Props) {
         <div className="text-sm text-gray-500">No events</div>
       ) : (
         <ul className="space-y-1">
-          {sorted.map((ev) => (
-            <li key={ev.id} className="text-sm">
-              {ev.title}
-            </li>
-          ))}
+          {sorted.map((ev) => {
+            const start = new Date(ev.date);
+            const end = new Date(ev.end);
+            const dateStr = start.toLocaleDateString("en-US");
+            const startStr = start.toLocaleTimeString("en-US", {
+              hour: "numeric",
+              minute: "2-digit",
+            });
+            const endStr = end.toLocaleTimeString("en-US", {
+              hour: "numeric",
+              minute: "2-digit",
+            });
+            return (
+              <li key={ev.id} className="text-sm">
+                {`${dateStr} ${startStr} - ${endStr} ${ev.title}`}
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/src/components/WeekView.tsx
+++ b/src/components/WeekView.tsx
@@ -17,18 +17,53 @@ export default function WeekView({ current, events }: Props) {
     return d >= start && d < end;
   });
 
+  const grouped: Record<number, CalendarEvent[]> = {};
+  weekEvents.forEach((ev) => {
+    const day = new Date(ev.date).getDay();
+    if (!grouped[day]) grouped[day] = [];
+    grouped[day].push(ev);
+  });
+
   return (
     <div data-testid="week-view">
       {weekEvents.length === 0 ? (
         <div className="text-sm text-gray-500">No events this week</div>
       ) : (
-        <ul className="space-y-1">
-          {weekEvents.map((ev) => (
-            <li key={ev.id} className="text-sm">
-              {ev.title}
-            </li>
-          ))}
-        </ul>
+        Object.keys(grouped)
+          .sort((a, b) => Number(a) - Number(b))
+          .map((day) => {
+            const dayEvents = grouped[Number(day)].sort(
+              (a, b) =>
+                new Date(a.date).getTime() - new Date(b.date).getTime()
+            );
+            const dayDate = new Date(start);
+            dayDate.setDate(start.getDate() + Number(day));
+            const dayName = dayDate.toLocaleDateString("en-US", {
+              weekday: "long",
+            });
+            return (
+              <div key={day} className="mb-2">
+                <div className="font-medium">{dayName}</div>
+                <ul className="space-y-1">
+                  {dayEvents.map((ev) => {
+                    const startStr = new Date(ev.date).toLocaleTimeString(
+                      "en-US",
+                      { hour: "numeric", minute: "2-digit" }
+                    );
+                    const endStr = new Date(ev.end).toLocaleTimeString(
+                      "en-US",
+                      { hour: "numeric", minute: "2-digit" }
+                    );
+                    return (
+                      <li key={ev.id} className="text-sm">
+                        {`${startStr} - ${endStr} ${ev.title}`}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            );
+          })
       )}
     </div>
   );

--- a/src/pages/Calendar.test.tsx
+++ b/src/pages/Calendar.test.tsx
@@ -145,14 +145,30 @@ describe('Calendar time validation', () => {
     });
     fireEvent.click(screen.getByTestId('add-button'));
 
+    const startDate = new Date(`${yyyy}-${mm}-${dd}T09:00`);
+    const endDate = new Date(`${yyyy}-${mm}-${dd}T10:00`);
+    const startStr = startDate.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    const endStr = endDate.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    const dateStr = startDate.toLocaleDateString('en-US');
+
     fireEvent.click(screen.getByText('week'));
     expect(screen.getByTestId('week-view')).toBeInTheDocument();
-    expect(screen.getByText('Meeting')).toBeInTheDocument();
+    expect(
+      screen.getByText(`${startStr} - ${endStr} Meeting`)
+    ).toBeInTheDocument();
     expect(screen.queryByTestId(`day-${parseInt(dd, 10)}`)).toBeNull();
 
     fireEvent.click(screen.getByText('agenda'));
     expect(screen.getByTestId('agenda-view')).toBeInTheDocument();
-    expect(screen.getByText('Meeting')).toBeInTheDocument();
+    expect(
+      screen.getByText(`${dateStr} ${startStr} - ${endStr} Meeting`)
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByText('month'));
     expect(screen.getByTestId(`day-${parseInt(dd, 10)}`)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Group week view events by weekday and show start/end times using `toLocaleTimeString`
- Show date and time next to titles in agenda view
- Update tests to expect formatted time strings in week and agenda views

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a16625c7d4832587e5c2efa96d7ac5