### PR TITLE
Enforce non-empty voice fields in NPC schema

### DIFF
--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Typography, TextField, Button } from "@mui/material";
+import { z } from "zod";
 import { zNpc } from "./schemas";
 import { NpcData } from "./types";
 
@@ -18,6 +19,9 @@ export default function NpcForm() {
   const [portrait, setPortrait] = useState("");
   const [statblock, setStatblock] = useState("{}");
   const [statblockError, setStatblockError] = useState<string | null>(null);
+  const [voiceStyleError, setVoiceStyleError] = useState<string | null>(null);
+  const [voiceProviderError, setVoiceProviderError] = useState<string | null>(null);
+  const [voicePresetError, setVoicePresetError] = useState<string | null>(null);
   const [tags, setTags] = useState("");
   const [result, setResult] = useState<NpcData | null>(null);
 
@@ -52,8 +56,24 @@ export default function NpcForm() {
       tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
     };
 
-    const parsed = zNpc.parse(data);
-    setResult(parsed);
+    setVoiceStyleError(null);
+    setVoiceProviderError(null);
+    setVoicePresetError(null);
+
+    try {
+      const parsed = zNpc.parse(data);
+      setResult(parsed);
+    } catch (err) {
+      setResult(null);
+      if (err instanceof z.ZodError) {
+        err.issues.forEach((issue) => {
+          const path = issue.path.join(".");
+          if (path === "voice.style") setVoiceStyleError(issue.message);
+          if (path === "voice.provider") setVoiceProviderError(issue.message);
+          if (path === "voice.preset") setVoicePresetError(issue.message);
+        });
+      }
+    }
   };
 
   return (
@@ -118,23 +138,38 @@ export default function NpcForm() {
       <TextField
         label="Voice Style"
         value={voiceStyle}
-        onChange={(e) => setVoiceStyle(e.target.value)}
+        onChange={(e) => {
+          setVoiceStyle(e.target.value);
+          setVoiceStyleError(null);
+        }}
         fullWidth
         margin="normal"
+        error={Boolean(voiceStyleError)}
+        helperText={voiceStyleError}
       />
       <TextField
         label="Voice Provider"
         value={voiceProvider}
-        onChange={(e) => setVoiceProvider(e.target.value)}
+        onChange={(e) => {
+          setVoiceProvider(e.target.value);
+          setVoiceProviderError(null);
+        }}
         fullWidth
         margin="normal"
+        error={Boolean(voiceProviderError)}
+        helperText={voiceProviderError}
       />
       <TextField
         label="Voice Preset"
         value={voicePreset}
-        onChange={(e) => setVoicePreset(e.target.value)}
+        onChange={(e) => {
+          setVoicePreset(e.target.value);
+          setVoicePresetError(null);
+        }}
         fullWidth
         margin="normal"
+        error={Boolean(voicePresetError)}
+        helperText={voicePresetError}
       />
       <TextField
         label="Portrait URL"

--- a/src/features/dnd/schemas.ts
+++ b/src/features/dnd/schemas.ts
@@ -12,9 +12,9 @@ export const zDndTheme = z.enum(["Parchment", "Ink", "Minimal"]);
  * Designed to keep downstream consumers consistent and predictable.
  */
 export const zVoice = z.object({
-  style: z.string(),
-  provider: z.string(),
-  preset: z.string(),
+  style: z.string().min(1),
+  provider: z.string().min(1),
+  preset: z.string().min(1),
 });
 
 export const zNpc = z.object({

--- a/src/features/dnd/tests/schemas.test.ts
+++ b/src/features/dnd/tests/schemas.test.ts
@@ -17,6 +17,21 @@ describe("dnd schemas", () => {
     expect(zNpc.parse(npc)).toEqual(npc);
   });
 
+  it("rejects NPCs with empty voice fields", () => {
+    const npc = {
+      id: "1",
+      name: "Goblin Scout",
+      species: "Goblinoid",
+      role: "Scout",
+      alignment: "CE",
+      hooks: ["steal"],
+      voice: { style: "", provider: "", preset: "" },
+      statblock: {},
+      tags: ["monster"],
+    };
+    expect(() => zNpc.parse(npc)).toThrowError();
+  });
+
   it("parses Lore data", () => {
     const lore = {
       id: "l1",


### PR DESCRIPTION
## Summary
- require non-empty `style`, `provider`, and `preset` in `zVoice`
- show voice field validation errors in `NpcForm`
- test empty voice field validation in NPC schema

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4f12c89ac8325b1e8e46478865a23