### PR TITLE
chore: expose audio effects

### DIFF
--- a/src-tauri/python/effects.py
+++ b/src-tauri/python/effects.py
@@ -5,6 +5,22 @@ from scipy.signal import butter, filtfilt, resample_poly
 
 SR = 44100
 
+# Explicitly export functions used by other modules.
+__all__ = [
+    "SR",
+    "_butter_lowpass",
+    "_butter_highpass",
+    "_butter_bandpass",
+    "soft_clip_np",
+    "apply_soft_limit",
+    "apply_tape_saturation",
+    "apply_wow_flutter",
+    "stereoize_np",
+    "apply_chorus_np",
+    "_apply_duck_envelope",
+    "_schroeder_room",
+]
+
 def _butter_lowpass(x, cutoff_hz):
     nyq = 0.5 * SR
     norm = min(cutoff_hz / nyq, 0.999)


### PR DESCRIPTION
## Summary
- explicitly export audio effect utilities for use in the HQ renderer

## Testing
- `python -m py_compile src-tauri/python/effects.py src-tauri/python/lofi_gpu_hq.py`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ac9e6dc883259c87661c79a30edf