### PR TITLE
refactor(dnd): share theme constants

### DIFF
--- a/src/features/dnd/EncounterForm.tsx
+++ b/src/features/dnd/EncounterForm.tsx
@@ -7,8 +7,7 @@ import {
 } from "@mui/material";
 import { zEncounter } from "./schemas";
 import { EncounterData, DndTheme } from "./types";
-
-const themes: DndTheme[] = ["Parchment", "Ink", "Minimal"];
+import { themes, themeStyles } from "./theme";
 
 export default function EncounterForm() {
   const [name, setName] = useState("");
@@ -20,25 +19,6 @@ export default function EncounterForm() {
   const [scaling, setScaling] = useState("");
   const [theme, setTheme] = useState<DndTheme>("Parchment");
   const [result, setResult] = useState<EncounterData | null>(null);
-
-  const themeStyles: Record<DndTheme, React.CSSProperties> = {
-    Parchment: {
-      background: "#fdf5e6",
-      padding: "1rem",
-      fontFamily: "serif",
-    },
-    Ink: {
-      background: "#fff",
-      color: "#000",
-      padding: "1rem",
-      fontFamily: "monospace",
-    },
-    Minimal: {
-      background: "#f0f0f0",
-      padding: "1rem",
-      fontFamily: "sans-serif",
-    },
-  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/features/dnd/QuestForm.tsx
+++ b/src/features/dnd/QuestForm.tsx
@@ -7,8 +7,7 @@ import {
 } from "@mui/material";
 import { zQuest } from "./schemas";
 import { QuestData, DndTheme } from "./types";
-
-const themes: DndTheme[] = ["Parchment", "Ink", "Minimal"];
+import { themes, themeStyles } from "./theme";
 
 export default function QuestForm() {
   const [name, setName] = useState("");
@@ -21,25 +20,6 @@ export default function QuestForm() {
   const [complications, setComplications] = useState("");
   const [theme, setTheme] = useState<DndTheme>("Parchment");
   const [result, setResult] = useState<QuestData | null>(null);
-
-  const themeStyles: Record<DndTheme, React.CSSProperties> = {
-    Parchment: {
-      background: "#fdf5e6",
-      padding: "1rem",
-      fontFamily: "serif",
-    },
-    Ink: {
-      background: "#fff",
-      color: "#000",
-      padding: "1rem",
-      fontFamily: "monospace",
-    },
-    Minimal: {
-      background: "#f0f0f0",
-      padding: "1rem",
-      fontFamily: "sans-serif",
-    },
-  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/features/dnd/theme.ts
+++ b/src/features/dnd/theme.ts
@@ -1,0 +1,23 @@
+import type { CSSProperties } from "react";
+import { DndTheme } from "./types";
+
+export const themes: DndTheme[] = ["Parchment", "Ink", "Minimal"];
+
+export const themeStyles: Record<DndTheme, CSSProperties> = {
+  Parchment: {
+    background: "#fdf5e6",
+    padding: "1rem",
+    fontFamily: "serif",
+  },
+  Ink: {
+    background: "#fff",
+    color: "#000",
+    padding: "1rem",
+    fontFamily: "monospace",
+  },
+  Minimal: {
+    background: "#f0f0f0",
+    padding: "1rem",
+    fontFamily: "sans-serif",
+  },
+};


### PR DESCRIPTION
## Summary
- centralize DnD form themes and styles in `theme.ts`
- consume shared `themes` and `themeStyles` in quest and encounter forms

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a4cef61b4c832585df78d897205dce