### PR TITLE
Add Bossa Nova drum pattern and preset template

### DIFF
--- a/src-tauri/python/lofi_gpu_hq.py
+++ b/src-tauri/python/lofi_gpu_hq.py
@@ -605,6 +605,7 @@ DRUM_PATTERNS = {
     "half_time":   {"kick": [(0,0.00)],           "snare":[(2,0.00)],           "hat_8ths": True},
     "swing":       {"kick": [(0,0.00), (1,0.75), (2,0.00)], "snare":[(1,0.00), (3,0.00)], "hat_8ths": True},
     "half_time_shuffle": {"kick": [(0,0.00), (3,0.50)], "snare":[(2,0.00)], "hat_8ths": True},
+    "bossa_nova":  {"kick": [(0,0.00), (1,0.50), (2,0.00), (3,0.50)], "snare":[(1,0.00), (3,0.00)], "hat_8ths": True},
     "no_drums":   {"kick": [], "snare": [], "hat_8ths": False},
 }
 

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -134,6 +134,14 @@ describe('SongForm', () => {
     expect(values).toContain('no_drums');
   });
 
+  it('offers a bossa_nova option', () => {
+    render(<SongForm />);
+    const label = screen.getByText('Drum Pattern');
+    const select = label.parentElement!.querySelector('select') as HTMLSelectElement;
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toContain('bossa_nova');
+  });
+
   it('shows fantasy mood option', () => {
     render(<SongForm />);
     expect(screen.getByText('fantasy')).toBeInTheDocument();
@@ -144,11 +152,34 @@ describe('SongForm', () => {
     expect(screen.getAllByText('Arcane Clash')[0]).toBeInTheDocument();
   });
 
+  it('shows Bossa Nova template option and applies it', () => {
+    render(<SongForm />);
+    expect(screen.getAllByText('Bossa Nova')[0]).toBeInTheDocument();
+    const select = screen.getByLabelText(/song templates/i) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'Bossa Nova' } });
+    const label = screen.getByText('Drum Pattern');
+    const drumSelect = label.parentElement!.querySelector('select') as HTMLSelectElement;
+    expect(drumSelect.value).toBe('bossa_nova');
+    const bpmSlider = screen.getAllByRole('slider')[0] as HTMLInputElement;
+    expect(bpmSlider.value).toBe('120');
+  });
+
   it('shows ambience options', () => {
     render(<SongForm />);
     ['street', 'vinyl', 'forest', 'fireplace', 'ocean'].forEach((name) => {
       expect(screen.getByText(name)).toBeInTheDocument();
     });
+  });
+
+  it('keeps preset templates when loading custom templates', () => {
+    localStorage.setItem(
+      'songTemplates',
+      JSON.stringify({ Foo: PRESET_TEMPLATES['Classic Lofi'] })
+    );
+    render(<SongForm />);
+    const select = screen.getByLabelText(/song templates/i) as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toContain('Bossa Nova');
   });
 
   it('passes selected instruments in spec', async () => {

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -154,6 +154,7 @@ const DRUM_PATS = [
   "half_time",
   "swing",
   "half_time_shuffle",
+  "bossa_nova",
 ];
 
 function inferLeadInstrument(instrs: string[]): string {
@@ -328,6 +329,29 @@ export const PRESET_TEMPLATES: Record<string, TemplateSpec> = {
     limiterDrive: 1.05,
     dither: true,
     bpmJitterPct: 6,
+  },
+  "Bossa Nova": {
+    structure: [
+      { name: "Intro", bars: 4, chords: [] },
+      { name: "A", bars: 16, chords: [] },
+      { name: "B", bars: 16, chords: [] },
+      { name: "A", bars: 16, chords: [] },
+      { name: "Outro", bars: 4, chords: [] },
+    ],
+    bpm: 120,
+    key: "Auto",
+    mood: ["calm", "cozy"],
+    instruments: ["nylon guitar", "upright bass", "piano"],
+    ambience: ["cafe"],
+    drumPattern: "bossa_nova",
+    variety: 35,
+    hqStereo: true,
+    hqReverb: true,
+    hqSidechain: true,
+    hqChorus: true,
+    limiterDrive: 1.05,
+    dither: true,
+    bpmJitterPct: 3,
   },
   "Quick Beat": {
     structure: [
@@ -1195,6 +1219,7 @@ export default function SongForm() {
             <option value="Jazz Cafe">Jazz Cafe</option>
             <option value="Midnight Drive">Midnight Drive</option>
             <option value="Rain & Coffee">Rain & Coffee</option>
+            <option value="Bossa Nova">Bossa Nova</option>
             <option value="Quick Beat">Quick Beat</option>
             <option value="Sunset Sketches">Sunset Sketches</option>
             <option value="Neon Rain">Neon Rain</option>


### PR DESCRIPTION
## Summary
- add `bossa_nova` drum pattern option and engine pattern definition
- introduce "Bossa Nova" preset template and expose in selector
- test template prefill, drum option, and persistence with stored templates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a652c3bb5c8325b37667f7743f3bac