### PR TITLE
Add stocks tracking feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import Laser from "./pages/Laser";
 import Lofi from "./pages/Lofi";
 import NotFound from "./pages/NotFound";
 import DND from "./pages/DND";
+import Stocks from "./pages/Stocks";
 
 export default function App() {
   return (
@@ -41,6 +42,7 @@ export default function App() {
         />
         <Route path="/laser" element={<Laser />} />
         <Route path="/lofi" element={<Lofi />} />
+        <Route path="/stocks" element={<Stocks />} />
         <Route path="/dnd" element={<DND />} />
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/src/components/FeatureCarousel.tsx
+++ b/src/components/FeatureCarousel.tsx
@@ -10,6 +10,7 @@ import {
   FaBolt,
   FaCalendarAlt,
   FaDiceD20,
+  FaChartLine,
 } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import { useSettings } from "../features/settings/useSettings";
@@ -41,6 +42,7 @@ export default function FeatureCarousel({
       { key: "assistant", icon: <FaRobot />, label: "AI Assistant", path: "/assistant" },
       { key: "laser", icon: <FaBolt />, label: "Laser Lab", path: "/laser" },
       { key: "dnd", icon: <FaDiceD20 />, label: "DND", path: "/dnd" },
+      { key: "stocks", icon: <FaChartLine />, label: "Stocks", path: "/stocks" },
     ],
     []
   );

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -9,7 +9,8 @@ type ModuleKey =
   | 'comfy'
   | 'assistant'
   | 'laser'
-  | 'dnd';
+  | 'dnd'
+  | 'stocks';
 
 type ModulesState = Record<ModuleKey, boolean>;
 
@@ -21,6 +22,7 @@ const defaultModules: ModulesState = {
   assistant: true,
   laser: true,
   dnd: true,
+  stocks: true,
 };
 
 interface User {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -93,6 +93,7 @@ export default function Settings() {
               ["assistant", "AI Assistant"],
               ["laser", "Laser Lab"],
               ["dnd", "DND"],
+              ["stocks", "Stocks"],
             ] as const
           ).map(([key, label]) => (
             <FormControlLabel

--- a/src/pages/Stocks.tsx
+++ b/src/pages/Stocks.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  TextField,
+  List,
+  ListItem,
+  ListItemText,
+  IconButton,
+} from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import { useStocks } from "../store/stocks";
+
+export default function Stocks() {
+  const [symbol, setSymbol] = useState("");
+  const { symbols, quotes, addStock, removeStock } = useStocks();
+
+  const handleAdd = () => {
+    const sym = symbol.trim();
+    if (sym) {
+      addStock(sym);
+      setSymbol("");
+    }
+  };
+
+  return (
+    <Box sx={{ p: 2, color: "#fff" }}>
+      <Box sx={{ display: "flex", gap: 1, mb: 2 }}>
+        <TextField
+          label="Symbol"
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value)}
+        />
+        <Button variant="contained" onClick={handleAdd}>
+          Add
+        </Button>
+      </Box>
+      <List>
+        {symbols.map((s) => (
+          <ListItem
+            key={s}
+            secondaryAction={
+              <IconButton edge="end" onClick={() => removeStock(s)}>
+                <DeleteIcon />
+              </IconButton>
+            }
+          >
+            <ListItemText primary={`${s}: ${quotes[s]?.price ?? "..."}`} />
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+}
+

--- a/src/store/stocks.ts
+++ b/src/store/stocks.ts
@@ -9,15 +9,19 @@ interface Quote {
 interface StockState {
   quotes: Record<string, Quote>;
   pollers: Record<string, ReturnType<typeof setInterval>>;
+  symbols: string[];
   fetchQuote: (symbol: string, force?: boolean) => Promise<number>;
   startPolling: (symbol: string, interval?: number) => void;
   stopPolling: (symbol: string) => void;
   forecast: (symbol: string) => Promise<string>;
+  addStock: (symbol: string) => void;
+  removeStock: (symbol: string) => void;
 }
 
 export const useStocks = create<StockState>((set, get) => ({
   quotes: {},
   pollers: {},
+  symbols: [],
   fetchQuote: async (symbol, force = false) => {
     const sym = symbol.toUpperCase();
     const existing = get().quotes[sym];
@@ -53,6 +57,20 @@ export const useStocks = create<StockState>((set, get) => ({
   forecast: async (symbol) => {
     const sym = symbol.toUpperCase();
     return invoke<string>('stock_forecast', { symbol: sym });
+  },
+  addStock: (symbol) => {
+    const sym = symbol.toUpperCase();
+    set((state) =>
+      state.symbols.includes(sym)
+        ? state
+        : { symbols: [...state.symbols, sym] }
+    );
+    get().startPolling(sym);
+  },
+  removeStock: (symbol) => {
+    const sym = symbol.toUpperCase();
+    set((state) => ({ symbols: state.symbols.filter((s) => s !== sym) }));
+    get().stopPolling(sym);
   },
 }));
 


### PR DESCRIPTION
## Summary
- include Stocks module in feature carousel and settings
- implement stock tracking store and page
- route `/stocks` for managing tracked symbols

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a2997d2b248325a820aa33bbdf8d09