### PR TITLE
Surface backend quote errors

### DIFF
--- a/src/store/stocks.test.ts
+++ b/src/store/stocks.test.ts
@@ -29,6 +29,17 @@ describe('useStocks store', () => {
     expect(invoke).toHaveBeenCalledWith('stocks_fetch', { tickers: ['AAPL'], range: '1d' });
   });
 
+  it('captures quote errors from the backend', async () => {
+    (invoke as any).mockResolvedValue({
+      quotes: [{ price: 0, change_percent: 0, status: 'CLOSED', error: 'fail' }],
+      series: [{ points: [] }],
+      market: { phase: 'CLOSED' },
+      stale: false,
+    });
+    await useStocks.getState().fetchQuote('AAPL');
+    expect(useStocks.getState().quotes['AAPL'].error).toBe('fail');
+  });
+
   it('stores an error when backend call fails', async () => {
     (invoke as any).mockRejectedValue(new Error('boom'));
     const price = await useStocks.getState().fetchQuote('AAPL');

--- a/src/store/stocks.ts
+++ b/src/store/stocks.ts
@@ -12,6 +12,7 @@ interface Quote {
   history: number[];
   marketStatus: string;
   lastFetched: number;
+  // Optional error message from backend
   error?: string;
 }
 
@@ -51,7 +52,7 @@ export const useStocks = create<StockState>((set, get) => ({
     const fetchSym = SYMBOL_MAP[sym] ?? sym;
     try {
       const bundle = await invoke<{
-        quotes: { price: number; change_percent: number; status: string }[];
+        quotes: { price: number; change_percent: number; status: string; error?: string }[];
         series: { points: { ts: number; close: number }[] }[];
         market: { phase: string };
         stale: boolean;
@@ -69,7 +70,7 @@ export const useStocks = create<StockState>((set, get) => ({
             history,
             marketStatus: market_status,
             lastFetched: Date.now(),
-            error: undefined,
+            error: quote?.error,
           },
         },
       }));


### PR DESCRIPTION
## Summary
- Add optional `error` field to quote responses
- Store backend-provided quote errors in the stock store and UI
- Test error propagation from backend to frontend

## Testing
- `npm test`
- `cd src-tauri && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fb6a119c8325ad38d38dbd0a9625