### PR TITLE
feat: expand instrument normalization

### DIFF
--- a/src-tauri/python/lofi_gpu_hq.py
+++ b/src-tauri/python/lofi_gpu_hq.py
@@ -120,6 +120,11 @@ def _normalize_instruments(instrs):
         "pads": "airy pads",
         "vinyl": "vinyl sounds",
         "acoustic": "acoustic guitar",
+        "harps": "harp",
+        "lutes": "lute",
+        "panflute": "pan flute",
+        "pan pipes": "pan flute",
+        "panpipes": "pan flute",
     }
     canon = [
         "electric piano",
@@ -138,6 +143,9 @@ def _normalize_instruments(instrs):
         "saxophone",
         "trumpet",
         "synth lead",
+        "harp",
+        "lute",
+        "pan flute",
     ]
     out = []
     for s in (instrs or []):


### PR DESCRIPTION
## Summary
- expand canonical instrument list with harp, lute, and pan flute
- map shorthand aliases (harps, lutes, panflute/pan pipes) to new instruments

## Testing
- `npx vitest run > /tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68a16b6594f88325ac83233f26295b5e