### PR TITLE
Connect HomeChat to assistant and music workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-sql": "^2",
+        "nanoid": "^5.1.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -5510,10 +5511,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
       "funding": [
         {
           "type": "github",
@@ -5522,10 +5522,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/neo-async": {
@@ -5978,6 +5978,25 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "@react-three/fiber": "^9.3.0",
     "@tauri-apps/api": "^2.7.0",
     "@tauri-apps/plugin-dialog": "^2",
-    "@tauri-apps/plugin-sql": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-sql": "^2",
+    "nanoid": "^5.1.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
@@ -45,15 +46,15 @@
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
     "autoprefixer": "^10.4.20",
+    "handlebars": "^4.7.8",
     "jsdom": "^26.1.0",
     "postcss": "^8.4.47",
+    "puppeteer": "^23.4.1",
     "tailwindcss": "^3.4.13",
+    "tsx": "^4.19.1",
     "typescript": "~5.8.3",
     "vite": "^7.0.4",
     "vitest": "^2.0.5",
-    "tsx": "^4.19.1",
-    "zod-to-json-schema": "^3.23.5",
-    "handlebars": "^4.7.8",
-    "puppeteer": "^23.4.1"
+    "zod-to-json-schema": "^3.23.5"
   }
 }

--- a/src/components/HomeChat.test.tsx
+++ b/src/components/HomeChat.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import HomeChat from './HomeChat';
+import { invoke } from '@tauri-apps/api/core';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+describe('HomeChat', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('sends to general_chat', async () => {
+    (invoke as any).mockResolvedValue('Reply');
+    render(<HomeChat />);
+    fireEvent.change(screen.getByPlaceholderText('Ask Blossom...'), {
+      target: { value: 'Hello' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('general_chat', {
+        messages: [{ role: 'user', content: 'Hello' }],
+      });
+    });
+    expect(await screen.findByText('Reply')).toBeInTheDocument();
+  });
+
+  it('handles /music command', async () => {
+    (invoke as any).mockResolvedValue(undefined);
+    render(<HomeChat />);
+    fireEvent.change(screen.getByPlaceholderText('Ask Blossom...'), {
+      target: { value: '/music My Song' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('generate_album', {
+        meta: { track_count: 1, title_base: 'My Song' },
+      });
+    });
+    expect(
+      await screen.findByText('Started music generation for "My Song".')
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- connect HomeChat to Tauri backend using `invoke`
- add `/music` command that triggers `generate_album`
- use `nanoid` ids and auto-scroll on new messages
- test HomeChat message flow and music command

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a653bf69788325ba93875ae74075a4