### PR TITLE
Handle HTTP errors in stock provider

### DIFF
--- a/src-tauri/src/stocks.rs
+++ b/src-tauri/src/stocks.rs
@@ -116,6 +116,13 @@ impl Provider for YahooProvider {
         );
         let start = Instant::now();
         let resp = reqwest::get(&url).await.map_err(|e| e.to_string())?;
+        if !resp.status().is_success() {
+            return Err(format!(
+                "failed to fetch quote for {}: HTTP {}",
+                ticker,
+                resp.status()
+            ));
+        }
         let size = resp.content_length().unwrap_or_default();
         let json: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
         let result = json["quoteResponse"]["result"].get(0).ok_or("no result")?;
@@ -155,6 +162,13 @@ impl Provider for YahooProvider {
         );
         let start = Instant::now();
         let resp = reqwest::get(&url).await.map_err(|e| e.to_string())?;
+        if !resp.status().is_success() {
+            return Err(format!(
+                "failed to fetch series for {}: HTTP {}",
+                ticker,
+                resp.status()
+            ));
+        }
         let size = resp.content_length().unwrap_or_default();
         let json: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
         let result = json["chart"]["result"].get(0).ok_or("no result")?;


### PR DESCRIPTION
## Summary
- Check HTTP response status in stock quote and series fetches
- Return descriptive errors when requests fail

## Testing
- `cargo test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6498e604483258e3bdae3e953a2b4