### PR TITLE
feat: add DnD forms with themes and previews

### DIFF
--- a/src/features/dnd/EncounterForm.tsx
+++ b/src/features/dnd/EncounterForm.tsx
@@ -1,9 +1,167 @@
-import { Typography } from "@mui/material";
+import { useState } from "react";
+import {
+  Typography,
+  TextField,
+  Button,
+  MenuItem,
+} from "@mui/material";
+import { zEncounter } from "./schemas";
+import { EncounterData, DndTheme } from "./types";
+
+const themes: DndTheme[] = ["Parchment", "Ink", "Minimal"];
 
 export default function EncounterForm() {
+  const [name, setName] = useState("");
+  const [level, setLevel] = useState("");
+  const [creatures, setCreatures] = useState("");
+  const [tactics, setTactics] = useState("");
+  const [terrain, setTerrain] = useState("");
+  const [treasure, setTreasure] = useState("");
+  const [scaling, setScaling] = useState("");
+  const [theme, setTheme] = useState<DndTheme>("Parchment");
+  const [result, setResult] = useState<EncounterData | null>(null);
+
+  const themeStyles: Record<DndTheme, React.CSSProperties> = {
+    Parchment: {
+      background: "#fdf5e6",
+      padding: "1rem",
+      fontFamily: "serif",
+    },
+    Ink: {
+      background: "#fff",
+      color: "#000",
+      padding: "1rem",
+      fontFamily: "monospace",
+    },
+    Minimal: {
+      background: "#f0f0f0",
+      padding: "1rem",
+      fontFamily: "sans-serif",
+    },
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: EncounterData = {
+      id: crypto.randomUUID(),
+      name,
+      level,
+      creatures: creatures.split(",").map((c) => c.trim()).filter(Boolean),
+      tactics,
+      terrain,
+      treasure,
+      scaling,
+      theme,
+    };
+    const parsed = zEncounter.parse(data);
+    setResult(parsed);
+  };
+
   return (
-    <form>
+    <form onSubmit={handleSubmit}>
       <Typography variant="h6">Encounter Form</Typography>
+      <TextField
+        label="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Level"
+        value={level}
+        onChange={(e) => setLevel(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Creatures (comma separated)"
+        value={creatures}
+        onChange={(e) => setCreatures(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Tactics"
+        value={tactics}
+        onChange={(e) => setTactics(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Terrain"
+        value={terrain}
+        onChange={(e) => setTerrain(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Treasure"
+        value={treasure}
+        onChange={(e) => setTreasure(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Scaling"
+        value={scaling}
+        onChange={(e) => setScaling(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        select
+        label="Theme"
+        value={theme}
+        onChange={(e) => setTheme(e.target.value as DndTheme)}
+        fullWidth
+        margin="normal"
+      >
+        {themes.map((t) => (
+          <MenuItem key={t} value={t}>
+            {t}
+          </MenuItem>
+        ))}
+      </TextField>
+      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+        Submit
+      </Button>
+      <div style={{ ...themeStyles[theme], marginTop: "1rem" }}>
+        <h3>{name || "Encounter Preview"}</h3>
+        {level && (
+          <p>
+            <strong>Level:</strong> {level}
+          </p>
+        )}
+        {creatures && (
+          <p>
+            <strong>Creatures:</strong> {creatures}
+          </p>
+        )}
+        {tactics && (
+          <p>
+            <strong>Tactics:</strong> {tactics}
+          </p>
+        )}
+        {terrain && (
+          <p>
+            <strong>Terrain:</strong> {terrain}
+          </p>
+        )}
+        {treasure && (
+          <p>
+            <strong>Treasure:</strong> {treasure}
+          </p>
+        )}
+        {scaling && (
+          <p>
+            <strong>Scaling:</strong> {scaling}
+          </p>
+        )}
+      </div>
+      {result && (
+        <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>
+      )}
     </form>
   );
 }

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -1,9 +1,180 @@
-import { Typography } from "@mui/material";
+import { useState } from "react";
+import {
+  Typography,
+  TextField,
+  Button,
+  MenuItem,
+} from "@mui/material";
+import { zNpc } from "./schemas";
+import { NpcData, DndTheme } from "./types";
+
+const themes: DndTheme[] = ["Parchment", "Ink", "Minimal"];
 
 export default function NpcForm() {
+  const [name, setName] = useState("");
+  const [tags, setTags] = useState("");
+  const [appearance, setAppearance] = useState("");
+  const [personality, setPersonality] = useState("");
+  const [motivation, setMotivation] = useState("");
+  const [secret, setSecret] = useState("");
+  const [hooks, setHooks] = useState("");
+  const [statBlockRef, setStatBlockRef] = useState("");
+  const [statOverrides, setStatOverrides] = useState("");
+  const [theme, setTheme] = useState<DndTheme>("Parchment");
+  const [result, setResult] = useState<NpcData | null>(null);
+
+  const themeStyles: Record<DndTheme, React.CSSProperties> = {
+    Parchment: {
+      background: "#fdf5e6",
+      padding: "1rem",
+      fontFamily: "serif",
+    },
+    Ink: {
+      background: "#fff",
+      color: "#000",
+      padding: "1rem",
+      fontFamily: "monospace",
+    },
+    Minimal: {
+      background: "#f0f0f0",
+      padding: "1rem",
+      fontFamily: "sans-serif",
+    },
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: NpcData = {
+      id: crypto.randomUUID(),
+      name,
+      tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
+      appearance,
+      personality,
+      motivation,
+      secret,
+      hooks: hooks.split(",").map((h) => h.trim()).filter(Boolean),
+      stat_block_ref: statBlockRef,
+      stat_overrides: statOverrides,
+      theme,
+    };
+    const parsed = zNpc.parse(data);
+    setResult(parsed);
+  };
+
   return (
-    <form>
+    <form onSubmit={handleSubmit}>
       <Typography variant="h6">NPC Form</Typography>
+      <TextField
+        label="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Tags (comma separated)"
+        value={tags}
+        onChange={(e) => setTags(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Appearance"
+        value={appearance}
+        onChange={(e) => setAppearance(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Personality"
+        value={personality}
+        onChange={(e) => setPersonality(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Motivation"
+        value={motivation}
+        onChange={(e) => setMotivation(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Secret"
+        value={secret}
+        onChange={(e) => setSecret(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Hooks (comma separated)"
+        value={hooks}
+        onChange={(e) => setHooks(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Stat Block Ref"
+        value={statBlockRef}
+        onChange={(e) => setStatBlockRef(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Stat Overrides"
+        value={statOverrides}
+        onChange={(e) => setStatOverrides(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        select
+        label="Theme"
+        value={theme}
+        onChange={(e) => setTheme(e.target.value as DndTheme)}
+        fullWidth
+        margin="normal"
+      >
+        {themes.map((t) => (
+          <MenuItem key={t} value={t}>
+            {t}
+          </MenuItem>
+        ))}
+      </TextField>
+      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+        Submit
+      </Button>
+      <div style={{ ...themeStyles[theme], marginTop: "1rem" }}>
+        <h3>{name || "NPC Preview"}</h3>
+        {appearance && (
+          <p>
+            <strong>Appearance:</strong> {appearance}
+          </p>
+        )}
+        {personality && (
+          <p>
+            <strong>Personality:</strong> {personality}
+          </p>
+        )}
+        {motivation && (
+          <p>
+            <strong>Motivation:</strong> {motivation}
+          </p>
+        )}
+        {secret && (
+          <p>
+            <strong>Secret:</strong> {secret}
+          </p>
+        )}
+        {hooks && (
+          <p>
+            <strong>Hooks:</strong> {hooks}
+          </p>
+        )}
+      </div>
+      {result && (
+        <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>
+      )}
     </form>
   );
 }

--- a/src/features/dnd/QuestForm.tsx
+++ b/src/features/dnd/QuestForm.tsx
@@ -1,9 +1,173 @@
-import { Typography } from "@mui/material";
+import { useState } from "react";
+import {
+  Typography,
+  TextField,
+  Button,
+  MenuItem,
+} from "@mui/material";
+import { zQuest } from "./schemas";
+import { QuestData, DndTheme } from "./types";
+
+const themes: DndTheme[] = ["Parchment", "Ink", "Minimal"];
 
 export default function QuestForm() {
+  const [name, setName] = useState("");
+  const [tier, setTier] = useState("");
+  const [summary, setSummary] = useState("");
+  const [beats, setBeats] = useState("");
+  const [gp, setGp] = useState("");
+  const [items, setItems] = useState("");
+  const [favors, setFavors] = useState("");
+  const [complications, setComplications] = useState("");
+  const [theme, setTheme] = useState<DndTheme>("Parchment");
+  const [result, setResult] = useState<QuestData | null>(null);
+
+  const themeStyles: Record<DndTheme, React.CSSProperties> = {
+    Parchment: {
+      background: "#fdf5e6",
+      padding: "1rem",
+      fontFamily: "serif",
+    },
+    Ink: {
+      background: "#fff",
+      color: "#000",
+      padding: "1rem",
+      fontFamily: "monospace",
+    },
+    Minimal: {
+      background: "#f0f0f0",
+      padding: "1rem",
+      fontFamily: "sans-serif",
+    },
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: QuestData = {
+      id: crypto.randomUUID(),
+      name,
+      tier,
+      summary,
+      beats: beats.split(",").map((b) => b.trim()).filter(Boolean),
+      rewards: {
+        gp: gp || undefined,
+        items: items || undefined,
+        favors: favors || undefined,
+      },
+      complications: complications
+        .split(",")
+        .map((c) => c.trim())
+        .filter(Boolean),
+      theme,
+    };
+    const parsed = zQuest.parse(data);
+    setResult(parsed);
+  };
+
   return (
-    <form>
+    <form onSubmit={handleSubmit}>
       <Typography variant="h6">Quest Form</Typography>
+      <TextField
+        label="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Tier"
+        value={tier}
+        onChange={(e) => setTier(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Summary"
+        value={summary}
+        onChange={(e) => setSummary(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Beats (comma separated)"
+        value={beats}
+        onChange={(e) => setBeats(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Reward GP"
+        value={gp}
+        onChange={(e) => setGp(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Reward Items"
+        value={items}
+        onChange={(e) => setItems(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Reward Favors"
+        value={favors}
+        onChange={(e) => setFavors(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Complications (comma separated)"
+        value={complications}
+        onChange={(e) => setComplications(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        select
+        label="Theme"
+        value={theme}
+        onChange={(e) => setTheme(e.target.value as DndTheme)}
+        fullWidth
+        margin="normal"
+      >
+        {themes.map((t) => (
+          <MenuItem key={t} value={t}>
+            {t}
+          </MenuItem>
+        ))}
+      </TextField>
+      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+        Submit
+      </Button>
+      <div style={{ ...themeStyles[theme], marginTop: "1rem" }}>
+        <h3>{name || "Quest Preview"}</h3>
+        {summary && (
+          <p>
+            <strong>Summary:</strong> {summary}
+          </p>
+        )}
+        {beats && (
+          <p>
+            <strong>Beats:</strong> {beats}
+          </p>
+        )}
+        {(gp || items || favors) && (
+          <p>
+            <strong>Rewards:</strong> {gp && `GP: ${gp} `}
+            {items && `Items: ${items} `}
+            {favors && `Favors: ${favors}`}
+          </p>
+        )}
+        {complications && (
+          <p>
+            <strong>Complications:</strong> {complications}
+          </p>
+        )}
+      </div>
+      {result && (
+        <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>
+      )}
     </form>
   );
 }

--- a/src/features/dnd/schemas.ts
+++ b/src/features/dnd/schemas.ts
@@ -5,6 +5,39 @@ export const zDndBase = z.object({
   name: z.string(),
 });
 
-export const zNpc = zDndBase;
-export const zQuest = zDndBase;
-export const zEncounter = zDndBase;
+export const zDndTheme = z.enum(["Parchment", "Ink", "Minimal"]);
+
+export const zNpc = zDndBase.extend({
+  tags: z.array(z.string()),
+  appearance: z.string(),
+  personality: z.string(),
+  motivation: z.string(),
+  secret: z.string(),
+  hooks: z.array(z.string()),
+  stat_block_ref: z.string(),
+  stat_overrides: z.string(),
+  theme: zDndTheme,
+});
+
+export const zQuest = zDndBase.extend({
+  tier: z.string(),
+  summary: z.string(),
+  beats: z.array(z.string()),
+  rewards: z.object({
+    gp: z.string().optional(),
+    items: z.string().optional(),
+    favors: z.string().optional(),
+  }),
+  complications: z.array(z.string()),
+  theme: zDndTheme,
+});
+
+export const zEncounter = zDndBase.extend({
+  level: z.string(),
+  creatures: z.array(z.string()),
+  tactics: z.string(),
+  terrain: z.string(),
+  treasure: z.string(),
+  scaling: z.string(),
+  theme: zDndTheme,
+});

--- a/src/features/dnd/tests/schemas.test.ts
+++ b/src/features/dnd/tests/schemas.test.ts
@@ -3,17 +3,48 @@ import { zNpc, zQuest, zEncounter } from "../schemas";
 
 describe("dnd schemas", () => {
   it("parses NPC data", () => {
-    const npc = { id: "1", name: "Goblin" };
+    const npc = {
+      id: "1",
+      name: "Goblin",
+      tags: ["monster"],
+      appearance: "green",
+      personality: "sneaky",
+      motivation: "loot",
+      secret: "afraid of light",
+      hooks: ["steal"],
+      stat_block_ref: "goblin",
+      stat_overrides: "hp 10",
+      theme: "Parchment",
+    };
     expect(zNpc.parse(npc)).toEqual(npc);
   });
 
   it("parses Quest data", () => {
-    const quest = { id: "q1", name: "Find the ring" };
+    const quest = {
+      id: "q1",
+      name: "Find the ring",
+      tier: "1",
+      summary: "Find the ring summary",
+      beats: ["start"],
+      rewards: { gp: "100" },
+      complications: ["orcs"],
+      theme: "Ink",
+    };
     expect(zQuest.parse(quest)).toEqual(quest);
   });
 
   it("parses Encounter data", () => {
-    const encounter = { id: "e1", name: "Goblin ambush" };
+    const encounter = {
+      id: "e1",
+      name: "Goblin ambush",
+      level: "1",
+      creatures: ["goblin"],
+      tactics: "hit and run",
+      terrain: "forest",
+      treasure: "gold",
+      scaling: "add more goblins",
+      theme: "Minimal",
+    };
     expect(zEncounter.parse(encounter)).toEqual(encounter);
   });
 });

--- a/src/features/dnd/types.ts
+++ b/src/features/dnd/types.ts
@@ -3,8 +3,39 @@ export interface DndBase {
   name: string;
 }
 
-export interface NpcData extends DndBase {}
+export type DndTheme = "Parchment" | "Ink" | "Minimal";
 
-export interface QuestData extends DndBase {}
+export interface NpcData extends DndBase {
+  tags: string[];
+  appearance: string;
+  personality: string;
+  motivation: string;
+  secret: string;
+  hooks: string[];
+  stat_block_ref: string;
+  stat_overrides: string;
+  theme: DndTheme;
+}
 
-export interface EncounterData extends DndBase {}
+export interface QuestData extends DndBase {
+  tier: string;
+  summary: string;
+  beats: string[];
+  rewards: {
+    gp?: string;
+    items?: string;
+    favors?: string;
+  };
+  complications: string[];
+  theme: DndTheme;
+}
+
+export interface EncounterData extends DndBase {
+  level: string;
+  creatures: string[];
+  tactics: string;
+  terrain: string;
+  treasure: string;
+  scaling: string;
+  theme: DndTheme;
+}


### PR DESCRIPTION
## Summary
- add detailed NPC, Quest, and Encounter forms with theme selector and live HTML preview
- extend DnD schemas and types for new fields including theme
- cover schemas with unit tests

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a2e41a312883259ebdb110f2c1dce8