### PR TITLE
feat: add dreamy mood option

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -147,6 +147,11 @@ describe('SongForm', () => {
     expect(screen.getByText('fantasy')).toBeInTheDocument();
   });
 
+  it('shows dreamy mood option', () => {
+    render(<SongForm />);
+    expect(screen.getByText('dreamy')).toBeInTheDocument();
+  });
+
   it('shows Arcane Clash template option', () => {
     render(<SongForm />);
     expect(screen.getAllByText('Arcane Clash')[0]).toBeInTheDocument();

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -83,7 +83,7 @@ const KEYS = ["Auto", ...KEYS_BASE, ...EXTRA_KEYS];
 const displayKey = (k: string) => k.replace("#", "♯").replace("b", "♭");
 const showKey = (k: SongSpec["key"]) =>
   typeof k === "string" ? displayKey(k) : displayKey(k.key + (k.mode === "minor" ? "m" : ""));
-const MOODS = ["calm", "melancholy", "cozy", "nostalgic", "fantasy"];
+const MOODS = ["calm", "melancholy", "cozy", "nostalgic", "fantasy", "dreamy"];
 const INSTR = [
   "rhodes",
   "nylon guitar",


### PR DESCRIPTION
## Summary
- allow selecting dreamy in SongForm mood list
- cover dreamy option with a unit test

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a6719b9da483258036edd7748fbd14