### PR TITLE
Optimize stock charts with memoization and downsampling

### DIFF
--- a/src/components/Sparkline.tsx
+++ b/src/components/Sparkline.tsx
@@ -1,18 +1,19 @@
 import { Box } from "@mui/material";
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
+import { bucketDownsample } from "../utils/downsample";
 
-export default function Sparkline({ data, color = "#4caf50", width = 100, height = 30 }: { data: number[]; color?: string; width?: number; height?: number }) {
-  const ds = useMemo(() => {
-    if (!data || data.length === 0) return [] as number[];
-    const bucket = Math.max(1, Math.floor(data.length / width));
-    const out: number[] = [];
-    for (let i = 0; i < data.length; i += bucket) {
-      const slice = data.slice(i, i + bucket);
-      const avg = slice.reduce((a, b) => a + b, 0) / slice.length;
-      out.push(avg);
-    }
-    return out;
-  }, [data, width]);
+function Sparkline({
+  data,
+  color = "#4caf50",
+  width = 100,
+  height = 30,
+}: {
+  data: number[];
+  color?: string;
+  width?: number;
+  height?: number;
+}) {
+  const ds = useMemo(() => bucketDownsample(data, width), [data, width]);
 
   if (!ds.length) return null;
   const max = Math.max(...ds);
@@ -31,3 +32,5 @@ export default function Sparkline({ data, color = "#4caf50", width = 100, height
     </Box>
   );
 }
+
+export default memo(Sparkline);

--- a/src/components/StockRow.tsx
+++ b/src/components/StockRow.tsx
@@ -1,0 +1,39 @@
+import { memo } from "react";
+import { Box, Typography, IconButton, ListItem } from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import Sparkline from "./Sparkline";
+import { useStocks } from "../store/stocks";
+
+function StockRow({ symbol }: { symbol: string }) {
+  const quote = useStocks((state) => state.quotes[symbol]);
+  const removeStock = useStocks((state) => state.removeStock);
+  const color = quote && quote.changePercent < 0 ? "#ff5252" : "#4caf50";
+
+  return (
+    <ListItem
+      key={symbol}
+      secondaryAction={
+        <IconButton edge="end" onClick={() => removeStock(symbol)}>
+          <DeleteIcon />
+        </IconButton>
+      }
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 2, width: "100%" }}>
+        <Typography sx={{ width: 80 }}>{symbol}</Typography>
+        {quote ? (
+          <>
+            <Typography sx={{ width: 120, color }}>
+              {quote.price.toFixed(2)} ({quote.changePercent.toFixed(2)}%)
+            </Typography>
+            <Typography sx={{ width: 80 }}>{quote.marketStatus}</Typography>
+            <Sparkline data={quote.history} color={color} />
+          </>
+        ) : (
+          <Typography sx={{ width: 120 }}>...</Typography>
+        )}
+      </Box>
+    </ListItem>
+  );
+}
+
+export default memo(StockRow);

--- a/src/pages/Stocks.tsx
+++ b/src/pages/Stocks.tsx
@@ -1,20 +1,14 @@
 import { useState } from "react";
-import {
-  Box,
-  Button,
-  TextField,
-  List,
-  ListItem,
-  IconButton,
-  Typography,
-} from "@mui/material";
-import DeleteIcon from "@mui/icons-material/Delete";
-import Sparkline from "../components/Sparkline";
+import { Box, Button, TextField, List } from "@mui/material";
+import { useShallow } from "zustand/react/shallow";
+import StockRow from "../components/StockRow";
 import { useStocks } from "../store/stocks";
 
 export default function Stocks() {
   const [symbol, setSymbol] = useState("");
-  const { symbols, quotes, addStock, removeStock } = useStocks();
+  const { symbols, addStock } = useStocks(
+    useShallow((state) => ({ symbols: state.symbols, addStock: state.addStock }))
+  );
 
   const handleAdd = () => {
     const sym = symbol.trim();
@@ -38,35 +32,9 @@ export default function Stocks() {
         </Button>
       </Box>
       <List>
-        {symbols.map((s) => {
-          const q = quotes[s];
-          const color = q && q.changePercent < 0 ? "#ff5252" : "#4caf50";
-          return (
-            <ListItem
-              key={s}
-              secondaryAction={
-                <IconButton edge="end" onClick={() => removeStock(s)}>
-                  <DeleteIcon />
-                </IconButton>
-              }
-            >
-              <Box sx={{ display: "flex", alignItems: "center", gap: 2, width: "100%" }}>
-                <Typography sx={{ width: 80 }}>{s}</Typography>
-                {q ? (
-                  <>
-                    <Typography sx={{ width: 120, color }}>
-                      {q.price.toFixed(2)} ({q.changePercent.toFixed(2)}%)
-                    </Typography>
-                    <Typography sx={{ width: 80 }}>{q.marketStatus}</Typography>
-                    <Sparkline data={q.history} color={color} />
-                  </>
-                ) : (
-                  <Typography sx={{ width: 120 }}>...</Typography>
-                )}
-              </Box>
-            </ListItem>
-          );
-        })}
+        {symbols.map((s) => (
+          <StockRow key={s} symbol={s} />
+        ))}
       </List>
     </Box>
   );

--- a/src/utils/downsample.test.ts
+++ b/src/utils/downsample.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { bucketDownsample } from './downsample';
+
+describe('bucketDownsample', () => {
+  it('averages buckets by pixel width', () => {
+    const data = Array.from({ length: 100 }, (_, i) => i);
+    const result = bucketDownsample(data, 10);
+    expect(result.length).toBe(10);
+    expect(result[0]).toBeCloseTo(4.5, 1);
+    expect(result[result.length - 1]).toBeCloseTo(94.5, 1);
+  });
+});

--- a/src/utils/downsample.ts
+++ b/src/utils/downsample.ts
@@ -1,0 +1,11 @@
+export function bucketDownsample(data: number[], pixelWidth: number): number[] {
+  if (!data || data.length === 0 || pixelWidth <= 0) return [];
+  const bucketSize = Math.max(1, Math.floor(data.length / pixelWidth));
+  const out: number[] = [];
+  for (let i = 0; i < data.length; i += bucketSize) {
+    const slice = data.slice(i, i + bucketSize);
+    const avg = slice.reduce((a, b) => a + b, 0) / slice.length;
+    out.push(avg);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- downsample stock history using a new `bucketDownsample` utility
- memoize sparkline charts and stock rows to avoid unnecessary re-renders
- refactor stocks page to render rows independently

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3cff236ec8325a60cbf19f9bea294