### PR TITLE
Refactor stock symbol mapping and forecast error handling

### DIFF
--- a/src/store/stocks.test.ts
+++ b/src/store/stocks.test.ts
@@ -74,6 +74,13 @@ describe('useStocks store', () => {
     expect(invoke).toHaveBeenCalledWith('stock_forecast', { symbol: 'GOOG' });
   });
 
+  it('returns a friendly message when forecast fails', async () => {
+    (invoke as any).mockRejectedValue(new Error('fail'));
+    const result = await useStocks.getState().forecast('goog');
+    expect(result).toBe('Forecast currently unavailable.');
+    expect(invoke).toHaveBeenCalledWith('stock_forecast', { symbol: 'GOOG' });
+  });
+
   it('adds and removes symbols', () => {
     const origStart = useStocks.getState().startPolling;
     const origStop = useStocks.getState().stopPolling;

--- a/src/store/stocks.ts
+++ b/src/store/stocks.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand';
 import { invoke } from '@tauri-apps/api/core';
 
+const SYMBOL_MAP: Record<string, string> = {
+  BTC: 'BTC-USD',
+  ETH: 'ETH-USD',
+};
+
 interface Quote {
   price: number;
   changePercent: number;
@@ -28,8 +33,7 @@ export const useStocks = create<StockState>((set, get) => ({
   symbols: [],
   fetchQuote: async (symbol) => {
     const sym = symbol.toUpperCase();
-    const map: Record<string, string> = { BTC: 'BTC-USD', ETH: 'ETH-USD' };
-    const fetchSym = map[sym] ?? sym;
+    const fetchSym = SYMBOL_MAP[sym] ?? sym;
     try {
       const bundle = await invoke<{
         quotes: { price: number; change_percent: number; status: string }[];
@@ -98,7 +102,11 @@ export const useStocks = create<StockState>((set, get) => ({
   },
   forecast: async (symbol) => {
     const sym = symbol.toUpperCase();
-    return invoke<string>('stock_forecast', { symbol: sym });
+    try {
+      return await invoke<string>('stock_forecast', { symbol: sym });
+    } catch {
+      return 'Forecast currently unavailable.';
+    }
   },
   addStock: (symbol) => {
     const sym = symbol.toUpperCase();


### PR DESCRIPTION
## Summary
- define BTC/ETH ticker mapping as module-level constant
- handle forecast invocation errors with friendly message
- test forecast error path

## Testing
- `npm test -- src/store/stocks.test.ts --run`


------
https://chatgpt.com/codex/tasks/task_e_68a4e8ed6c2c8325aa7db740eb7cb3ce