### PR TITLE
Cache stock news errors

### DIFF
--- a/src/store/stocks.test.ts
+++ b/src/store/stocks.test.ts
@@ -94,6 +94,16 @@ describe('useStocks store', () => {
     expect(invoke).not.toHaveBeenCalled();
   });
 
+  it('stores an error when news fetch fails', async () => {
+    (invoke as any).mockRejectedValue(new Error('news boom'));
+    const articles = await useStocks.getState().fetchNews('msft');
+    expect(articles).toEqual([]);
+    const entry = useStocks.getState().news['MSFT'];
+    expect(entry).toBeDefined();
+    expect(entry.articles).toEqual([]);
+    expect(entry.error).toBe('news boom');
+  });
+
   it('adds and removes symbols', () => {
     const origStart = useStocks.getState().startPolling;
     const origStop = useStocks.getState().stopPolling;

--- a/src/store/stocks.ts
+++ b/src/store/stocks.ts
@@ -31,7 +31,7 @@ interface StockState {
   quotes: Record<string, Quote>;
   pollers: Record<string, ReturnType<typeof setInterval>>;
   symbols: string[];
-  news: Record<string, { articles: NewsArticle[]; lastFetched: number }>;
+  news: Record<string, { articles: NewsArticle[]; lastFetched: number; error?: string }>;
   fetchQuote: (symbol: string) => Promise<number>;
   startPolling: (symbol: string, interval?: number) => void;
   stopPolling: (symbol: string) => void;
@@ -106,10 +106,20 @@ export const useStocks = create<StockState>((set, get) => ({
         symbol: sym,
       });
       set((state) => ({
-        news: { ...state.news, [sym]: { articles, lastFetched: Date.now() } },
+        news: {
+          ...state.news,
+          [sym]: { articles, lastFetched: Date.now(), error: undefined },
+        },
       }));
       return articles;
-    } catch {
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      set((state) => ({
+        news: {
+          ...state.news,
+          [sym]: { articles: [], lastFetched: Date.now(), error: message },
+        },
+      }));
       return [];
     }
   },


### PR DESCRIPTION
## Summary
- Add optional error field to stored news entries
- Cache empty articles and error message when news retrieval fails
- Test news error handling

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a5d5aeade88325bd5b3350dc52058a