### PR TITLE
Enable removing worlds and avoid duplicates

### DIFF
--- a/src/pages/WorldBuilder.tsx
+++ b/src/pages/WorldBuilder.tsx
@@ -1,17 +1,20 @@
 import { useState } from "react";
-import { Button, Stack, TextField } from "@mui/material";
+import { Button, Stack, TextField, IconButton } from "@mui/material";
 import Center from "./_Center";
 import { useWorlds } from "../store/worlds";
+import { TrashIcon } from "@heroicons/react/24/outline";
 
 export default function WorldBuilder() {
   const worlds = useWorlds((s) => s.worlds);
   const addWorld = useWorlds((s) => s.addWorld);
+  const removeWorld = useWorlds((s) => s.removeWorld);
   const [creating, setCreating] = useState(false);
   const [name, setName] = useState("");
 
   function submit() {
     const trimmed = name.trim();
     if (!trimmed) return;
+    if (worlds.some((w) => w.toLowerCase() === trimmed.toLowerCase())) return;
     addWorld(trimmed);
     setName("");
     setCreating(false);
@@ -21,9 +24,14 @@ export default function WorldBuilder() {
     <Center>
       <Stack spacing={2} sx={{ width: "100%", maxWidth: 400 }}>
         {worlds.map((w) => (
-          <Button key={w} variant="outlined">
-            {w}
-          </Button>
+          <Stack direction="row" spacing={1} key={w}>
+            <Button variant="outlined" sx={{ flexGrow: 1 }}>
+              {w}
+            </Button>
+            <IconButton onClick={() => removeWorld(w)}>
+              <TrashIcon className="h-5 w-5" />
+            </IconButton>
+          </Stack>
         ))}
         {creating ? (
           <>

--- a/src/store/worlds.ts
+++ b/src/store/worlds.ts
@@ -4,6 +4,7 @@ import { persist } from 'zustand/middleware';
 interface WorldState {
   worlds: string[];
   addWorld: (world: string) => void;
+  removeWorld: (world: string) => void;
 }
 
 export const useWorlds = create<WorldState>()(
@@ -11,7 +12,19 @@ export const useWorlds = create<WorldState>()(
     (set) => ({
       worlds: [],
       addWorld: (world) =>
-        set((state) => ({ worlds: [...state.worlds, world] })),
+        set((state) => {
+          const name = world.trim();
+          if (
+            !name ||
+            state.worlds.some((w) => w.toLowerCase() === name.toLowerCase())
+          )
+            return state;
+          return { worlds: [...state.worlds, name] };
+        }),
+      removeWorld: (world) =>
+        set((state) => ({
+          worlds: state.worlds.filter((w) => w !== world),
+        })),
     }),
     { name: 'world-store' }
   )


### PR DESCRIPTION
## Summary
- allow deleting worlds via `removeWorld` store action
- add delete button for each world
- block adding worlds with duplicate names (case-insensitive)

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68a178c8fb1c832580a2978d19a4f250