### PR TITLE
feat: add stock quote store with polling

### DIFF
--- a/src/store/stocks.test.ts
+++ b/src/store/stocks.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useStocks } from './stocks';
+import { invoke } from '@tauri-apps/api/core';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+describe('useStocks store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useStocks.setState({ quotes: {}, pollers: {} });
+  });
+
+  afterEach(() => {
+    const { pollers, stopPolling } = useStocks.getState();
+    Object.keys(pollers).forEach((s) => stopPolling(s));
+    vi.useRealTimers();
+  });
+
+  it('caches quotes for 60 seconds', async () => {
+    (invoke as any).mockResolvedValue(123);
+    const price1 = await useStocks.getState().fetchQuote('AAPL');
+    const price2 = await useStocks.getState().fetchQuote('AAPL');
+    expect(price1).toBe(123);
+    expect(price2).toBe(123);
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls for updates when started', async () => {
+    vi.useFakeTimers();
+    (invoke as any).mockResolvedValue(100);
+    const store = useStocks.getState();
+    store.startPolling('MSFT', 1000);
+    await vi.advanceTimersByTimeAsync(3100);
+    store.stopPolling('MSFT');
+    expect(invoke).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/store/stocks.ts
+++ b/src/store/stocks.ts
@@ -1,0 +1,54 @@
+import { create } from 'zustand';
+import { invoke } from '@tauri-apps/api/core';
+
+interface Quote {
+  price: number;
+  lastFetched: number;
+}
+
+interface StockState {
+  quotes: Record<string, Quote>;
+  pollers: Record<string, ReturnType<typeof setInterval>>;
+  fetchQuote: (symbol: string, force?: boolean) => Promise<number>;
+  startPolling: (symbol: string, interval?: number) => void;
+  stopPolling: (symbol: string) => void;
+}
+
+export const useStocks = create<StockState>((set, get) => ({
+  quotes: {},
+  pollers: {},
+  fetchQuote: async (symbol, force = false) => {
+    const sym = symbol.toUpperCase();
+    const existing = get().quotes[sym];
+    if (!force && existing && Date.now() - existing.lastFetched < 60000) {
+      return existing.price;
+    }
+    const price = await invoke<number>('fetch_stock_quote', { symbol: sym, force });
+    set((state) => ({
+      quotes: { ...state.quotes, [sym]: { price, lastFetched: Date.now() } },
+    }));
+    return price;
+  },
+  startPolling: (symbol, interval = 60000) => {
+    const sym = symbol.toUpperCase();
+    const { pollers } = get();
+    if (pollers[sym]) clearInterval(pollers[sym]);
+    const id = setInterval(() => {
+      get().fetchQuote(sym, true);
+    }, interval);
+    set((state) => ({ pollers: { ...state.pollers, [sym]: id } }));
+    get().fetchQuote(sym, true);
+  },
+  stopPolling: (symbol) => {
+    const sym = symbol.toUpperCase();
+    const { pollers } = get();
+    const id = pollers[sym];
+    if (id) clearInterval(id);
+    set((state) => {
+      const { [sym]: _, ...rest } = state.pollers;
+      return { pollers: rest };
+    });
+  },
+}));
+
+export type { Quote, StockState };


### PR DESCRIPTION
## Summary
- add Zustand store for fetching and caching stock quotes
- support optional polling to refresh prices
- test store caching and polling behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1727b252483258cd62dd64cfcd854