### PR TITLE
Handle overlapping week events in WeekView

### DIFF
--- a/src/components/WeekView.test.tsx
+++ b/src/components/WeekView.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import WeekView from './WeekView';
+import type { CalendarEvent } from '../features/calendar/types';
+
+describe('WeekView', () => {
+  const current = new Date('2024-05-15T12:00:00Z');
+
+  it('includes events that overlap the week', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: '1',
+        title: 'Weekend',
+        date: '2024-05-11T23:00:00Z',
+        end: '2024-05-12T01:00:00Z',
+        tags: [],
+        status: 'scheduled',
+        hasCountdown: false,
+      },
+    ];
+
+    render(<WeekView current={current} events={events} />);
+    const sunday = screen.getByText('Sunday').parentElement!;
+    expect(
+      within(sunday).getByText('12:00 AM - 1:00 AM Weekend')
+    ).toBeInTheDocument();
+  });
+
+  it('splits spanning events across days', () => {
+    const events: CalendarEvent[] = [
+      {
+        id: '2',
+        title: 'Overnight',
+        date: '2024-05-13T23:00:00Z',
+        end: '2024-05-14T01:00:00Z',
+        tags: [],
+        status: 'scheduled',
+        hasCountdown: false,
+      },
+    ];
+
+    render(<WeekView current={current} events={events} />);
+    const monday = screen.getByText('Monday').parentElement!;
+    const tuesday = screen.getByText('Tuesday').parentElement!;
+    expect(
+      within(monday).getByText('11:00 PM - 12:00 AM Overnight')
+    ).toBeInTheDocument();
+    expect(
+      within(tuesday).getByText('12:00 AM - 1:00 AM Overnight')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/WeekView.tsx
+++ b/src/components/WeekView.tsx
@@ -13,15 +13,25 @@ export default function WeekView({ current, events }: Props) {
   end.setDate(start.getDate() + 7);
 
   const weekEvents = events.filter((e) => {
-    const d = new Date(e.date);
-    return d >= start && d < end;
+    const eventStart = new Date(e.date);
+    const eventEnd = new Date(e.end);
+    return eventStart < end && eventEnd > start;
   });
 
   const grouped: Record<number, CalendarEvent[]> = {};
   weekEvents.forEach((ev) => {
-    const day = new Date(ev.date).getDay();
-    if (!grouped[day]) grouped[day] = [];
-    grouped[day].push(ev);
+    const eventStart = new Date(ev.date);
+    const eventEnd = new Date(ev.end);
+    for (let d = 0; d < 7; d++) {
+      const dayStart = new Date(start);
+      dayStart.setDate(start.getDate() + d);
+      const dayEnd = new Date(dayStart);
+      dayEnd.setDate(dayStart.getDate() + 1);
+      if (eventStart < dayEnd && eventEnd > dayStart) {
+        if (!grouped[d]) grouped[d] = [];
+        grouped[d].push(ev);
+      }
+    }
   });
 
   return (
@@ -32,13 +42,22 @@ export default function WeekView({ current, events }: Props) {
         Object.keys(grouped)
           .sort((a, b) => Number(a) - Number(b))
           .map((day) => {
-            const dayEvents = grouped[Number(day)].sort(
-              (a, b) =>
-                new Date(a.date).getTime() - new Date(b.date).getTime()
-            );
-            const dayDate = new Date(start);
-            dayDate.setDate(start.getDate() + Number(day));
-            const dayName = dayDate.toLocaleDateString("en-US", {
+            const dayStart = new Date(start);
+            dayStart.setDate(start.getDate() + Number(day));
+            const dayEnd = new Date(dayStart);
+            dayEnd.setDate(dayStart.getDate() + 1);
+            const dayEvents = grouped[Number(day)].sort((a, b) => {
+              const aStart = Math.max(
+                new Date(a.date).getTime(),
+                dayStart.getTime()
+              );
+              const bStart = Math.max(
+                new Date(b.date).getTime(),
+                dayStart.getTime()
+              );
+              return aStart - bStart;
+            });
+            const dayName = dayStart.toLocaleDateString("en-US", {
               weekday: "long",
             });
             return (
@@ -46,17 +65,23 @@ export default function WeekView({ current, events }: Props) {
                 <div className="font-medium">{dayName}</div>
                 <ul className="space-y-1">
                   {dayEvents.map((ev) => {
-                    const startStr = new Date(ev.date).toLocaleTimeString(
-                      "en-US",
-                      { hour: "numeric", minute: "2-digit" }
-                    );
-                    const endStr = new Date(ev.end).toLocaleTimeString(
-                      "en-US",
-                      { hour: "numeric", minute: "2-digit" }
-                    );
+                    const evStart = new Date(ev.date).getTime();
+                    const evEnd = new Date(ev.end).getTime();
+                    const displayStart = new Date(
+                      Math.max(evStart, dayStart.getTime())
+                    ).toLocaleTimeString("en-US", {
+                      hour: "numeric",
+                      minute: "2-digit",
+                    });
+                    const displayEnd = new Date(
+                      Math.min(evEnd, dayEnd.getTime())
+                    ).toLocaleTimeString("en-US", {
+                      hour: "numeric",
+                      minute: "2-digit",
+                    });
                     return (
                       <li key={ev.id} className="text-sm">
-                        {`${startStr} - ${endStr} ${ev.title}`}
+                        {`${displayStart} - ${displayEnd} ${ev.title}`}
                       </li>
                     );
                   })}


### PR DESCRIPTION
## Summary
- Include events in WeekView if any part overlaps the week
- Clip events to day boundaries and render on each overlapping day
- Add tests for multi-day and week-spanning events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a178385ea483259b4bc3e0f74bf475