### PR TITLE
Add user profile page with balance display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import NotFound from "./pages/NotFound";
 import DND from "./pages/DND";
 import Stocks from "./pages/Stocks";
 import Shorts from "./pages/Shorts";
+import User from "./pages/User";
 
 export default function App() {
   return (
@@ -44,6 +45,7 @@ export default function App() {
         <Route path="/stocks" element={<Stocks />} />
         <Route path="/shorts" element={<Shorts />} />
         <Route path="/dnd" element={<DND />} />
+        <Route path="/user" element={<User />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,7 +1,7 @@
 import { IconButton } from "@mui/material";
 import type { SxProps } from "@mui/material";
 import { fixedIconButtonSx } from "./sx";
-import { FaHome, FaWrench } from "react-icons/fa";
+import { FaHome, FaWrench, FaUser } from "react-icons/fa";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useState } from "react";
 import SettingsDrawer from "./SettingsDrawer";
@@ -24,6 +24,15 @@ export default function TopBar() {
         aria-current={pathname === "/" ? "page" : undefined}
       >
         <FaHome />
+      </IconButton>
+
+      <IconButton
+        onClick={() => nav("/user")}
+        sx={{ ...fixedIconButtonSx, left: 60, ...activeSx("/user") }}
+        aria-label="User"
+        aria-current={pathname === "/user" ? "page" : undefined}
+      >
+        <FaUser />
       </IconButton>
 
       <IconButton

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -33,6 +33,7 @@ interface User {
   name: string;
   theme: Theme;
   mode: PaletteMode;
+  money: number;
   modules: ModulesState;
 }
 
@@ -61,6 +62,7 @@ export const useUsers = create<UsersState>()(
               name,
               theme: 'default',
               mode: 'dark',
+              money: 5000,
               modules: { ...defaultModules },
             },
           },

--- a/src/pages/GeneralChat.test.tsx
+++ b/src/pages/GeneralChat.test.tsx
@@ -18,6 +18,8 @@ describe('GeneralChat', () => {
           id: 'test',
           name: 'Test User',
           theme: 'default',
+          mode: 'dark',
+          money: 5000,
           modules: { ...defaultModules },
         },
       },

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -1,0 +1,36 @@
+import Center from "./_Center";
+import { useUsers } from "../features/users/useUsers";
+
+export default function User() {
+  const user = useUsers((state) => {
+    const id = state.currentUserId;
+    return id ? state.users[id] : null;
+  });
+
+  if (!user) {
+    return <Center>No user selected</Center>;
+  }
+
+  return (
+    <Center>
+      <div style={{ textAlign: "left" }}>
+        <h1>User Info</h1>
+        <p><strong>ID:</strong> {user.id}</p>
+        <p><strong>Name:</strong> {user.name}</p>
+        <p><strong>Theme:</strong> {user.theme}</p>
+        <p><strong>Mode:</strong> {user.mode}</p>
+        <p><strong>Money:</strong> {user.money}</p>
+        <div>
+          <h2>Modules</h2>
+          <ul>
+            {Object.entries(user.modules).map(([key, enabled]) => (
+              <li key={key}>
+                {key}: {enabled ? "on" : "off"}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </Center>
+  );
+}


### PR DESCRIPTION
## Summary
- add money field to user store with default 5,000
- create user page showing user info
- expose user page through router and top bar icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a415678f6483259c983c9306966a94