### PR TITLE
Import resample_poly in lofi renderer

### DIFF
--- a/src-tauri/python/lofi_gpu_hq.py
+++ b/src-tauri/python/lofi_gpu_hq.py
@@ -37,6 +37,7 @@ from typing import List, Dict, Tuple, Any, Optional
 import numpy as np
 from pydub import AudioSegment
 from pydub.utils import which
+from scipy.signal import resample_poly
 
 from effects import (
     SR,


### PR DESCRIPTION
## Summary
- add missing `resample_poly` import in `lofi_gpu_hq`

## Testing
- `python -m py_compile src-tauri/python/lofi_gpu_hq.py`
- `pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a38e99b3fc832595e279c3c1f14e25