### PR TITLE
feat: make feature carousel vertical on home

### DIFF
--- a/src/components/FeatureCarousel.tsx
+++ b/src/components/FeatureCarousel.tsx
@@ -67,8 +67,8 @@ export default function FeatureCarousel({
     const now = Date.now();
     if (now - wheelLock.current < 200) return;
     wheelLock.current = now;
-    if (Math.abs(e.deltaY) < 5 && Math.abs(e.deltaX) < 5) return;
-    go(e.deltaY > 0 || e.deltaX > 0 ? 1 : -1);
+    if (Math.abs(e.deltaY) < 5) return;
+    go(e.deltaY > 0 ? 1 : -1);
   };
 
   // layout constants

--- a/src/components/sx.ts
+++ b/src/components/sx.ts
@@ -8,17 +8,21 @@ export const fixedIconButtonSx: SxProps = {
 
 export const carouselContainerSx: SxProps = {
   height: "100vh",
-  display: "grid",
-  placeItems: "center",
-  position: "relative",
+  width: 180,
+  position: "fixed",
+  left: 0,
+  top: 0,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
   overflow: "hidden",
   zIndex: 1,
 };
 
 export const carouselItemsWrapperSx: SxProps = {
   position: "relative",
-  width: "100%",
-  height: 240,
+  width: 180,
+  height: "100%",
 };
 
 export const carouselItemSx = (
@@ -31,7 +35,7 @@ export const carouselItemSx = (
   position: "absolute",
   left: "50%",
   top: "50%",
-  transform: `translate(-50%, -50%) translateX(${offset * gap}px) scale(${center ? scaleMid : scaleSide})`,
+  transform: `translate(-50%, -50%) translateY(${offset * gap}px) scale(${center ? scaleMid : scaleSide})`,
   transition: "transform 280ms ease, opacity 280ms ease, color 180ms ease",
   textAlign: "center",
   opacity: center ? 1 : 0.6,


### PR DESCRIPTION
## Summary
- position feature carousel on the left side of the home screen
- arrange carousel items vertically
- allow mouse wheel to advance one icon per notch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a41fa45fc883258968fd42d8e40a38