### PR TITLE
Use numeric types for DnD tier, level and GP

### DIFF
--- a/src/features/dnd/EncounterForm.tsx
+++ b/src/features/dnd/EncounterForm.tsx
@@ -25,7 +25,7 @@ export default function EncounterForm() {
     const data: EncounterData = {
       id: crypto.randomUUID(),
       name,
-      level,
+      level: Number(level),
       creatures: creatures.split(",").map((c) => c.trim()).filter(Boolean),
       tactics,
       terrain,

--- a/src/features/dnd/QuestForm.tsx
+++ b/src/features/dnd/QuestForm.tsx
@@ -26,11 +26,11 @@ export default function QuestForm() {
     const data: QuestData = {
       id: crypto.randomUUID(),
       name,
-      tier,
+      tier: Number(tier),
       summary,
       beats: beats.split(",").map((b) => b.trim()).filter(Boolean),
       rewards: {
-        gp: gp || undefined,
+        gp: gp ? Number(gp) : undefined,
         items: items || undefined,
         favors: favors || undefined,
       },

--- a/src/features/dnd/schemas.ts
+++ b/src/features/dnd/schemas.ts
@@ -46,11 +46,11 @@ export const zLore = z.object({
 });
 
 export const zQuest = zDndBase.extend({
-  tier: z.string(),
+  tier: z.number(),
   summary: z.string(),
   beats: z.array(z.string()),
   rewards: z.object({
-    gp: z.string().optional(),
+    gp: z.number().optional(),
     items: z.string().optional(),
     favors: z.string().optional(),
   }),
@@ -59,7 +59,7 @@ export const zQuest = zDndBase.extend({
 });
 
 export const zEncounter = zDndBase.extend({
-  level: z.string(),
+  level: z.number(),
   creatures: z.array(z.string()),
   tactics: z.string(),
   terrain: z.string(),

--- a/src/features/dnd/tests/schemas.test.ts
+++ b/src/features/dnd/tests/schemas.test.ts
@@ -31,10 +31,10 @@ describe("dnd schemas", () => {
     const quest = {
       id: "q1",
       name: "Find the ring",
-      tier: "1",
+      tier: 1,
       summary: "Find the ring summary",
       beats: ["start"],
-      rewards: { gp: "100" },
+      rewards: { gp: 100 },
       complications: ["orcs"],
       theme: "Ink",
     };
@@ -45,7 +45,7 @@ describe("dnd schemas", () => {
     const encounter = {
       id: "e1",
       name: "Goblin ambush",
-      level: "1",
+      level: 1,
       creatures: ["goblin"],
       tactics: "hit and run",
       terrain: "forest",

--- a/src/features/dnd/types.ts
+++ b/src/features/dnd/types.ts
@@ -31,11 +31,11 @@ export interface LoreData extends DndBase {
 }
 
 export interface QuestData extends DndBase {
-  tier: string;
+  tier: number;
   summary: string;
   beats: string[];
   rewards: {
-    gp?: string;
+    gp?: number;
     items?: string;
     favors?: string;
   };
@@ -44,7 +44,7 @@ export interface QuestData extends DndBase {
 }
 
 export interface EncounterData extends DndBase {
-  level: string;
+  level: number;
   creatures: string[];
   tactics: string;
   terrain: string;


### PR DESCRIPTION
## Summary
- switch quest tier, encounter level and reward GP to numbers
- update validation schemas and form parsing for numeric fields
- adjust tests for numeric types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f12eca5483258fe823f2c5fa5ae4