### PR TITLE
feat: add npc and lore schemas

### DIFF
--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -1,62 +1,54 @@
 import { useState } from "react";
-import {
-  Typography,
-  TextField,
-  Button,
-  MenuItem,
-} from "@mui/material";
+import { Typography, TextField, Button } from "@mui/material";
 import { zNpc } from "./schemas";
-import { NpcData, DndTheme } from "./types";
-
-const themes: DndTheme[] = ["Parchment", "Ink", "Minimal"];
+import { NpcData } from "./types";
 
 export default function NpcForm() {
   const [name, setName] = useState("");
-  const [tags, setTags] = useState("");
-  const [appearance, setAppearance] = useState("");
-  const [personality, setPersonality] = useState("");
-  const [motivation, setMotivation] = useState("");
-  const [secret, setSecret] = useState("");
+  const [species, setSpecies] = useState("");
+  const [role, setRole] = useState("");
+  const [alignment, setAlignment] = useState("");
+  const [backstory, setBackstory] = useState("");
+  const [location, setLocation] = useState("");
   const [hooks, setHooks] = useState("");
-  const [statBlockRef, setStatBlockRef] = useState("");
-  const [statOverrides, setStatOverrides] = useState("");
-  const [theme, setTheme] = useState<DndTheme>("Parchment");
+  const [quirks, setQuirks] = useState("");
+  const [voiceStyle, setVoiceStyle] = useState("");
+  const [voiceProvider, setVoiceProvider] = useState("");
+  const [voicePreset, setVoicePreset] = useState("");
+  const [portrait, setPortrait] = useState("");
+  const [statblock, setStatblock] = useState("{}");
+  const [tags, setTags] = useState("");
   const [result, setResult] = useState<NpcData | null>(null);
-
-  const themeStyles: Record<DndTheme, React.CSSProperties> = {
-    Parchment: {
-      background: "#fdf5e6",
-      padding: "1rem",
-      fontFamily: "serif",
-    },
-    Ink: {
-      background: "#fff",
-      color: "#000",
-      padding: "1rem",
-      fontFamily: "monospace",
-    },
-    Minimal: {
-      background: "#f0f0f0",
-      padding: "1rem",
-      fontFamily: "sans-serif",
-    },
-  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    let parsedStatblock: Record<string, unknown> = {};
+    try {
+      parsedStatblock = JSON.parse(statblock || "{}");
+    } catch {
+      // keep empty object
+    }
+
     const data: NpcData = {
       id: crypto.randomUUID(),
       name,
-      tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
-      appearance,
-      personality,
-      motivation,
-      secret,
+      species,
+      role,
+      alignment,
+      backstory: backstory || undefined,
+      location: location || undefined,
       hooks: hooks.split(",").map((h) => h.trim()).filter(Boolean),
-      stat_block_ref: statBlockRef,
-      stat_overrides: statOverrides,
-      theme,
+      quirks: quirks ? quirks.split(",").map((q) => q.trim()).filter(Boolean) : undefined,
+      voice: {
+        style: voiceStyle,
+        provider: voiceProvider,
+        preset: voicePreset,
+      },
+      portrait: portrait || undefined,
+      statblock: parsedStatblock,
+      tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
     };
+
     const parsed = zNpc.parse(data);
     setResult(parsed);
   };
@@ -72,37 +64,37 @@ export default function NpcForm() {
         margin="normal"
       />
       <TextField
-        label="Tags (comma separated)"
-        value={tags}
-        onChange={(e) => setTags(e.target.value)}
+        label="Species"
+        value={species}
+        onChange={(e) => setSpecies(e.target.value)}
         fullWidth
         margin="normal"
       />
       <TextField
-        label="Appearance"
-        value={appearance}
-        onChange={(e) => setAppearance(e.target.value)}
+        label="Role"
+        value={role}
+        onChange={(e) => setRole(e.target.value)}
         fullWidth
         margin="normal"
       />
       <TextField
-        label="Personality"
-        value={personality}
-        onChange={(e) => setPersonality(e.target.value)}
+        label="Alignment"
+        value={alignment}
+        onChange={(e) => setAlignment(e.target.value)}
         fullWidth
         margin="normal"
       />
       <TextField
-        label="Motivation"
-        value={motivation}
-        onChange={(e) => setMotivation(e.target.value)}
+        label="Backstory"
+        value={backstory}
+        onChange={(e) => setBackstory(e.target.value)}
         fullWidth
         margin="normal"
       />
       <TextField
-        label="Secret"
-        value={secret}
-        onChange={(e) => setSecret(e.target.value)}
+        label="Location"
+        value={location}
+        onChange={(e) => setLocation(e.target.value)}
         fullWidth
         margin="normal"
       />
@@ -114,67 +106,59 @@ export default function NpcForm() {
         margin="normal"
       />
       <TextField
-        label="Stat Block Ref"
-        value={statBlockRef}
-        onChange={(e) => setStatBlockRef(e.target.value)}
+        label="Quirks (comma separated)"
+        value={quirks}
+        onChange={(e) => setQuirks(e.target.value)}
         fullWidth
         margin="normal"
       />
       <TextField
-        label="Stat Overrides"
-        value={statOverrides}
-        onChange={(e) => setStatOverrides(e.target.value)}
+        label="Voice Style"
+        value={voiceStyle}
+        onChange={(e) => setVoiceStyle(e.target.value)}
         fullWidth
         margin="normal"
       />
       <TextField
-        select
-        label="Theme"
-        value={theme}
-        onChange={(e) => setTheme(e.target.value as DndTheme)}
+        label="Voice Provider"
+        value={voiceProvider}
+        onChange={(e) => setVoiceProvider(e.target.value)}
         fullWidth
         margin="normal"
-      >
-        {themes.map((t) => (
-          <MenuItem key={t} value={t}>
-            {t}
-          </MenuItem>
-        ))}
-      </TextField>
+      />
+      <TextField
+        label="Voice Preset"
+        value={voicePreset}
+        onChange={(e) => setVoicePreset(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Portrait URL"
+        value={portrait}
+        onChange={(e) => setPortrait(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Statblock JSON"
+        value={statblock}
+        onChange={(e) => setStatblock(e.target.value)}
+        fullWidth
+        margin="normal"
+        multiline
+      />
+      <TextField
+        label="Tags (comma separated)"
+        value={tags}
+        onChange={(e) => setTags(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
       <Button type="submit" variant="contained" sx={{ mt: 2 }}>
         Submit
       </Button>
-      <div style={{ ...themeStyles[theme], marginTop: "1rem" }}>
-        <h3>{name || "NPC Preview"}</h3>
-        {appearance && (
-          <p>
-            <strong>Appearance:</strong> {appearance}
-          </p>
-        )}
-        {personality && (
-          <p>
-            <strong>Personality:</strong> {personality}
-          </p>
-        )}
-        {motivation && (
-          <p>
-            <strong>Motivation:</strong> {motivation}
-          </p>
-        )}
-        {secret && (
-          <p>
-            <strong>Secret:</strong> {secret}
-          </p>
-        )}
-        {hooks && (
-          <p>
-            <strong>Hooks:</strong> {hooks}
-          </p>
-        )}
-      </div>
-      {result && (
-        <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>
-      )}
+      {result && <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>}
     </form>
   );
 }

--- a/src/features/dnd/lore.schema.json
+++ b/src/features/dnd/lore.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["id", "name", "summary", "tags"],
+  "properties": {
+    "id": { "type": "string" },
+    "name": { "type": "string" },
+    "summary": { "type": "string" },
+    "location": { "type": "string" },
+    "hooks": { "type": "array", "items": { "type": "string" } },
+    "tags": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/src/features/dnd/npc.schema.json
+++ b/src/features/dnd/npc.schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["id", "name", "species", "role", "alignment", "hooks", "voice", "statblock", "tags"],
+  "properties": {
+    "id": { "type": "string" },
+    "name": { "type": "string" },
+    "species": { "type": "string" },
+    "role": { "type": "string" },
+    "alignment": { "type": "string" },
+    "backstory": { "type": "string" },
+    "location": { "type": "string" },
+    "hooks": { "type": "array", "items": { "type": "string" } },
+    "quirks": { "type": "array", "items": { "type": "string" } },
+    "voice": {
+      "type": "object",
+      "properties": {
+        "style": { "type": "string" },
+        "provider": { "type": "string" },
+        "preset": { "type": "string" }
+      },
+      "required": ["style", "provider", "preset"]
+    },
+    "portrait": { "type": "string" },
+    "statblock": { "type": "object" },
+    "tags": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/src/features/dnd/schemas.ts
+++ b/src/features/dnd/schemas.ts
@@ -7,16 +7,42 @@ export const zDndBase = z.object({
 
 export const zDndTheme = z.enum(["Parchment", "Ink", "Minimal"]);
 
-export const zNpc = zDndBase.extend({
-  tags: z.array(z.string()),
-  appearance: z.string(),
-  personality: z.string(),
-  motivation: z.string(),
-  secret: z.string(),
+/**
+ * Minimal schema for non-player characters (NPCs).
+ * Designed to keep downstream consumers consistent and predictable.
+ */
+export const zVoice = z.object({
+  style: z.string(),
+  provider: z.string(),
+  preset: z.string(),
+});
+
+export const zNpc = z.object({
+  id: z.string(),
+  name: z.string(),
+  species: z.string(),
+  role: z.string(),
+  alignment: z.string(),
+  backstory: z.string().optional(),
+  location: z.string().optional(),
   hooks: z.array(z.string()),
-  stat_block_ref: z.string(),
-  stat_overrides: z.string(),
-  theme: zDndTheme,
+  quirks: z.array(z.string()).optional(),
+  voice: zVoice,
+  portrait: z.string().optional(),
+  statblock: z.record(z.unknown()),
+  tags: z.array(z.string()),
+});
+
+/**
+ * Simple schema for world lore entries.
+ */
+export const zLore = z.object({
+  id: z.string(),
+  name: z.string(),
+  summary: z.string(),
+  location: z.string().optional(),
+  hooks: z.array(z.string()).optional(),
+  tags: z.array(z.string()),
 });
 
 export const zQuest = zDndBase.extend({

--- a/src/features/dnd/tests/schemas.test.ts
+++ b/src/features/dnd/tests/schemas.test.ts
@@ -1,22 +1,30 @@
 import { describe, expect, it } from "vitest";
-import { zNpc, zQuest, zEncounter } from "../schemas";
+import { zNpc, zLore, zQuest, zEncounter } from "../schemas";
 
 describe("dnd schemas", () => {
   it("parses NPC data", () => {
     const npc = {
       id: "1",
-      name: "Goblin",
-      tags: ["monster"],
-      appearance: "green",
-      personality: "sneaky",
-      motivation: "loot",
-      secret: "afraid of light",
+      name: "Goblin Scout",
+      species: "Goblinoid",
+      role: "Scout",
+      alignment: "CE",
       hooks: ["steal"],
-      stat_block_ref: "goblin",
-      stat_overrides: "hp 10",
-      theme: "Parchment",
+      voice: { style: "gravelly", provider: "acme", preset: "goblin" },
+      statblock: {},
+      tags: ["monster"],
     };
     expect(zNpc.parse(npc)).toEqual(npc);
+  });
+
+  it("parses Lore data", () => {
+    const lore = {
+      id: "l1",
+      name: "Ancient Ruins",
+      summary: "Crumbling stones from a lost age",
+      tags: ["history"],
+    };
+    expect(zLore.parse(lore)).toEqual(lore);
   });
 
   it("parses Quest data", () => {

--- a/src/features/dnd/types.ts
+++ b/src/features/dnd/types.ts
@@ -6,15 +6,28 @@ export interface DndBase {
 export type DndTheme = "Parchment" | "Ink" | "Minimal";
 
 export interface NpcData extends DndBase {
-  tags: string[];
-  appearance: string;
-  personality: string;
-  motivation: string;
-  secret: string;
+  species: string;
+  role: string;
+  alignment: string;
+  backstory?: string;
+  location?: string;
   hooks: string[];
-  stat_block_ref: string;
-  stat_overrides: string;
-  theme: DndTheme;
+  quirks?: string[];
+  voice: {
+    style: string;
+    provider: string;
+    preset: string;
+  };
+  portrait?: string;
+  statblock: Record<string, unknown>;
+  tags: string[];
+}
+
+export interface LoreData extends DndBase {
+  summary: string;
+  location?: string;
+  hooks?: string[];
+  tags: string[];
 }
 
 export interface QuestData extends DndBase {


### PR DESCRIPTION
## Summary
- define strict Zod schemas for NPCs and lore entries
- expose matching JSON schemas for validation
- update forms, types, and tests to use the new minimal model

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ce718e4c8325b9201a24abb03663