### PR TITLE
feat: add album album creation mode in Song Form

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -380,6 +380,22 @@ pub struct SongSpec {
     pub limiter_drive: Option<f32>,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AlbumRequest {
+    pub track_count: u32,
+    #[serde(alias = "title_base", skip_serializing_if = "Option::is_none")]
+    pub title_base: Option<String>,
+    #[serde(alias = "out_dir", skip_serializing_if = "Option::is_none")]
+    pub out_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AlbumMeta {
+    pub track_count: u32,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -539,6 +555,18 @@ pub async fn run_lofi_song<R: Runtime>(
         .emit("lofi_progress", r#"{"stage":"done","message":"saved"}"#)
         .ok();
     Ok(out_path.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+pub async fn generate_album(meta: AlbumRequest) -> Result<AlbumMeta, String> {
+    Ok(AlbumMeta {
+        track_count: meta.track_count,
+    })
+}
+
+#[tauri::command]
+pub async fn cancel_album(_job_id: String) -> Result<(), String> {
+    Ok(())
 }
 
 /* ==============================

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,6 +16,8 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             commands::lofi_generate_gpu,
             commands::run_lofi_song,
+            commands::generate_album,
+            commands::cancel_album,
             // ComfyUI:
             commands::comfy_status,
             commands::comfy_start,

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -160,5 +160,24 @@ describe('SongForm', () => {
     const call = (invoke as any).mock.calls.find(([c]: any) => c === 'run_lofi_song');
     expect(call[1].spec.instruments).toEqual(['harp', 'lute', 'pan flute']);
   });
+
+  it('calls generate_album when album mode enabled', async () => {
+    (open as any).mockResolvedValue('/tmp/out');
+    (invoke as any).mockResolvedValue({});
+    (listen as any).mockResolvedValue(() => {});
+
+    render(<SongForm />);
+
+    fireEvent.click(screen.getByText(/choose folder/i));
+    await screen.findByText('/tmp/out');
+
+    fireEvent.click(screen.getByLabelText(/album mode/i));
+    fireEvent.click(screen.getByText(/create album/i));
+
+    await waitFor(() => {
+      const calls = (invoke as any).mock.calls.map(([c]: any) => c);
+      expect(calls).toContain('generate_album');
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary
- add album mode toggle with track count and generate-album button
- stub album generation and cancel commands in tauri backend
- cover album mode in SongForm tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2df9aa8a083258a9d6c4ff66e325c