### PR TITLE
Prompt music options in HomeChat

### DIFF
--- a/src/components/HomeChat.test.tsx
+++ b/src/components/HomeChat.test.tsx
@@ -29,20 +29,42 @@ describe('HomeChat', () => {
     expect(await screen.findByText('Reply')).toBeInTheDocument();
   });
 
-  it('handles /music command', async () => {
-    (invoke as any).mockResolvedValue(undefined);
+  it('prompts for template and track count when missing', async () => {
     render(<HomeChat />);
     fireEvent.change(screen.getByPlaceholderText('Ask Blossom...'), {
       target: { value: '/music My Song' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send/i }));
     await waitFor(() => {
+      expect(invoke).not.toHaveBeenCalled();
+    });
+    expect(
+      await screen.findByText(/Please specify template and track count/i)
+    ).toBeInTheDocument();
+  });
+
+  it('handles /music with template and tracks', async () => {
+    (invoke as any).mockResolvedValue(undefined);
+    render(<HomeChat />);
+    fireEvent.change(screen.getByPlaceholderText('Ask Blossom...'), {
+      target: {
+        value: '/music My Song template="Classic Lofi" tracks=2',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /send/i }));
+    await waitFor(() => {
       expect(invoke).toHaveBeenCalledWith('generate_album', {
-        meta: { track_count: 1, title_base: 'My Song' },
+        meta: {
+          track_count: 2,
+          title_base: 'My Song',
+          template: 'Classic Lofi',
+        },
       });
     });
     expect(
-      await screen.findByText('Started music generation for "My Song".')
+      await screen.findByText(
+        'Started music generation for "My Song" using "Classic Lofi" with 2 tracks.'
+      )
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- require template and track count for `/music` commands in HomeChat
- list available templates and sample command when options are missing
- test prompting and successful music generation with options

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a671684ad48325aca681158a9dc157