### PR TITLE
feat: add stock news fetching

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -63,6 +63,7 @@ fn main() {
             // Stocks:
             commands::stocks_fetch,
             commands::stock_forecast,
+            commands::fetch_stock_news,
             // Shorts:
             commands::load_shorts,
             commands::save_shorts,

--- a/src/store/stocks.test.ts
+++ b/src/store/stocks.test.ts
@@ -7,13 +7,13 @@ vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 describe('useStocks store', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useStocks.setState({ quotes: {}, pollers: {}, symbols: [] });
+    useStocks.setState({ quotes: {}, pollers: {}, symbols: [], news: {} });
   });
 
   afterEach(() => {
     const { pollers, stopPolling } = useStocks.getState();
     Object.keys(pollers).forEach((s) => stopPolling(s));
-    useStocks.setState({ symbols: [] });
+    useStocks.setState({ symbols: [], news: {} });
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
## Summary
- implement `fetch_stock_news` command using AlphaVantage's news endpoint
- register the command with Tauri and expose a client helper that caches per ticker
- expand stock store tests setup to handle news cache

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a509a8c5a08325aa377a1e1ac69568