### PR TITLE
feat: add harp, lute, and pan flute instruments

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -134,5 +134,29 @@ describe('SongForm', () => {
     render(<SongForm />);
     expect(screen.getByText('fantasy')).toBeInTheDocument();
   });
+
+  it('passes selected instruments in spec', async () => {
+    (open as any).mockResolvedValue('/tmp/out');
+    (invoke as any).mockResolvedValue('');
+    (listen as any).mockResolvedValue(() => {});
+
+    render(<SongForm />);
+
+    fireEvent.click(screen.getByText(/choose folder/i));
+    await screen.findByText('/tmp/out');
+
+    ['rhodes', 'nylon guitar', 'upright bass'].forEach((name) =>
+      fireEvent.click(screen.getByText(name))
+    );
+    ['harp', 'lute', 'pan flute'].forEach((name) =>
+      fireEvent.click(screen.getByText(name))
+    );
+
+    fireEvent.click(screen.getByText(/render songs/i));
+
+    await waitFor(() => expect(invoke).toHaveBeenCalled());
+    const call = (invoke as any).mock.calls.find(([c]: any) => c === 'run_lofi_song');
+    expect(call[1].spec.instruments).toEqual(['harp', 'lute', 'pan flute']);
+  });
 });
 

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -77,6 +77,9 @@ const INSTR = [
   "string squeaks",
   "key clicks",
   "breath noise",
+  "harp",
+  "lute",
+  "pan flute",
 ];
 const AMBI = ["rain", "cafe"];
 const DRUM_PATS = [


### PR DESCRIPTION
## Summary
- include harp, lute, and pan flute in SongForm instrument options
- test that selected instruments are forwarded in the song spec

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a17ac4ea948325b5e71e236135dd58