### PR TITLE
Refactor stock fetch to use concurrent futures

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -373,6 +373,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "dirs 5.0.1",
+ "futures",
  "nyse-holiday-cal",
  "once_cell",
  "reqwest 0.11.27",
@@ -1306,6 +1307,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,6 +1407,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,4 +36,5 @@ async-trait = "0.1"
 chrono-tz = "0.8"
 nyse-holiday-cal = "0.2.3"
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio-rustls"] }
+futures = "0.3"
 


### PR DESCRIPTION
## Summary
- Run stock quote and series retrieval concurrently using `futures::future::join_all`
- Share provider across tasks via `Arc` and maintain caching and error handling
- Add `futures` dependency for async utilities

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: system library `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a669fd57308325bbb1199fa7b92dd6