### PR TITLE
Add lead instrument selection and street ambience toggle

### DIFF
--- a/src-tauri/python/lofi_gpu_hq.py
+++ b/src-tauri/python/lofi_gpu_hq.py
@@ -1115,7 +1115,8 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60, chords=None
             section_name=section_name,
             motif_store=motif,
         )
-        melody = _apply_melody_timbre(melody, instrs)
+        lead = motif.get("lead_instrument")
+        melody = _apply_melody_timbre(melody, [lead] if lead else instrs)
     else:
         melody = np.zeros(n, dtype=np.float32)
 
@@ -1417,9 +1418,14 @@ def render_from_spec(spec: Dict[str, Any]) -> Tuple[AudioSegment, int]:
     except Exception:
         dither_amt = 1.0
 
+    lead = spec.get("lead_instrument")
+    if lead:
+        lead = _normalize_instruments([lead])[0]
+
     motif = {
         "mood": spec.get("mood") or [],
         "instruments": spec.get("instruments") or [],
+        "lead_instrument": lead,
         "ambience": spec.get("ambience") or [],
         "ambience_level": amb_lvl,
         "key": key_letter,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -402,6 +402,8 @@ pub struct SongSpec {
     pub structure: Option<Vec<Section>>,
     pub mood: Vec<String>,
     pub instruments: Vec<String>,
+    #[serde(alias = "leadInstrument", skip_serializing_if = "Option::is_none")]
+    pub lead_instrument: Option<String>,
     pub ambience: Vec<String>,
     #[serde(alias = "ambienceLevel")]
     pub ambience_level: Option<f32>,
@@ -454,6 +456,7 @@ mod tests {
             structure: None,
             mood: vec![],
             instruments: vec![],
+            lead_instrument: None,
             ambience: vec![],
             ambience_level: Some(0.5),
             seed: 1,

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -73,6 +73,7 @@ describe('SongForm', () => {
     expect(call[1].spec).toMatchObject({
       ambience: ['rain'],
       ambience_level: 0.5,
+      lead_instrument: 'synth lead',
       hq_stereo: true,
       hq_reverb: true,
       hq_sidechain: true,
@@ -138,6 +139,11 @@ describe('SongForm', () => {
     expect(screen.getByText('fantasy')).toBeInTheDocument();
   });
 
+  it('shows street ambience option', () => {
+    render(<SongForm />);
+    expect(screen.getByText('street')).toBeInTheDocument();
+  });
+
   it('passes selected instruments in spec', async () => {
     (open as any).mockResolvedValue('/tmp/out');
     (invoke as any).mockResolvedValue('');
@@ -160,6 +166,25 @@ describe('SongForm', () => {
     await waitFor(() => expect(invoke).toHaveBeenCalled());
     const call = (invoke as any).mock.calls.find(([c]: any) => c === 'run_lofi_song');
     expect(call[1].spec.instruments).toEqual(['harp', 'lute', 'pan flute']);
+  });
+
+  it('passes lead instrument in spec', async () => {
+    (open as any).mockResolvedValue('/tmp/out');
+    (invoke as any).mockResolvedValue('');
+    (listen as any).mockResolvedValue(() => {});
+
+    render(<SongForm />);
+
+    fireEvent.click(screen.getByText(/choose folder/i));
+    await screen.findByText('/tmp/out');
+
+    fireEvent.click(screen.getByRole('radio', { name: 'flute' }));
+
+    fireEvent.click(screen.getByText(/render songs/i));
+
+    await waitFor(() => expect(invoke).toHaveBeenCalled());
+    const call = (invoke as any).mock.calls.find(([c]: any) => c === 'run_lofi_song');
+    expect(call[1].spec.lead_instrument).toBe('flute');
   });
 
   it('calls generate_album when album mode enabled', async () => {

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -18,6 +18,7 @@ type SongSpec = {
   form?: string;
   mood: string[];
   instruments: string[];
+  lead_instrument?: string;
   ambience: string[];
   ambience_level: number; // 0..1
   seed: number;
@@ -40,6 +41,7 @@ type TemplateSpec = {
   mood: string[];
   instruments: string[];
   ambience: string[];
+  leadInstrument?: string;
   drumPattern: string;
   variety: number;
   chordSpanBeats?: number;
@@ -106,7 +108,13 @@ const INSTR = [
   "lute",
   "pan flute",
 ];
-const AMBI = ["rain", "cafe"];
+const AMBI = ["rain", "cafe", "street"];
+const LEAD_INSTR = [
+  { value: "flute", label: "flute" },
+  { value: "saxophone", label: "sax" },
+  { value: "synth lead", label: "synth" },
+  { value: "violin", label: "violin" },
+];
 const DRUM_PATS = [
   "random",
   "no_drums",
@@ -117,6 +125,14 @@ const DRUM_PATS = [
   "swing",
   "half_time_shuffle",
 ];
+
+function inferLeadInstrument(instrs: string[]): string {
+  if (instrs.includes("flute")) return "flute";
+  if (instrs.includes("saxophone")) return "saxophone";
+  if (instrs.includes("violin")) return "violin";
+  if (instrs.includes("synth lead")) return "synth lead";
+  return "synth lead";
+}
 
 const SECTION_PRESETS: Record<string, Section[]> = {
   "Intro(4)-A(8)-B(8)-Break(4)-A(8)-Outro(4)": [
@@ -350,11 +366,11 @@ export default function SongForm() {
   const [bpm, setBpm] = useState(defaultBpm);
   const [key, setKey] = useState<string>(defaultKey);
   const [mood, setMood] = useState<string[]>(["calm", "cozy", "nostalgic"]);
-  const [instruments, setInstruments] = useState<string[]>([
-    "rhodes",
-    "nylon guitar",
-    "upright bass",
-  ]);
+  const defaultInstruments = ["rhodes", "nylon guitar", "upright bass"];
+  const [instruments, setInstruments] = useState<string[]>(defaultInstruments);
+  const [leadInstrument, setLeadInstrument] = useState<string>(() =>
+    inferLeadInstrument(defaultInstruments)
+  );
   const [ambience, setAmbience] = useState<string[]>(["rain"]);
   const [ambienceLevel, setAmbienceLevel] = useState(0.5);
   const [templates, setTemplates] = useState<Record<string, TemplateSpec>>(() => {
@@ -384,6 +400,7 @@ export default function SongForm() {
     setKey(tpl.key);
     setMood(tpl.mood);
     setInstruments(tpl.instruments);
+    setLeadInstrument(tpl.leadInstrument ?? inferLeadInstrument(tpl.instruments));
     setAmbience(tpl.ambience);
     setDrumPattern(tpl.drumPattern);
     setVariety(tpl.variety);
@@ -653,6 +670,7 @@ export default function SongForm() {
       structure: structure.map(({ name, bars, chords }) => ({ name, bars, chords })),
       mood,
       instruments,
+      lead_instrument: leadInstrument,
       ambience,
       ambience_level: amb,
       seed: pickSeed(i),
@@ -921,6 +939,7 @@ export default function SongForm() {
                         key,
                         mood,
                         instruments,
+                        leadInstrument,
                         ambience,
                         drumPattern,
                         variety,
@@ -1079,6 +1098,24 @@ export default function SongForm() {
               ))}
             </div>
             <div style={S.small}>Drums are synthesized automatically.</div>
+          </div>
+
+          <div style={S.panel}>
+            <label style={S.label}>Lead Instrument</label>
+            <div style={S.optionGrid}>
+              {LEAD_INSTR.map((l) => (
+                <label key={l.value} style={S.optionCard}>
+                  <span>{l.label}</span>
+                  <input
+                    type="radio"
+                    name="leadInstrument"
+                    value={l.value}
+                    checked={leadInstrument === l.value}
+                    onChange={() => setLeadInstrument(l.value)}
+                  />
+                </label>
+              ))}
+            </div>
           </div>
 
           <div style={S.panel}>


### PR DESCRIPTION
## Summary
- support explicit lead instrument selection (flute, sax, synth, violin)
- add "street" ambience option
- handle new lead_instrument field in backend and commands

## Testing
- `npx vitest run`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e76547a88325858bb41b6e727178