### PR TITLE
feat: add keyboard navigation to feature carousel

### DIFF
--- a/src/components/FeatureCarousel.tsx
+++ b/src/components/FeatureCarousel.tsx
@@ -71,13 +71,29 @@ export default function FeatureCarousel({
     go(e.deltaY > 0 ? 1 : -1);
   };
 
+  // keyboard navigation: Up/Left for previous, Down/Right for next
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowUp" || e.key === "ArrowLeft") {
+      go(-1);
+    }
+    if (e.key === "ArrowDown" || e.key === "ArrowRight") {
+      go(1);
+    }
+  };
+
   // layout constants
   const GAP = 140; // distance between items
   const SCALE_MID = 1.05; // center scale
   const SCALE_SIDE = 0.7; // side scale
 
     return (
-      <Box onWheel={onWheel} sx={carouselContainerSx}>
+      <Box
+        onWheel={onWheel}
+        onKeyDown={onKeyDown}
+        tabIndex={0}
+        role="listbox"
+        sx={carouselContainerSx}
+      >
         {/* items */}
         <Box sx={carouselItemsWrapperSx}>
           {len > 0 && [-2, -1, 0, 1, 2].map((offset) => {


### PR DESCRIPTION
## Summary
- allow FeatureCarousel to receive focus and act as a listbox
- support arrow key navigation through carousel items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5fd01391c8325b4949621222120b8