### PR TITLE
feat: add sparkline stock panel

### DIFF
--- a/src/components/Sparkline.tsx
+++ b/src/components/Sparkline.tsx
@@ -1,0 +1,20 @@
+import { Box } from "@mui/material";
+
+export default function Sparkline({ data, color = "#4caf50", width = 100, height = 30 }: { data: number[]; color?: string; width?: number; height?: number }) {
+  if (!data || data.length === 0) return null;
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const len = data.length - 1;
+  const points = data
+    .map((v, i) => {
+      const x = (i / len) * width;
+      const y = height - ((v - min) / (max - min || 1)) * height;
+      return `${x},${y}`;
+    })
+    .join(" ");
+  return (
+    <Box component="svg" width={width} height={height}>
+      <polyline fill="none" stroke={color} strokeWidth="2" points={points} />
+    </Box>
+  );
+}

--- a/src/pages/Stocks.tsx
+++ b/src/pages/Stocks.tsx
@@ -5,10 +5,11 @@ import {
   TextField,
   List,
   ListItem,
-  ListItemText,
   IconButton,
+  Typography,
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
+import Sparkline from "../components/Sparkline";
 import { useStocks } from "../store/stocks";
 
 export default function Stocks() {
@@ -30,24 +31,41 @@ export default function Stocks() {
           label="Symbol"
           value={symbol}
           onChange={(e) => setSymbol(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && handleAdd()}
         />
         <Button variant="contained" onClick={handleAdd}>
           Add
         </Button>
       </Box>
       <List>
-        {symbols.map((s) => (
-          <ListItem
-            key={s}
-            secondaryAction={
-              <IconButton edge="end" onClick={() => removeStock(s)}>
-                <DeleteIcon />
-              </IconButton>
-            }
-          >
-            <ListItemText primary={`${s}: ${quotes[s]?.price ?? "..."}`} />
-          </ListItem>
-        ))}
+        {symbols.map((s) => {
+          const q = quotes[s];
+          const color = q && q.changePercent < 0 ? "#ff5252" : "#4caf50";
+          return (
+            <ListItem
+              key={s}
+              secondaryAction={
+                <IconButton edge="end" onClick={() => removeStock(s)}>
+                  <DeleteIcon />
+                </IconButton>
+              }
+            >
+              <Box sx={{ display: "flex", alignItems: "center", gap: 2, width: "100%" }}>
+                <Typography sx={{ width: 80 }}>{s}</Typography>
+                {q ? (
+                  <>
+                    <Typography sx={{ width: 120, color }}>
+                      {q.price.toFixed(2)} ({q.changePercent.toFixed(2)}%)
+                    </Typography>
+                    <Sparkline data={q.history} color={color} />
+                  </>
+                ) : (
+                  <Typography sx={{ width: 120 }}>...</Typography>
+                )}
+              </Box>
+            </ListItem>
+          );
+        })}
       </List>
     </Box>
   );

--- a/src/store/stocks.test.ts
+++ b/src/store/stocks.test.ts
@@ -18,7 +18,7 @@ describe('useStocks store', () => {
   });
 
   it('caches quotes for 60 seconds', async () => {
-    (invoke as any).mockResolvedValue(123);
+    (invoke as any).mockResolvedValue({ price: 123, change_percent: 1, history: [1, 2, 3] });
     const price1 = await useStocks.getState().fetchQuote('AAPL');
     const price2 = await useStocks.getState().fetchQuote('AAPL');
     expect(price1).toBe(123);
@@ -28,7 +28,7 @@ describe('useStocks store', () => {
 
   it('polls for updates when started', async () => {
     vi.useFakeTimers();
-    (invoke as any).mockResolvedValue(100);
+    (invoke as any).mockResolvedValue({ price: 100, change_percent: 0, history: [100] });
     const store = useStocks.getState();
     store.startPolling('MSFT', 1000);
     await vi.advanceTimersByTimeAsync(3100);


### PR DESCRIPTION
## Summary
- fetch stock change percent and history for sparkline
- show stock price, percent change and sparkline with color coding

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a2dac67cd88325aa254fe25821262d