### PR TITLE
Add fantasy mood option

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -129,5 +129,10 @@ describe('SongForm', () => {
     const values = Array.from(select.options).map((o) => o.value);
     expect(values).toContain('no_drums');
   });
+
+  it('shows fantasy mood option', () => {
+    render(<SongForm />);
+    expect(screen.getByText('fantasy')).toBeInTheDocument();
+  });
 });
 

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -56,7 +56,7 @@ type Job = {
 
 const KEYS_BASE = ["C", "D", "E", "F", "G", "A", "B"];
 const KEYS = ["Auto", ...KEYS_BASE];
-const MOODS = ["calm", "melancholy", "cozy", "nostalgic"];
+const MOODS = ["calm", "melancholy", "cozy", "nostalgic", "fantasy"];
 const INSTR = [
   "rhodes",
   "nylon guitar",
@@ -238,7 +238,7 @@ const PRESET_TEMPLATES: Record<string, TemplateSpec> = {
     ],
     bpm: 78,
     key: "E",
-    mood: ["nostalgic", "melancholy"],
+    mood: ["fantasy", "nostalgic", "melancholy"],
     instruments: ["flute", "piano", "upright bass"],
     ambience: ["rain"],
     drumPattern: "swing",


### PR DESCRIPTION
## Summary
- extend available moods with a new "fantasy" entry
- include "fantasy" in the "New Fantasy" preset
- test that the mood selector shows the new option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1768d56208325a7357a813b7547eb