### PR TITLE
Add named song forms and cadential chord endings

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -396,7 +396,10 @@ pub struct SongSpec {
     pub title: String,
     pub bpm: u32,
     pub key: String,
-    pub structure: Vec<Section>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub form: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub structure: Option<Vec<Section>>,
     pub mood: Vec<String>,
     pub instruments: Vec<String>,
     pub ambience: Vec<String>,
@@ -447,7 +450,8 @@ mod tests {
             title: "t".into(),
             bpm: 80,
             key: "C".into(),
-            structure: vec![],
+            form: None,
+            structure: None,
             mood: vec![],
             instruments: vec![],
             ambience: vec![],

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -14,7 +14,8 @@ type SongSpec = {
   outDir: string;
   bpm: number;
   key: string; // "C".."B" or "Auto"
-  structure: Section[];
+  structure?: Section[];
+  form?: string;
   mood: string[];
   instruments: string[];
   ambience: string[];


### PR DESCRIPTION
## Summary
- Allow SongSpec JSON to choose from named forms like `AABA32`, `ABABCB`, or `LoFiBasic`.
- Bias final chords toward authentic cadences for more intentional phrase endings.
- Extend SongSpec types in TypeScript and Rust with optional `form` support.

## Testing
- `python -m py_compile src-tauri/python/lofi_gpu_hq.py`
- `npm test -- --run`
- `cargo test` *(fails: The system library `gio-2.0` required by crate `gio-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c0e26e3c8325aed7df5a03ab51df