### PR TITLE
feat: add spoken word generator

### DIFF
--- a/src/features/lofi/spokenWord.test.ts
+++ b/src/features/lofi/spokenWord.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { scheduleSpokenWord, applyVinylEffect } from './spokenWord';
+
+describe('spoken word helpers', () => {
+  it('exposes a schedule function', () => {
+    expect(typeof scheduleSpokenWord).toBe('function');
+  });
+
+  it('exposes an effect helper', () => {
+    expect(typeof applyVinylEffect).toBe('function');
+  });
+});

--- a/src/features/lofi/spokenWord.ts
+++ b/src/features/lofi/spokenWord.ts
@@ -1,0 +1,64 @@
+import * as Tone from 'tone';
+
+/**
+ * Render text to an audio buffer using the browser's SpeechSynthesis API.
+ * Falls back to an empty buffer if the API is unavailable.
+ */
+export async function renderSpokenWord(text: string): Promise<Tone.ToneAudioBuffer> {
+  if (typeof window === 'undefined' || !('speechSynthesis' in window)) {
+    return new Tone.ToneAudioBuffer();
+  }
+
+  return new Promise<Tone.ToneAudioBuffer>((resolve) => {
+    const ctx = Tone.getContext();
+    const dest = ctx.createMediaStreamDestination();
+    const recorder = new MediaRecorder(dest.stream);
+    const chunks: Blob[] = [];
+
+    recorder.ondataavailable = (e) => chunks.push(e.data);
+    recorder.onstop = async () => {
+      const blob = new Blob(chunks);
+      const arrayBuffer = await blob.arrayBuffer();
+      const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
+      resolve(new Tone.ToneAudioBuffer(audioBuffer));
+    };
+
+    recorder.start();
+    const utter = new SpeechSynthesisUtterance(text);
+    window.speechSynthesis.speak(utter);
+    utter.onend = () => recorder.stop();
+  });
+}
+
+/**
+ * Convert an uploaded audio File into a ToneAudioBuffer.
+ */
+export async function fileToBuffer(file: File): Promise<Tone.ToneAudioBuffer> {
+  const arrayBuffer = await file.arrayBuffer();
+  const audioBuffer = await Tone.getContext().decodeAudioData(arrayBuffer);
+  return new Tone.ToneAudioBuffer(audioBuffer);
+}
+
+/**
+ * Apply a simple vinyl/tape style effect chain to a Player.
+ */
+export function applyVinylEffect(player: Tone.Player): Tone.ToneAudioNode {
+  const crusher = new Tone.BitCrusher(8);
+  const wobble = new Tone.Vibrato(0.3, 0.2);
+  const filter = new Tone.Filter({ frequency: 8000, type: 'lowpass' });
+  player.chain(crusher, wobble, filter);
+  return filter;
+}
+
+/**
+ * Schedule a spoken word player to repeat every few measures.
+ */
+export function scheduleSpokenWord(player: Tone.Player, measures = 32) {
+  const interval = `${measures}m`;
+  Tone.Transport.scheduleRepeat((time) => {
+    if (player.buffer && player.buffer.length > 0) {
+      player.start(time);
+    }
+  }, interval);
+}
+

--- a/src/features/lofi/tests/SongForm.test.ts
+++ b/src/features/lofi/tests/SongForm.test.ts
@@ -13,6 +13,7 @@ describe('Song form hook', () => {
         bpm: { value: 80, rampTo: vi.fn() },
         start: vi.fn(),
         stop: vi.fn(),
+        scheduleRepeat: vi.fn(),
       };
       const mkSynth = () => {
         const obj: any = {
@@ -48,6 +49,16 @@ describe('Song form hook', () => {
         };
         return obj;
       });
+      const Player = vi.fn().mockImplementation(() => {
+        const obj: any = {
+          connect: vi.fn().mockReturnThis(),
+          chain: vi.fn().mockReturnThis(),
+          buffer: { length: 0 },
+        };
+        return obj;
+      });
+      const BitCrusher = vi.fn().mockImplementation(() => ({ connect: vi.fn().mockReturnThis() }));
+      const Vibrato = vi.fn().mockImplementation(() => ({ connect: vi.fn().mockReturnThis() }));
       const Loop = vi
         .fn()
         .mockImplementation(() => ({ start: vi.fn(), stop: vi.fn() }));
@@ -68,6 +79,9 @@ describe('Song form hook', () => {
         Volume,
         Filter,
         Gain,
+        Player,
+        BitCrusher,
+        Vibrato,
         Loop,
         Frequency,
         Synth,


### PR DESCRIPTION
## Summary
- add spoken word utilities for text-to-speech or user audio
- route spoken word through vinyl/tape-style effects and schedule playback
- expand tests and mocks for Tone.js helpers

## Testing
- `npm test --run`

------
https://chatgpt.com/codex/tasks/task_e_68a2e50a02208325946659360d79cfba