### PR TITLE
Handle stock quote errors and prevent duplicate polling

### DIFF
--- a/src/components/StockRow.test.tsx
+++ b/src/components/StockRow.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import StockRow from './StockRow';
+import { useStocks } from '../store/stocks';
+
+const baseQuote = {
+  price: 123,
+  changePercent: 1,
+  history: [1, 2, 3],
+  marketStatus: 'OPEN',
+  lastFetched: Date.now(),
+};
+
+describe('StockRow', () => {
+  beforeEach(() => {
+    useStocks.setState({ quotes: {}, removeStock: vi.fn() } as any);
+  });
+
+  afterEach(() => {
+    useStocks.setState({ quotes: {} });
+    cleanup();
+  });
+
+  it('renders quote data', () => {
+    useStocks.setState({ quotes: { AAPL: baseQuote } });
+    const { asFragment } = render(<StockRow symbol="AAPL" />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it('renders error message when present', () => {
+    useStocks.setState({ quotes: { AAPL: { ...baseQuote, error: 'fail' } } });
+    const { getByText } = render(<StockRow symbol="AAPL" />);
+    expect(getByText('fail')).toBeInTheDocument();
+  });
+});

--- a/src/components/StockRow.tsx
+++ b/src/components/StockRow.tsx
@@ -21,13 +21,19 @@ function StockRow({ symbol }: { symbol: string }) {
       <Box sx={{ display: "flex", alignItems: "center", gap: 2, width: "100%" }}>
         <Typography sx={{ width: 80 }}>{symbol}</Typography>
         {quote ? (
-          <>
-            <Typography sx={{ width: 120, color }}>
-              {quote.price.toFixed(2)} ({quote.changePercent.toFixed(2)}%)
+          quote.error ? (
+            <Typography sx={{ width: 120, color: "#ff5252" }}>
+              {quote.error}
             </Typography>
-            <Typography sx={{ width: 80 }}>{quote.marketStatus}</Typography>
-            <Sparkline data={quote.history} color={color} />
-          </>
+          ) : (
+            <>
+              <Typography sx={{ width: 120, color }}>
+                {quote.price.toFixed(2)} ({quote.changePercent.toFixed(2)}%)
+              </Typography>
+              <Typography sx={{ width: 80 }}>{quote.marketStatus}</Typography>
+              <Sparkline data={quote.history} color={color} />
+            </>
+          )
         ) : (
           <Typography sx={{ width: 120 }}>...</Typography>
         )}

--- a/src/components/__snapshots__/StockRow.test.tsx.snap
+++ b/src/components/__snapshots__/StockRow.test.tsx.snap
@@ -1,0 +1,60 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`StockRow > renders quote data 1`] = `
+<DocumentFragment>
+  <li
+    class="MuiListItem-root MuiListItem-gutters MuiListItem-padding css-1p4qrhw-MuiListItem-root"
+  >
+    <div
+      class="MuiBox-root css-1lq4uud"
+    >
+      <p
+        class="MuiTypography-root MuiTypography-body1 css-1019lio-MuiTypography-root"
+      >
+        AAPL
+      </p>
+      <p
+        class="MuiTypography-root MuiTypography-body1 css-tsexvv-MuiTypography-root"
+      >
+        123.00 (1.00%)
+      </p>
+      <p
+        class="MuiTypography-root MuiTypography-body1 css-1019lio-MuiTypography-root"
+      >
+        OPEN
+      </p>
+      <svg
+        class="MuiBox-root css-1bayzp8"
+      >
+        <polyline
+          fill="none"
+          points="0,30 50,15 100,0"
+          stroke="#4caf50"
+          stroke-width="2"
+        />
+      </svg>
+    </div>
+    <div
+      class="MuiListItemSecondaryAction-root css-zezwi5-MuiListItemSecondaryAction-root"
+    >
+      <button
+        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1ysp02-MuiButtonBase-root-MuiIconButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+          data-testid="DeleteIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zM19 4h-3.5l-1-1h-5l-1 1H5v2h14z"
+          />
+        </svg>
+      </button>
+    </div>
+  </li>
+</DocumentFragment>
+`;


### PR DESCRIPTION
## Summary
- capture backend errors in `fetchQuote` so UI can show failure states instead of zeros
- avoid duplicate timers in `startPolling`
- add component snapshot tests for `StockRow`

## Testing
- `npm test -- -u --run`


------
https://chatgpt.com/codex/tasks/task_e_68a41c49bba48325b8ec5148777f7ed1