### PR TITLE
feat: scaffold shorts module

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1081,3 +1081,49 @@ pub async fn fetch_big_brother_summary<R: Runtime>(
 
     Ok(summary)
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ShortSpec {
+    pub id: String,
+    pub title: String,
+    pub script: String,
+    pub audio_path: Option<String>,
+    pub visual_path: Option<String>,
+    pub export_path: Option<String>,
+    pub status: String,
+    pub created_at: String,
+}
+
+fn shorts_path() -> PathBuf {
+    let mut dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    dir.push(".blossom");
+    let _ = fs::create_dir_all(&dir);
+    dir.push("shorts.json");
+    dir
+}
+
+#[tauri::command]
+pub async fn load_shorts() -> Result<Vec<ShortSpec>, String> {
+    let path = shorts_path();
+    if let Ok(data) = fs::read_to_string(path) {
+        serde_json::from_str(&data).map_err(|e| e.to_string())
+    } else {
+        Ok(vec![])
+    }
+}
+
+#[tauri::command]
+pub async fn save_shorts(specs: Vec<ShortSpec>) -> Result<(), String> {
+    let path = shorts_path();
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let data = serde_json::to_string_pretty(&specs).map_err(|e| e.to_string())?;
+    fs::write(path, data).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn generate_short(spec: ShortSpec) -> Result<String, String> {
+    println!("Generating short: {:?}", spec);
+    Ok("ok".into())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -42,6 +42,10 @@ fn main() {
             // Stocks:
             commands::fetch_stock_quote,
             commands::stock_forecast,
+            // Shorts:
+            commands::load_shorts,
+            commands::save_shorts,
+            commands::generate_short,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import Lofi from "./pages/Lofi";
 import NotFound from "./pages/NotFound";
 import DND from "./pages/DND";
 import Stocks from "./pages/Stocks";
+import Shorts from "./pages/Shorts";
 
 export default function App() {
   return (
@@ -41,6 +42,7 @@ export default function App() {
         <Route path="/laser" element={<Laser />} />
         <Route path="/lofi" element={<Lofi />} />
         <Route path="/stocks" element={<Stocks />} />
+        <Route path="/shorts" element={<Shorts />} />
         <Route path="/dnd" element={<DND />} />
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/src/components/DashboardIcons.tsx
+++ b/src/components/DashboardIcons.tsx
@@ -1,6 +1,6 @@
 import { Box, IconButton } from "@mui/material";
 import {
-  FaMusic, FaCubes, FaCameraRetro, FaRobot, FaBolt, FaCalendarAlt
+  FaMusic, FaCubes, FaCameraRetro, FaRobot, FaBolt, FaCalendarAlt, FaFilm
 } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 
@@ -14,6 +14,7 @@ export default function DashboardIcons({ onHoverColor }:{ onHoverColor:(c:string
     { icon:<FaCameraRetro/>, label:"ComfyUI",       color:"rgba(255,213,165,0.55)", path:"/comfy" },
     { icon:<FaRobot/>,       label:"AI Assistant",  color:"rgba(175,245,215,0.55)", path:"/assistant" },
     { icon:<FaBolt/>,        label:"Laser Lab",     color:"rgba(255,180,180,0.55)", path:"/laser" },
+    { icon:<FaFilm/>,       label:"Shorts",        color:"rgba(200,200,200,0.55)", path:"/shorts" },
   ];
 
   return (

--- a/src/components/FeatureCarousel.tsx
+++ b/src/components/FeatureCarousel.tsx
@@ -11,6 +11,7 @@ import {
   FaCalendarAlt,
   FaDiceD20,
   FaChartLine,
+  FaFilm,
 } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import { useSettings } from "../features/settings/useSettings";
@@ -43,6 +44,7 @@ export default function FeatureCarousel({
       { key: "laser", icon: <FaBolt />, label: "Laser Lab", path: "/laser" },
       { key: "dnd", icon: <FaDiceD20 />, label: "DND", path: "/dnd" },
       { key: "stocks", icon: <FaChartLine />, label: "Stocks", path: "/stocks" },
+      { key: "shorts", icon: <FaFilm />, label: "Shorts", path: "/shorts" },
     ],
     []
   );

--- a/src/features/shorts/types.ts
+++ b/src/features/shorts/types.ts
@@ -1,0 +1,12 @@
+type ShortSpec = {
+  id: string;
+  title: string;
+  script: string;
+  audio_path?: string;
+  visual_path?: string;
+  export_path?: string;
+  status: "draft" | "rendering" | "done" | "failed";
+  created_at: string;
+};
+
+export type { ShortSpec };

--- a/src/features/shorts/useShorts.ts
+++ b/src/features/shorts/useShorts.ts
@@ -1,0 +1,59 @@
+import { create } from "zustand";
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect } from "react";
+import type { ShortSpec } from "./types";
+
+interface ShortsState {
+  shorts: ShortSpec[];
+  selectedId: string | null;
+  loaded: boolean;
+  load: () => Promise<void>;
+  create: () => Promise<void>;
+  select: (id: string | null) => void;
+  update: (id: string, patch: Partial<ShortSpec>) => Promise<void>;
+}
+
+const useShortsStore = create<ShortsState>((set, get) => ({
+  shorts: [],
+  selectedId: null,
+  loaded: false,
+  async load() {
+    if (get().loaded) return;
+    try {
+      const res = await invoke<ShortSpec[]>("load_shorts");
+      set({ shorts: res, loaded: true });
+    } catch {
+      set({ shorts: [], loaded: true });
+    }
+  },
+  async create() {
+    const spec: ShortSpec = {
+      id: crypto.randomUUID(),
+      title: "Untitled",
+      script: "",
+      status: "draft",
+      created_at: new Date().toISOString(),
+    };
+    set((state) => ({ shorts: [...state.shorts, spec], selectedId: spec.id }));
+    await invoke("save_shorts", { specs: get().shorts });
+  },
+  select(id) {
+    set({ selectedId: id });
+  },
+  async update(id, patch) {
+    set((state) => ({
+      shorts: state.shorts.map((s) => (s.id === id ? { ...s, ...patch } : s)),
+    }));
+    await invoke("save_shorts", { specs: get().shorts });
+  },
+}));
+
+export function useShorts() {
+  const store = useShortsStore();
+  useEffect(() => {
+    store.load();
+  }, [store]);
+  return store;
+}
+
+export type { ShortsState };

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -11,7 +11,8 @@ type ModuleKey =
   | 'assistant'
   | 'laser'
   | 'dnd'
-  | 'stocks';
+  | 'stocks'
+  | 'shorts';
 
 type ModulesState = Record<ModuleKey, boolean>;
 
@@ -24,6 +25,7 @@ const defaultModules: ModulesState = {
   laser: true,
   dnd: true,
   stocks: true,
+  shorts: true,
 };
 
 interface User {

--- a/src/pages/Shorts.tsx
+++ b/src/pages/Shorts.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { Button, List, ListItemButton, ListItemText, Tabs, Tab } from "@mui/material";
+import { invoke } from "@tauri-apps/api/core";
+import { useShorts } from "../features/shorts/useShorts";
+
+export default function Shorts() {
+  const { shorts, selectedId, create, select } = useShorts();
+  const short = shorts.find((s) => s.id === selectedId) || null;
+  const [tab, setTab] = useState(0);
+
+  if (!short) {
+    return (
+      <div style={{ padding: 24 }}>
+        <Button variant="contained" onClick={create} sx={{ mb: 2 }}>
+          New Short
+        </Button>
+        <List>
+          {shorts.map((s) => (
+            <ListItemButton key={s.id} onClick={() => select(s.id)}>
+              <ListItemText primary={s.title} secondary={s.status} />
+            </ListItemButton>
+          ))}
+        </List>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: 24 }}>
+      <Button onClick={() => select(null)} sx={{ mb: 2 }}>
+        Back
+      </Button>
+      <Tabs value={tab} onChange={(_, v) => setTab(v)}>
+        <Tab label="Script" />
+        <Tab label="Audio" />
+        <Tab label="Visual" />
+        <Tab label="Export" />
+      </Tabs>
+      {tab === 0 && <div style={{ marginTop: 16 }}>Script placeholder</div>}
+      {tab === 1 && <div style={{ marginTop: 16 }}>Audio placeholder</div>}
+      {tab === 2 && <div style={{ marginTop: 16 }}>Visual placeholder</div>}
+      {tab === 3 && (
+        <div style={{ marginTop: 16 }}>
+          <Button
+            variant="contained"
+            onClick={async () => {
+              await invoke("generate_short", { spec: short });
+            }}
+          >
+            Generate
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Shorts feature route with tabbed editor and list
- persist ShortSpec records to `~/.blossom/shorts.json`
- stub Tauri commands for loading, saving, and generating shorts

## Testing
- `npm test`
- `cargo check` *(fails: The system library `gdk-3.0` required by crate `gdk-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e1be22f48325b0959fd64e451c3f