### PR TITLE
Add stock quote command with caching

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -36,6 +36,8 @@ fn main() {
             // News scraping:
             commands::fetch_big_brother_news,
             commands::fetch_big_brother_summary,
+            // Stocks:
+            commands::fetch_stock_quote,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Summary
- implement `fetch_stock_quote` that queries a stock API via `ureq` and caches results
- expose the new stock quote command through the Tauri invoke handler

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a16d5a9db483259b077cecdd86fd1e