### PR TITLE
feat: incremental calendar tag totals

### DIFF
--- a/src/features/calendar/recalcTagTotals.ts
+++ b/src/features/calendar/recalcTagTotals.ts
@@ -1,0 +1,16 @@
+import type { CalendarEvent } from './types';
+
+export function recalcTagTotals(events: CalendarEvent[]): Record<string, number> {
+  const totals: Record<string, number> = {};
+  for (const ev of events) {
+    const status = ev.status ?? 'scheduled';
+    if (status === 'canceled' || status === 'missed') continue;
+    if (!ev.end) continue;
+    const duration = new Date(ev.end).getTime() - new Date(ev.date).getTime();
+    if (duration <= 0) continue;
+    (ev.tags ?? []).forEach((t) => {
+      totals[t] = (totals[t] || 0) + duration;
+    });
+  }
+  return totals;
+}

--- a/src/features/calendar/tests/useCalendar.test.ts
+++ b/src/features/calendar/tests/useCalendar.test.ts
@@ -101,7 +101,7 @@ describe('useCalendar store', () => {
     expect(useCalendar.getState().events).toHaveLength(0);
   });
 
-  it('calculates tag totals', () => {
+  it('updates tag totals when events are added', () => {
     const add = useCalendar.getState().addEvent;
     add({
       title: 'A',
@@ -111,6 +111,8 @@ describe('useCalendar store', () => {
       status: 'completed',
       hasCountdown: false,
     });
+    const hour = 60 * 60 * 1000;
+    expect(useCalendar.getState().tagTotals.work).toBe(1 * hour);
     add({
       title: 'B',
       date: '2024-01-02T09:00',
@@ -119,10 +121,45 @@ describe('useCalendar store', () => {
       status: 'scheduled',
       hasCountdown: false,
     });
-    const hour = 60 * 60 * 1000;
     const totals = useCalendar.getState().tagTotals;
     expect(totals.work).toBe(1.5 * hour);
     expect(totals.play).toBe(0.5 * hour);
+  });
+
+  it('updates tag totals when an event is updated', () => {
+    const add = useCalendar.getState().addEvent;
+    add({
+      title: 'A',
+      date: '2024-01-01T09:00',
+      end: '2024-01-01T10:00',
+      tags: ['work'],
+      status: 'scheduled',
+      hasCountdown: false,
+    });
+    const id = useCalendar.getState().events[0].id;
+    useCalendar.getState().updateEvent(id, {
+      tags: ['play'],
+      end: '2024-01-01T11:00',
+    });
+    const hour = 60 * 60 * 1000;
+    const totals = useCalendar.getState().tagTotals;
+    expect(totals.work).toBeUndefined();
+    expect(totals.play).toBe(2 * hour);
+  });
+
+  it('updates tag totals when an event is removed', () => {
+    const add = useCalendar.getState().addEvent;
+    add({
+      title: 'A',
+      date: '2024-01-01T09:00',
+      end: '2024-01-01T10:00',
+      tags: ['work'],
+      status: 'scheduled',
+      hasCountdown: false,
+    });
+    const id = useCalendar.getState().events[0].id;
+    useCalendar.getState().removeEvent(id);
+    expect(useCalendar.getState().tagTotals).toEqual({});
   });
 
   it('rejects events where end is not after start', () => {

--- a/src/features/calendar/useCalendar.ts
+++ b/src/features/calendar/useCalendar.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { CalendarEvent, CalendarState } from './types';
+import { recalcTagTotals } from './recalcTagTotals';
 
 interface Actions {
   addEvent: (e: Omit<CalendarEvent, 'id'>) => void;
@@ -11,62 +12,70 @@ interface Actions {
 
 export const useCalendar = create<CalendarState & Actions>()(
   persist(
-    (set) => {
-      const recalc = (events: CalendarEvent[]) => {
-        const totals: Record<string, number> = {};
-        for (const ev of events) {
-          const status = ev.status ?? 'scheduled';
-          if (status === 'canceled' || status === 'missed') continue;
-          if (!ev.end) continue;
-          const duration =
-            new Date(ev.end).getTime() - new Date(ev.date).getTime();
-          if (duration <= 0) continue;
-          (ev.tags ?? []).forEach((t) => {
-            totals[t] = (totals[t] || 0) + duration;
-          });
-        }
-        return totals;
-      };
-
-      return {
-        events: [],
-        selectedCountdownId: null,
-        tagTotals: {},
-        addEvent: (e) => {
-          if (!e.title || !e.date || !e.end) return;
-          const start = Date.parse(e.date);
-          const end = Date.parse(e.end);
-          if (Number.isNaN(start) || Number.isNaN(end) || end <= start) return;
-          set((state) => {
-            const events = [...state.events, { id: crypto.randomUUID(), ...e }].sort(
-              (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+    (set) => ({
+      events: [],
+      selectedCountdownId: null,
+      tagTotals: {},
+      addEvent: (e) => {
+        if (!e.title || !e.date || !e.end) return;
+        const start = Date.parse(e.date);
+        const end = Date.parse(e.end);
+        if (Number.isNaN(start) || Number.isNaN(end) || end <= start) return;
+        set((state) => {
+          const newEvent = { id: crypto.randomUUID(), ...e };
+          const events = [...state.events, newEvent].sort(
+            (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+          );
+          const tagTotals = { ...state.tagTotals };
+          const contrib = recalcTagTotals([newEvent]);
+          for (const [tag, ms] of Object.entries(contrib)) {
+            tagTotals[tag] = (tagTotals[tag] || 0) + ms;
+          }
+          return { events, tagTotals };
+        });
+      },
+      updateEvent: (id, patch) =>
+        set((state) => {
+          const ev = state.events.find((e) => e.id === id);
+          if (!ev) return state;
+          const next = { ...ev, ...patch };
+          if (!next.title || !next.date || !next.end) return state;
+          const start = Date.parse(next.date);
+          const end = Date.parse(next.end);
+          if (Number.isNaN(start) || Number.isNaN(end) || end <= start)
+            return state;
+          const events = state.events
+            .map((e) => (e.id === id ? next : e))
+            .sort((a, b) =>
+              new Date(a.date).getTime() - new Date(b.date).getTime()
             );
-            return { events, tagTotals: recalc(events) };
-          });
-        },
-        updateEvent: (id, patch) =>
-          set((state) => {
-            const ev = state.events.find((e) => e.id === id);
-            if (!ev) return state;
-            const next = { ...ev, ...patch };
-            if (!next.title || !next.date || !next.end) return state;
-            const start = Date.parse(next.date);
-            const end = Date.parse(next.end);
-            if (Number.isNaN(start) || Number.isNaN(end) || end <= start)
-              return state;
-            const events = state.events
-              .map((e) => (e.id === id ? next : e))
-              .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
-            return { events, tagTotals: recalc(events) };
-          }),
-        removeEvent: (id) =>
-          set((state) => {
-            const events = state.events.filter((ev) => ev.id !== id);
-            return { events, tagTotals: recalc(events) };
-          }),
-        setSelectedCountdownId: (id) => set({ selectedCountdownId: id }),
-      };
-    },
+          const tagTotals = { ...state.tagTotals };
+          const prevContrib = recalcTagTotals([ev]);
+          for (const [tag, ms] of Object.entries(prevContrib)) {
+            tagTotals[tag] = (tagTotals[tag] || 0) - ms;
+            if (tagTotals[tag] <= 0) delete tagTotals[tag];
+          }
+          const nextContrib = recalcTagTotals([next]);
+          for (const [tag, ms] of Object.entries(nextContrib)) {
+            tagTotals[tag] = (tagTotals[tag] || 0) + ms;
+          }
+          return { events, tagTotals };
+        }),
+      removeEvent: (id) =>
+        set((state) => {
+          const ev = state.events.find((e) => e.id === id);
+          if (!ev) return state;
+          const events = state.events.filter((e) => e.id !== id);
+          const tagTotals = { ...state.tagTotals };
+          const contrib = recalcTagTotals([ev]);
+          for (const [tag, ms] of Object.entries(contrib)) {
+            tagTotals[tag] = (tagTotals[tag] || 0) - ms;
+            if (tagTotals[tag] <= 0) delete tagTotals[tag];
+          }
+          return { events, tagTotals };
+        }),
+      setSelectedCountdownId: (id) => set({ selectedCountdownId: id }),
+    }),
     { name: 'calendar-store' }
   )
 );


### PR DESCRIPTION
## Summary
- refactor calendar store to incrementally update tag totals
- extract reusable `recalcTagTotals` helper
- add tests covering tag total updates for add, update, and remove actions

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a17ad2832083259d0e6ab86916c1d4