### PR TITLE
feat: configure Alpha Vantage API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ npm test
 
 ## Configuration and optional features
 
+- **Alpha Vantage API key:** Set the `ALPHAVANTAGE_API_KEY` environment variable (or add
+  `alphavantage_api_key` to `~/.blossom/config.json`) so the app can fetch stock
+  news.
 - **Paths:** Set the ComfyUI directory in the Settings page and edit
   `conda_python()` in `src-tauri/src/commands.rs` so the app can find your Python
   interpreter.


### PR DESCRIPTION
## Summary
- read Alpha Vantage API key from `ALPHAVANTAGE_API_KEY` env or config file
- use API key when requesting stock news
- document the `ALPHAVANTAGE_API_KEY` variable

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a650da866c8325a7c559ab02a56832