### PR TITLE
feat: resolve python path via env and path search

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -361,6 +361,7 @@ dependencies = [
  "tauri-plugin-opener",
  "ureq",
  "url",
+ "which",
 ]
 
 [[package]]
@@ -1002,6 +1003,12 @@ dependencies = [
  "quote",
  "syn 2.0.104",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -4956,6 +4963,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5436,6 +5454,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,4 +30,5 @@ once_cell = "1"
 url = "2"
 robotstxt = "0.3"
 dirs = "5"
+which = "8"
 


### PR DESCRIPTION
## Summary
- add `which` crate to locate Python in `PATH`
- resolve Python path using config, environment variable, or `PATH` search
- load resolved interpreter path into settings

## Testing
- `npm test`
- `cargo check` *(fails: system library `gobject-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3aa3d573c83259b7ab80ca9aacd6a