### PR TITLE
Handle statblock JSON parse errors in NPC form

### DIFF
--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -17,6 +17,7 @@ export default function NpcForm() {
   const [voicePreset, setVoicePreset] = useState("");
   const [portrait, setPortrait] = useState("");
   const [statblock, setStatblock] = useState("{}");
+  const [statblockError, setStatblockError] = useState<string | null>(null);
   const [tags, setTags] = useState("");
   const [result, setResult] = useState<NpcData | null>(null);
 
@@ -25,8 +26,10 @@ export default function NpcForm() {
     let parsedStatblock: Record<string, unknown> = {};
     try {
       parsedStatblock = JSON.parse(statblock || "{}");
+      setStatblockError(null);
     } catch {
-      // keep empty object
+      setStatblockError("Invalid JSON");
+      return;
     }
 
     const data: NpcData = {
@@ -143,10 +146,15 @@ export default function NpcForm() {
       <TextField
         label="Statblock JSON"
         value={statblock}
-        onChange={(e) => setStatblock(e.target.value)}
+        onChange={(e) => {
+          setStatblock(e.target.value);
+          setStatblockError(null);
+        }}
         fullWidth
         margin="normal"
         multiline
+        error={Boolean(statblockError)}
+        helperText={statblockError}
       />
       <TextField
         label="Tags (comma separated)"


### PR DESCRIPTION
## Summary
- catch statblock JSON parse errors and store message in state
- show parsing error on statblock field and skip schema validation

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a4e8fc955083259135457ffcc16d85