### PR TITLE
feat: add lore form to DND tools

### DIFF
--- a/src/features/dnd/LoreForm.tsx
+++ b/src/features/dnd/LoreForm.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { Typography, TextField, Button } from "@mui/material";
+import { zLore } from "./schemas";
+import { LoreData } from "./types";
+
+export default function LoreForm() {
+  const [name, setName] = useState("");
+  const [summary, setSummary] = useState("");
+  const [location, setLocation] = useState("");
+  const [hooks, setHooks] = useState("");
+  const [tags, setTags] = useState("");
+  const [result, setResult] = useState<LoreData | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: LoreData = {
+      id: crypto.randomUUID(),
+      name,
+      summary,
+      location: location || undefined,
+      hooks: hooks
+        ? hooks.split(",").map((h) => h.trim()).filter(Boolean)
+        : undefined,
+      tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
+    };
+    const parsed = zLore.parse(data);
+    setResult(parsed);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Typography variant="h6">Lore Form</Typography>
+      <TextField
+        label="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Summary"
+        value={summary}
+        onChange={(e) => setSummary(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Location"
+        value={location}
+        onChange={(e) => setLocation(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Hooks (comma separated)"
+        value={hooks}
+        onChange={(e) => setHooks(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Tags (comma separated)"
+        value={tags}
+        onChange={(e) => setTags(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+        Submit
+      </Button>
+      {result && <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>}
+    </form>
+  );
+}

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -1,6 +1,7 @@
 import { Box, Tab, Tabs } from "@mui/material";
 import { SyntheticEvent, useState } from "react";
 import NpcForm from "../features/dnd/NpcForm";
+import LoreForm from "../features/dnd/LoreForm";
 import QuestForm from "../features/dnd/QuestForm";
 import EncounterForm from "../features/dnd/EncounterForm";
 
@@ -11,12 +12,14 @@ export default function DND() {
     <Box sx={{ p: 2 }}>
       <Tabs value={tab} onChange={handleChange}>
         <Tab label="NPC" />
+        <Tab label="Lore" />
         <Tab label="Quest" />
         <Tab label="Encounter" />
       </Tabs>
       {tab === 0 && <NpcForm />}
-      {tab === 1 && <QuestForm />}
-      {tab === 2 && <EncounterForm />}
+      {tab === 1 && <LoreForm />}
+      {tab === 2 && <QuestForm />}
+      {tab === 3 && <EncounterForm />}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add `LoreForm` to create and preview lore entries
- wire LoreForm into DND page as new tab

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4c7f484e8832582bab6c5c4a986ad