### PR TITLE
feat: expand ambience selection with new ambient sounds

### DIFF
--- a/src-tauri/python/lofi_gpu_hq.py
+++ b/src-tauri/python/lofi_gpu_hq.py
@@ -1153,7 +1153,19 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60, chords=None
     # --- ambience rotation
     amb_list = motif.get("ambience") or []
     if not amb_list:
-        amb_list = rng.choice([["rain"], ["cafe"], ["rain","cafe"], ["vinyl"], ["street"]])
+        amb_list = rng.choice(
+            [
+                ["rain"],
+                ["cafe"],
+                ["rain", "cafe"],
+                ["vinyl"],
+                ["street"],
+                ["forest"],
+                ["train"],
+                ["fireplace"],
+                ["ocean"],
+            ]
+        )
 
     amb_level = float(np.clip(motif.get("ambience_level", 0.5), 0.0, 1.0))
 
@@ -1189,6 +1201,23 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60, chords=None
         tr = _load_ambience_sample("train", n, rng=rng)
         if tr is not None:
             amb_mix += tr
+    if "forest" in amb_list:
+        if "cicadas" not in amb_list:
+            ci = _load_ambience_sample("cicadas", n, rng=rng)
+            if ci is not None:
+                amb_mix += ci
+        for name in ["crickets", "forest", "wind"]:
+            f = _load_ambience_sample(name, n, rng=rng)
+            if f is not None:
+                amb_mix += f
+    if "fireplace" in amb_list:
+        fp = _load_ambience_sample("fireplace", n, rng=rng)
+        if fp is not None:
+            amb_mix += fp
+    if "ocean" in amb_list:
+        oc = _load_ambience_sample("ocean", n, rng=rng)
+        if oc is not None:
+            amb_mix += oc
 
     if "vinyl sounds" in instrs:
         amb_mix += 0.5 * _vinyl_crackle(n, density=0.0015, ticky=0.004, rng=rng)

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -139,9 +139,11 @@ describe('SongForm', () => {
     expect(screen.getByText('fantasy')).toBeInTheDocument();
   });
 
-  it('shows street ambience option', () => {
+  it('shows ambience options', () => {
     render(<SongForm />);
-    expect(screen.getByText('street')).toBeInTheDocument();
+    ['street', 'vinyl', 'forest', 'fireplace', 'ocean'].forEach((name) => {
+      expect(screen.getByText(name)).toBeInTheDocument();
+    });
   });
 
   it('passes selected instruments in spec', async () => {

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -122,7 +122,18 @@ const INSTR = [
   "field recordings",
   "synth plucks",
 ];
-const AMBI = ["rain", "cafe", "street", "birds", "cicadas", "train"];
+const AMBI = [
+  "rain",
+  "cafe",
+  "street",
+  "birds",
+  "cicadas",
+  "train",
+  "vinyl",
+  "forest",
+  "fireplace",
+  "ocean",
+];
 const LEAD_INSTR = [
   { value: "flute", label: "flute" },
   { value: "saxophone", label: "sax" },
@@ -1347,19 +1358,26 @@ export default function SongForm() {
           </div>
 
           <div style={S.panel}>
-            <label style={S.label}>Ambience</label>
-            <div style={S.optionGrid}>
+            <label style={S.label} htmlFor="ambience-select">
+              Ambience
+            </label>
+            <select
+              id="ambience-select"
+              multiple
+              value={ambience}
+              onChange={(e) =>
+                setAmbience(
+                  Array.from(e.target.selectedOptions).map((o) => o.value)
+                )
+              }
+              style={S.input}
+            >
               {AMBI.map((a) => (
-                <label key={a} style={S.optionCard}>
-                  <span>{a}</span>
-                  <input
-                    type="checkbox"
-                    checked={ambience.includes(a)}
-                    onChange={() => setAmbience((prev) => toggle(prev, a))}
-                  />
-                </label>
+                <option key={a} value={a}>
+                  {a}
+                </option>
               ))}
-            </div>
+            </select>
             <input
               type="range"
               min={0}


### PR DESCRIPTION
## Summary
- expand ambience options to include vinyl, forest, fireplace, ocean and more
- switch ambience picker to a multi-select dropdown
- support new ambience samples in audio renderer

## Testing
- `npm test`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a57f8bca808325b3fc4e27f5d26e6b