### PR TITLE
feat: add DnD module scaffolding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "remark-gfm": "^4.0.1",
         "three": "^0.179.1",
         "tone": "^15.1.22",
+        "zod": "^4.0.17",
         "zustand": "^5.0.7"
       },
       "devDependencies": {
@@ -7954,6 +7955,15 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.17.tgz",
+      "integrity": "sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "remark-gfm": "^4.0.1",
     "three": "^0.179.1",
     "tone": "^15.1.22",
+    "zod": "^4.0.17",
     "zustand": "^5.0.7"
   },
   "devDependencies": {

--- a/src/features/dnd/EncounterForm.tsx
+++ b/src/features/dnd/EncounterForm.tsx
@@ -1,0 +1,9 @@
+import { Typography } from "@mui/material";
+
+export default function EncounterForm() {
+  return (
+    <form>
+      <Typography variant="h6">Encounter Form</Typography>
+    </form>
+  );
+}

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -1,0 +1,9 @@
+import { Typography } from "@mui/material";
+
+export default function NpcForm() {
+  return (
+    <form>
+      <Typography variant="h6">NPC Form</Typography>
+    </form>
+  );
+}

--- a/src/features/dnd/QuestForm.tsx
+++ b/src/features/dnd/QuestForm.tsx
@@ -1,0 +1,9 @@
+import { Typography } from "@mui/material";
+
+export default function QuestForm() {
+  return (
+    <form>
+      <Typography variant="h6">Quest Form</Typography>
+    </form>
+  );
+}

--- a/src/features/dnd/schemas.ts
+++ b/src/features/dnd/schemas.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const zDndBase = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+export const zNpc = zDndBase;
+export const zQuest = zDndBase;
+export const zEncounter = zDndBase;

--- a/src/features/dnd/tests/schemas.test.ts
+++ b/src/features/dnd/tests/schemas.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { zNpc, zQuest, zEncounter } from "../schemas";
+
+describe("dnd schemas", () => {
+  it("parses NPC data", () => {
+    const npc = { id: "1", name: "Goblin" };
+    expect(zNpc.parse(npc)).toEqual(npc);
+  });
+
+  it("parses Quest data", () => {
+    const quest = { id: "q1", name: "Find the ring" };
+    expect(zQuest.parse(quest)).toEqual(quest);
+  });
+
+  it("parses Encounter data", () => {
+    const encounter = { id: "e1", name: "Goblin ambush" };
+    expect(zEncounter.parse(encounter)).toEqual(encounter);
+  });
+});

--- a/src/features/dnd/types.ts
+++ b/src/features/dnd/types.ts
@@ -1,0 +1,10 @@
+export interface DndBase {
+  id: string;
+  name: string;
+}
+
+export interface NpcData extends DndBase {}
+
+export interface QuestData extends DndBase {}
+
+export interface EncounterData extends DndBase {}

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -1,35 +1,22 @@
-import { Button, Stack } from "@mui/material";
-import { useNavigate } from "react-router-dom";
-import Center from "./_Center";
-
-interface Feature {
-  label: string;
-  path?: string;
-}
-
-const features: Feature[] = [
-  { label: "Lore" },
-  { label: "Journal" },
-  { label: "NPC Maker", path: "/dnd/npc-maker" },
-  { label: "World Builder", path: "/dnd/world-builder" },
-  { label: "NPC List", path: "/dnd/npc-list" },
-];
+import { Box, Tab, Tabs } from "@mui/material";
+import { SyntheticEvent, useState } from "react";
+import NpcForm from "../features/dnd/NpcForm";
+import QuestForm from "../features/dnd/QuestForm";
+import EncounterForm from "../features/dnd/EncounterForm";
 
 export default function DND() {
-  const navigate = useNavigate();
+  const [tab, setTab] = useState(0);
+  const handleChange = (_e: SyntheticEvent, v: number) => setTab(v);
   return (
-    <Center>
-      <Stack spacing={2} sx={{ width: "100%", maxWidth: 400 }}>
-        {features.map((feature) => (
-          <Button
-            key={feature.label}
-            variant="contained"
-            onClick={() => feature.path && navigate(feature.path)}
-          >
-            {feature.label}
-          </Button>
-        ))}
-      </Stack>
-    </Center>
+    <Box sx={{ p: 2 }}>
+      <Tabs value={tab} onChange={handleChange}>
+        <Tab label="NPC" />
+        <Tab label="Quest" />
+        <Tab label="Encounter" />
+      </Tabs>
+      {tab === 0 && <NpcForm />}
+      {tab === 1 && <QuestForm />}
+      {tab === 2 && <EncounterForm />}
+    </Box>
   );
 }


### PR DESCRIPTION
## Summary
- scaffold DnD page with NPC, Quest, and Encounter tabs each showing a placeholder form
- define shared DnD types and Zod schemas
- add unit test validating schema parsing

## Testing
- `npx tsc --noEmit src/features/dnd/types.ts src/features/dnd/schemas.ts src/pages/DND.tsx`
- `npx vitest run src/features/dnd/tests/schemas.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a2e08a7df08325b6667b25aee960ec