### PR TITLE
Dynamically tuck ambience based on mix RMS

### DIFF
--- a/src-tauri/python/lofi_gpu_hq.py
+++ b/src-tauri/python/lofi_gpu_hq.py
@@ -1104,6 +1104,16 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60, chords=None
     if peak > 1.0:
         mix *= 0.9 / peak
 
+    # Auto-tuck ambience under the music based on RMS so it never overpowers
+    amb_component = amb_gain * amb_mix
+    music_only = mix - amb_component
+    music_rms = float(np.sqrt(np.mean(np.square(music_only))))
+    amb_rms = float(np.sqrt(np.mean(np.square(amb_component))))
+    if amb_rms > 0 and music_rms > 0:
+        target = music_rms * 0.3
+        tuck = float(np.clip(target / amb_rms, 0.0, 1.0))
+        mix = music_only + amb_component * tuck
+
     # stereoize
     if flags.get("hq_stereo", True):
         stereo = stereoize_np(mix)


### PR DESCRIPTION
## Summary
- prevent ambience from overpowering sparse sections by scaling its gain using RMS analysis of the music

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3a258525883259b7afd65b34c66e0