### PR TITLE
Enforce non-empty fields in DnD schemas

### DIFF
--- a/src/features/dnd/lore.schema.json
+++ b/src/features/dnd/lore.schema.json
@@ -3,11 +3,11 @@
   "type": "object",
   "required": ["id", "name", "summary", "tags"],
   "properties": {
-    "id": { "type": "string" },
-    "name": { "type": "string" },
-    "summary": { "type": "string" },
+    "id": { "type": "string", "minLength": 1 },
+    "name": { "type": "string", "minLength": 1 },
+    "summary": { "type": "string", "minLength": 1 },
     "location": { "type": "string" },
     "hooks": { "type": "array", "items": { "type": "string" } },
-    "tags": { "type": "array", "items": { "type": "string" } }
+    "tags": { "type": "array", "items": { "type": "string" }, "minItems": 1 }
   }
 }

--- a/src/features/dnd/npc.schema.json
+++ b/src/features/dnd/npc.schema.json
@@ -3,26 +3,26 @@
   "type": "object",
   "required": ["id", "name", "species", "role", "alignment", "hooks", "voice", "statblock", "tags"],
   "properties": {
-    "id": { "type": "string" },
-    "name": { "type": "string" },
-    "species": { "type": "string" },
-    "role": { "type": "string" },
-    "alignment": { "type": "string" },
+    "id": { "type": "string", "minLength": 1 },
+    "name": { "type": "string", "minLength": 1 },
+    "species": { "type": "string", "minLength": 1 },
+    "role": { "type": "string", "minLength": 1 },
+    "alignment": { "type": "string", "minLength": 1 },
     "backstory": { "type": "string" },
     "location": { "type": "string" },
-    "hooks": { "type": "array", "items": { "type": "string" } },
+    "hooks": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
     "quirks": { "type": "array", "items": { "type": "string" } },
     "voice": {
       "type": "object",
       "properties": {
-        "style": { "type": "string" },
-        "provider": { "type": "string" },
-        "preset": { "type": "string" }
+        "style": { "type": "string", "minLength": 1 },
+        "provider": { "type": "string", "minLength": 1 },
+        "preset": { "type": "string", "minLength": 1 }
       },
       "required": ["style", "provider", "preset"]
     },
     "portrait": { "type": "string" },
     "statblock": { "type": "object" },
-    "tags": { "type": "array", "items": { "type": "string" } }
+    "tags": { "type": "array", "items": { "type": "string" }, "minItems": 1 }
   }
 }

--- a/src/features/dnd/schemas.ts
+++ b/src/features/dnd/schemas.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
 export const zDndBase = z.object({
-  id: z.string(),
-  name: z.string(),
+  id: z.string().min(1),
+  name: z.string().min(1),
 });
 
 export const zDndTheme = z.enum(["Parchment", "Ink", "Minimal"]);
@@ -18,52 +18,52 @@ export const zVoice = z.object({
 });
 
 export const zNpc = z.object({
-  id: z.string(),
-  name: z.string(),
-  species: z.string(),
-  role: z.string(),
-  alignment: z.string(),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  species: z.string().min(1),
+  role: z.string().min(1),
+  alignment: z.string().min(1),
   backstory: z.string().optional(),
   location: z.string().optional(),
-  hooks: z.array(z.string()),
+  hooks: z.array(z.string()).nonempty(),
   quirks: z.array(z.string()).optional(),
   voice: zVoice,
   portrait: z.string().optional(),
   statblock: z.record(z.unknown()),
-  tags: z.array(z.string()),
+  tags: z.array(z.string()).nonempty(),
 });
 
 /**
  * Simple schema for world lore entries.
  */
 export const zLore = z.object({
-  id: z.string(),
-  name: z.string(),
-  summary: z.string(),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  summary: z.string().min(1),
   location: z.string().optional(),
   hooks: z.array(z.string()).optional(),
-  tags: z.array(z.string()),
+  tags: z.array(z.string()).nonempty(),
 });
 
 export const zQuest = zDndBase.extend({
   tier: z.number(),
-  summary: z.string(),
-  beats: z.array(z.string()),
+  summary: z.string().min(1),
+  beats: z.array(z.string()).nonempty(),
   rewards: z.object({
     gp: z.number().optional(),
     items: z.string().optional(),
     favors: z.string().optional(),
   }),
-  complications: z.array(z.string()),
+  complications: z.array(z.string()).nonempty(),
   theme: zDndTheme,
 });
 
 export const zEncounter = zDndBase.extend({
   level: z.number(),
-  creatures: z.array(z.string()),
-  tactics: z.string(),
-  terrain: z.string(),
-  treasure: z.string(),
-  scaling: z.string(),
+  creatures: z.array(z.string()).nonempty(),
+  tactics: z.string().min(1),
+  terrain: z.string().min(1),
+  treasure: z.string().min(1),
+  scaling: z.string().min(1),
   theme: zDndTheme,
 });

--- a/src/features/dnd/tests/schemas.test.ts
+++ b/src/features/dnd/tests/schemas.test.ts
@@ -46,6 +46,21 @@ describe("dnd schemas", () => {
     expect(() => zNpc.parse(npc)).toThrowError();
   });
 
+  it("rejects NPCs with empty required fields", () => {
+    const npc = {
+      id: "", // empty string
+      name: "",
+      species: "Goblinoid",
+      role: "Scout",
+      alignment: "CE",
+      hooks: [], // empty array
+      voice: { style: "gravelly", provider: "acme", preset: "goblin" },
+      statblock: {},
+      tags: ["monster"],
+    } as any;
+    expect(() => zNpc.parse(npc)).toThrowError();
+  });
+
   it("rejects NPCs with invalid hook types", () => {
     const npc = {
       id: "1",
@@ -91,6 +106,16 @@ describe("dnd schemas", () => {
     expect(() => zLore.parse(lore)).toThrowError();
   });
 
+  it("rejects Lore with empty required fields", () => {
+    const lore = {
+      id: "l1",
+      name: "",
+      summary: "",
+      tags: [],
+    };
+    expect(() => zLore.parse(lore)).toThrowError();
+  });
+
   it("parses Quest data", () => {
     const quest = {
       id: "q1",
@@ -129,6 +154,20 @@ describe("dnd schemas", () => {
       complications: ["orcs"],
       theme: "Ink",
     };
+    expect(() => zQuest.parse(quest)).toThrowError();
+  });
+
+  it("rejects Quests with empty required fields", () => {
+    const quest = {
+      id: "q1",
+      name: "Find the ring",
+      tier: 1,
+      summary: "",
+      beats: [],
+      rewards: { gp: 100 },
+      complications: [],
+      theme: "Ink",
+    } as any;
     expect(() => zQuest.parse(quest)).toThrowError();
   });
 
@@ -173,6 +212,21 @@ describe("dnd schemas", () => {
       scaling: "add more goblins",
       theme: "Minimal",
     };
+    expect(() => zEncounter.parse(encounter)).toThrowError();
+  });
+
+  it("rejects Encounters with empty required fields", () => {
+    const encounter = {
+      id: "e1",
+      name: "Goblin ambush",
+      level: 1,
+      creatures: [],
+      tactics: "",
+      terrain: "forest",
+      treasure: "gold",
+      scaling: "add more goblins",
+      theme: "Minimal",
+    } as any;
     expect(() => zEncounter.parse(encounter)).toThrowError();
   });
 });


### PR DESCRIPTION
## Summary
- ensure DnD zod schemas disallow empty strings and arrays
- mirror non-empty constraints in manual JSON schemas
- test that empty strings or arrays fail validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5d60999c883259efd55d3ce878b12