### PR TITLE
feat: integrate MUI theme provider and replace NPC icons

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,13 +4,18 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./styles.css";
 import { ThemeProvider } from "./features/theme/ThemeContext";
+import { ThemeProvider as MuiThemeProvider, CssBaseline } from "@mui/material";
+import theme from "./muiTheme";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <ThemeProvider>
-        <App />
-      </ThemeProvider>
+      <MuiThemeProvider theme={theme}>
+        <CssBaseline />
+        <ThemeProvider>
+          <App />
+        </ThemeProvider>
+      </MuiThemeProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/muiTheme.ts
+++ b/src/muiTheme.ts
@@ -1,0 +1,7 @@
+import { createTheme } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: { mode: 'dark' },
+});
+
+export default theme;

--- a/src/pages/NPCMaker.tsx
+++ b/src/pages/NPCMaker.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { Button, Stack, TextField, Typography, Alert, CircularProgress } from '@mui/material';
-import { CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/react/24/outline';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
 import Center from './_Center';
 import { useNPCs, NPC } from '../store/npcs';
 
@@ -85,10 +86,10 @@ export default function NPCMaker() {
           <Typography variant="h4">NPC Maker</Typography>
           {status === 'loading' && <CircularProgress size={24} />}
           {status === 'success' && (
-            <CheckCircleIcon className="h-6 w-6 text-green-500" />
+            <CheckCircleIcon color="success" fontSize="small" />
           )}
           {status === 'error' && (
-            <ExclamationCircleIcon className="h-6 w-6 text-red-500" />
+            <ErrorIcon color="error" fontSize="small" />
           )}
         </Stack>
         {error && <Alert severity="error">{error}</Alert>}


### PR DESCRIPTION
## Summary
- wrap app with MUI ThemeProvider and CssBaseline using a dark theme
- replace NPC Maker heroicons with MUI icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a16d9a85848325b85a6a179136256f