### PR TITLE
Sort TagStats by duration and add test

### DIFF
--- a/src/components/TagStats.tsx
+++ b/src/components/TagStats.tsx
@@ -2,7 +2,7 @@ import { useCalendar } from "../features/calendar/useCalendar";
 
 export default function TagStats() {
   const { tagTotals } = useCalendar();
-  const entries = Object.entries(tagTotals);
+  const entries = Object.entries(tagTotals).sort((a, b) => b[1] - a[1]);
 
   if (entries.length === 0) return null;
 

--- a/src/features/calendar/tests/useCalendar.test.ts
+++ b/src/features/calendar/tests/useCalendar.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { createElement } from 'react';
+import TagStats from '../../../components/TagStats';
 import { useCalendar } from '../useCalendar';
 
 describe('useCalendar store', () => {
@@ -97,6 +100,14 @@ describe('useCalendar store', () => {
       hasCountdown: false,
     });
     expect(useCalendar.getState().events).toHaveLength(0);
+  });
+
+  it('renders tag stats sorted by duration', () => {
+    useCalendar.setState({ tagTotals: { short: 1, long: 2 } });
+    render(createElement(TagStats));
+    const items = screen.getAllByRole('listitem');
+    expect(items[0]).toHaveTextContent(/^long:/);
+    expect(items[1]).toHaveTextContent(/^short:/);
   });
 });
 


### PR DESCRIPTION
## Summary
- sort TagStats entries descending by ms before rendering
- add useCalendar test to verify tag stats are sorted

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a171e082048325b49e8f13f32d94f9