### PR TITLE
feat: expand key options and minor mode

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -16,6 +16,31 @@ import { usePaths } from "../features/paths/usePaths";
 import { useOutput } from "../features/output/useOutput";
 import { useAudioDefaults } from "../features/audioDefaults/useAudioDefaults";
 
+const KEY_OPTIONS = [
+  "Auto",
+  "C",
+  "C#",
+  "Db",
+  "D",
+  "D#",
+  "Eb",
+  "E",
+  "F",
+  "F#",
+  "Gb",
+  "G",
+  "G#",
+  "Ab",
+  "A",
+  "A#",
+  "Bb",
+  "B",
+  "Am",
+  "Em",
+  "Dm",
+];
+const displayKey = (k: string) => k.replace("#", "♯").replace("b", "♭");
+
 interface SettingsDrawerProps {
   open: boolean;
   onClose: () => void;
@@ -103,18 +128,9 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               value={key}
               onChange={(e) => setKey(e.target.value as string)}
             >
-              {[
-                "Auto",
-                "C",
-                "D",
-                "E",
-                "F",
-                "G",
-                "A",
-                "B",
-              ].map((k) => (
+              {KEY_OPTIONS.map((k) => (
                 <MenuItem key={k} value={k}>
-                  {k}
+                  {displayKey(k)}
                 </MenuItem>
               ))}
             </Select>

--- a/src/features/lofi/tests/SongForm.test.ts
+++ b/src/features/lofi/tests/SongForm.test.ts
@@ -113,8 +113,12 @@ describe('Song form hook', () => {
   });
 
   it('handles key changes', () => {
-    useLofi.getState().setKey('D');
-    expect(useLofi.getState().key).toBe('D');
+    useLofi.getState().setKey('F#');
+    expect(useLofi.getState().key).toBe('F#');
+    useLofi.getState().setKey('Bb');
+    expect(useLofi.getState().key).toBe('Bb');
+    useLofi.getState().setKey('Am');
+    expect(useLofi.getState().key).toBe('Am');
   });
 });
 


### PR DESCRIPTION
## Summary
- allow sharps, flats, and minor labels in UI key selectors
- support minor/major key mode in lofi engine and spec
- add distinct progression bank for C sections

## Testing
- `npm test -- --run`
- `python -m py_compile src-tauri/python/lofi_gpu_hq.py`

------
https://chatgpt.com/codex/tasks/task_e_68a4cf098348832587c810fa46e5735f