### PR TITLE
feat: add harp instrument

### DIFF
--- a/src/features/lofi/SongForm.ts
+++ b/src/features/lofi/SongForm.ts
@@ -27,6 +27,7 @@ let chain: {
   kick: Tone.MembraneSynth;
   snare: Tone.NoiseSynth;
   pad: Tone.PolySynth;
+  harp: Tone.PluckSynth;
   rev: Tone.Reverb;
   voice: Tone.Player;
 } | null = null;
@@ -286,12 +287,15 @@ function init() {
   const pad = new Tone.PolySynth(Tone.Synth).connect(padFilter);
   addSend(padFilter, 0.4);
 
+  const harp = new Tone.PluckSynth().connect(master);
+  addSend(harp, 0.4);
+
   const voice = new Tone.Player();
   applyVinylEffect(voice).connect(master);
   addSend(voice, 0.3);
   scheduleSpokenWord(voice, 8);
 
-  chain = { lead, bass, hat, kick, snare, pad, rev, voice };
+  chain = { lead, bass, hat, kick, snare, pad, harp, rev, voice };
   Tone.Transport.bpm.value = 80;
 
   loop = new Tone.Loop((time) => {
@@ -317,6 +321,10 @@ function init() {
       chain.bass.triggerAttackRelease(b, '2n', time);
       const chord = chords[chordStep % chords.length];
       chain.pad.triggerAttackRelease(chord, '1m', time);
+      chord.forEach((n, i) => {
+        const harpNote = Tone.Frequency(n).transpose(12).toNote();
+        chain.harp.triggerAttackRelease(harpNote, '8n', time + i * Tone.Time('16n'));
+      });
       bassStep++;
       chordStep++;
     }

--- a/src/features/lofi/tests/SongForm.test.ts
+++ b/src/features/lofi/tests/SongForm.test.ts
@@ -27,6 +27,7 @@ describe('Song form hook', () => {
       const NoiseSynth = vi.fn().mockImplementation(() => mkSynth());
       const MembraneSynth = vi.fn().mockImplementation(() => mkSynth());
       const PolySynth = vi.fn().mockImplementation(() => mkSynth());
+      const PluckSynth = vi.fn().mockImplementation(() => mkSynth());
       const Reverb = vi.fn().mockImplementation(() => {
         const obj: any = {
           connect: vi.fn().mockReturnThis(),
@@ -75,6 +76,7 @@ describe('Song form hook', () => {
         NoiseSynth,
         MembraneSynth,
         PolySynth,
+        PluckSynth,
         Reverb,
         Volume,
         Filter,
@@ -96,6 +98,7 @@ describe('Song form hook', () => {
     const loopInstance = (tone.Loop as Mock).mock.results[0].value;
     expect(tone.start).toHaveBeenCalled();
     expect(tone.Transport.start).toHaveBeenCalled();
+    expect(tone.PluckSynth).toHaveBeenCalled();
     expect(loopInstance.start).toHaveBeenCalled();
     expect(useLofi.getState().isPlaying).toBe(true);
     useLofi.getState().stop();


### PR DESCRIPTION
## Summary
- add plucked harp instrument to lofi song form and arpeggiate chords
- mock and test new instrument in SongForm tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a570cb90f8832585e70240282086bc