### PR TITLE
feat: add theme toggle and studio theme

### DIFF
--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -1,11 +1,30 @@
-import { createContext, useContext, useEffect } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+} from "react";
+import {
+  ThemeProvider as MuiThemeProvider,
+  CssBaseline,
+  PaletteMode,
+  createTheme,
+} from "@mui/material";
 import { useUsers } from "../users/useUsers";
 
-export type Theme = "default" | "ocean" | "forest" | "sunset" | "sakura";
+export type Theme =
+  | "default"
+  | "ocean"
+  | "forest"
+  | "sunset"
+  | "sakura"
+  | "studio";
 
 interface ThemeContextType {
   theme: Theme;
   setTheme: (theme: Theme) => void;
+  mode: PaletteMode;
+  setMode: (mode: PaletteMode) => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
@@ -15,17 +34,44 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     const id = state.currentUserId;
     return id ? state.users[id].theme : "default";
   });
+  const mode = useUsers((state) => {
+    const id = state.currentUserId;
+    return id ? state.users[id].mode : "dark";
+  });
   const setTheme = useUsers((state) => state.setTheme);
+  const setMode = useUsers((state) => state.setMode);
 
   useEffect(() => {
-    const classes = ["theme-default", "theme-ocean", "theme-forest", "theme-sunset", "theme-sakura"];
+    const classes = [
+      "theme-default",
+      "theme-ocean",
+      "theme-forest",
+      "theme-sunset",
+      "theme-sakura",
+      "theme-studio",
+    ];
     document.body.classList.remove(...classes);
     document.body.classList.add(`theme-${theme}`);
   }, [theme]);
 
+  useEffect(() => {
+    document.documentElement.style.colorScheme = mode;
+  }, [mode]);
+
+  const muiTheme = useMemo(
+    () =>
+      createTheme({
+        palette: { mode },
+      }),
+    [mode]
+  );
+
   return (
-    <ThemeContext.Provider value={{ theme, setTheme }}>
-      {children}
+    <ThemeContext.Provider value={{ theme, setTheme, mode, setMode }}>
+      <MuiThemeProvider theme={muiTheme}>
+        <CssBaseline />
+        {children}
+      </MuiThemeProvider>
     </ThemeContext.Provider>
   );
 }

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { Theme } from '../theme/ThemeContext';
+import type { PaletteMode } from '@mui/material';
 
 type ModuleKey =
   | 'objects'
@@ -29,6 +30,7 @@ interface User {
   id: string;
   name: string;
   theme: Theme;
+  mode: PaletteMode;
   modules: ModulesState;
 }
 
@@ -38,6 +40,7 @@ interface UsersState {
   addUser: (name: string) => void;
   switchUser: (id: string) => void;
   setTheme: (theme: Theme) => void;
+  setMode: (mode: PaletteMode) => void;
   toggleModule: (key: ModuleKey) => void;
 }
 
@@ -51,7 +54,13 @@ export const useUsers = create<UsersState>()(
         set((state) => ({
           users: {
             ...state.users,
-            [id]: { id, name, theme: 'default', modules: { ...defaultModules } },
+            [id]: {
+              id,
+              name,
+              theme: 'default',
+              mode: 'dark',
+              modules: { ...defaultModules },
+            },
           },
           currentUserId: id,
         }));
@@ -64,6 +73,16 @@ export const useUsers = create<UsersState>()(
           users: {
             ...state.users,
             [id]: { ...state.users[id], theme },
+          },
+        }));
+      },
+      setMode: (mode) => {
+        const id = get().currentUserId;
+        if (!id) return;
+        set((state) => ({
+          users: {
+            ...state.users,
+            [id]: { ...state.users[id], mode },
           },
         }));
       },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,18 +4,13 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./styles.css";
 import { ThemeProvider } from "./features/theme/ThemeContext";
-import { ThemeProvider as MuiThemeProvider, CssBaseline } from "@mui/material";
-import theme from "./muiTheme";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <MuiThemeProvider theme={theme}>
-        <CssBaseline />
-        <ThemeProvider>
-          <App />
-        </ThemeProvider>
-      </MuiThemeProvider>
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/muiTheme.ts
+++ b/src/muiTheme.ts
@@ -1,7 +1,0 @@
-import { createTheme } from '@mui/material/styles';
-
-const theme = createTheme({
-  palette: { mode: 'dark' },
-});
-
-export default theme;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -27,7 +27,7 @@ import { useDocs } from "../features/docs/useDocs";
 import { TrashIcon } from "@heroicons/react/24/outline";
 
 export default function Settings() {
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, mode, setMode } = useTheme();
   const { events, selectedCountdownId, setSelectedCountdownId } = useCalendar();
   const { modules, toggleModule } = useSettings();
   const { users, currentUserId, addUser, switchUser } = useUsers();
@@ -197,6 +197,16 @@ export default function Settings() {
             ))}
           </List>
         </Box>
+        <FormControlLabel
+          sx={{ mt: 3 }}
+          control={
+            <Switch
+              checked={mode === "dark"}
+              onChange={(e) => setMode(e.target.checked ? "dark" : "light")}
+            />
+          }
+          label="Dark Mode"
+        />
         <FormControl fullWidth sx={{ mt: 3 }}>
           <InputLabel id="theme-label">Theme</InputLabel>
           <Select
@@ -210,6 +220,7 @@ export default function Settings() {
             <MenuItem value="forest">Forest</MenuItem>
             <MenuItem value="sunset">Sunset</MenuItem>
             <MenuItem value="sakura">Sakura</MenuItem>
+            <MenuItem value="studio">Studio</MenuItem>
           </Select>
         </FormControl>
         {countdownEvents.length > 0 && (

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
+/* color-scheme is controlled dynamically via ThemeContext */
+/* default to dark to match existing behavior */
 :root { color-scheme: dark; }
 * { box-sizing: border-box; }
 html, body, #root { height: 100%; margin: 0; }
@@ -24,4 +26,31 @@ body.theme-sunset {
 }
 body.theme-sakura {
   background: radial-gradient(circle at center, #5e0a3d, #380829);
+}
+
+body.theme-studio {
+  background: #000;
+}
+
+body.theme-studio button,
+body.theme-studio input,
+body.theme-studio select {
+  background: #111;
+  color: #0ff;
+  border: 1px solid #0ff;
+  box-shadow: 0 0 6px rgba(0, 255, 255, 0.7);
+}
+
+body.theme-studio button:hover,
+body.theme-studio input:hover,
+body.theme-studio select:hover {
+  box-shadow: 0 0 12px rgba(0, 255, 255, 0.9);
+}
+
+body.theme-studio input[type="range"]::-webkit-slider-thumb {
+  box-shadow: 0 0 10px #0ff;
+}
+
+body.theme-studio input[type="range"]::-moz-range-thumb {
+  box-shadow: 0 0 10px #0ff;
 }


### PR DESCRIPTION
## Summary
- add persisted light/dark mode and integrate MUI theme provider
- introduce "studio" theme with dark background and glowing controls
- expose dark mode toggle and studio option in settings

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68a29d70fe4c8325921cd47cc8a25c9e