### PR TITLE
Add chord span control to lofi engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Activate your Python environment first. The high‑quality generator lives at
   high‑quality processing.
 - **Limiter drive:** Add `limiter_drive` to the song JSON to control soft
   clipping intensity (values around `1.0` keep saturation subtle).
+- **Chord span:** Control how long each chord lasts with `chord_span_beats`
+  (2 = ½ bar, 4 = 1 bar, 8 = 2 bars).
 - **Analog polish:** Finishing chain adds tape-style saturation and subtle
   wow/flutter for vintage warmth.
 - **Dithering:** Exported 16‑bit WAVs now include low-level triangular dither.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -404,6 +404,8 @@ pub struct SongSpec {
     pub ambience_level: Option<f32>,
     pub seed: u64,
     pub variety: Option<u32>,
+    #[serde(alias = "chordSpanBeats", skip_serializing_if = "Option::is_none")]
+    pub chord_span_beats: Option<u32>,
     #[serde(alias = "drumPattern", skip_serializing_if = "Option::is_none")]
     pub drum_pattern: Option<String>,
     #[serde(alias = "hqStereo", skip_serializing_if = "Option::is_none")]
@@ -452,6 +454,7 @@ mod tests {
             ambience_level: Some(0.5),
             seed: 1,
             variety: Some(10),
+            chord_span_beats: None,
             drum_pattern: None,
             hq_stereo: None,
             hq_reverb: None,

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -69,6 +69,7 @@ describe('SongForm', () => {
     await waitFor(() => expect(invoke).toHaveBeenCalled());
     const call = (invoke as any).mock.calls.find(([c]: any) => c === 'run_lofi_song');
     expect(call[1].spec.structure[0]).toHaveProperty('chords');
+    expect(call[1].spec.chord_span_beats).toBe(4);
     expect(call[1].spec).toMatchObject({
       ambience: ['rain'],
       ambienceLevel: 0.5,

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -21,6 +21,7 @@ type SongSpec = {
   ambienceLevel: number; // 0..1
   seed: number;
   variety: number; // 0..100
+  chord_span_beats?: number;
   drum_pattern?: string;
   // NEW HQ feature flags (read by lofi_gpu_hq.py)
   hq_stereo?: boolean;
@@ -39,6 +40,7 @@ type TemplateSpec = {
   ambience: string[];
   drumPattern: string;
   variety: number;
+  chordSpanBeats?: number;
   hqStereo: boolean;
   hqReverb: boolean;
   hqSidechain: boolean;
@@ -334,6 +336,7 @@ export default function SongForm() {
     setAmbience(tpl.ambience);
     setDrumPattern(tpl.drumPattern);
     setVariety(tpl.variety);
+    setChordSpanBeats(tpl.chordSpanBeats ?? 4);
     setHqStereo(tpl.hqStereo);
     setHqReverb(tpl.hqReverb);
     setHqSidechain(tpl.hqSidechain);
@@ -370,6 +373,7 @@ export default function SongForm() {
   const [playLast, setPlayLast] = useState(true);
   const [drumPattern, setDrumPattern] = useState<string>("laidback");
   const [variety, setVariety] = useState(45);
+  const [chordSpanBeats, setChordSpanBeats] = useState(4);
 
   // NEW: Mix polish toggles mapping to engine flags
   const [hqStereo, setHqStereo] = useState(defaultHqStereo);
@@ -550,6 +554,7 @@ export default function SongForm() {
       ambienceLevel: amb,
       seed: pickSeed(i),
       variety: varPct,
+      chord_span_beats: chordSpanBeats,
       drum_pattern: drumPattern === "random" ? undefined : drumPattern,
       // pass-through HQ flags
       hq_stereo: hqStereo,
@@ -814,6 +819,7 @@ export default function SongForm() {
                         ambience,
                         drumPattern,
                         variety,
+                        chordSpanBeats,
                         hqStereo,
                         hqReverb,
                         hqSidechain,
@@ -956,7 +962,7 @@ export default function SongForm() {
         </div>
 
         {/* rhythm & feel */}
-        <div style={S.grid2}>
+        <div style={S.grid3}>
           <div style={S.panel}>
             <label style={S.label}>Drum Pattern</label>
             <select value={drumPattern} onChange={(e) => setDrumPattern(e.target.value)} style={{ ...S.input, padding: "8px 12px" }}>
@@ -971,6 +977,19 @@ export default function SongForm() {
             <label style={S.label}>Variety</label>
             <input type="range" min={0} max={100} value={variety} onChange={(e) => setVariety(Number(e.target.value))} style={S.slider} />
             <div style={S.small}>{variety}% fills & swing</div>
+          </div>
+
+          <div style={S.panel}>
+            <label style={S.label}>Chord Span</label>
+            <select
+              value={chordSpanBeats}
+              onChange={(e) => setChordSpanBeats(Number(e.target.value))}
+              style={{ ...S.input, padding: "8px 12px" }}
+            >
+              <option value={2}>½ bar</option>
+              <option value={4}>1 bar</option>
+              <option value={8}>2 bars</option>
+            </select>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- add `chord_span_beats` knob to SongSpec and audio engine to stretch chord durations
- expose chord span selector in SongForm UI and pass through generation spec
- document new `chord_span_beats` option in README

## Testing
- `python -m py_compile src-tauri/python/lofi_gpu_hq.py`
- `npm test`
- `cargo test` *(fails: The system library `gdk-3.0` required by crate `gdk-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b49e2dd08325a927d91cff92ac1b