### PR TITLE
docs: mention new preset templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ npm test
 - **Dithering:** Exported 16‑bit WAVs now include low-level triangular dither.
   Tune the noise floor with an optional `dither_amount` value in the song JSON
   (`1.0` for standard dithering, `0` to disable).
-- **Presets:** Set `"preset": "Warm Cassette"` or `"Night Drive"` in your song
-  JSON to load bundled settings from `src-tauri/python/presets.json`. Presets map
-  HQ flags, limiter drive, and wow/flutter depth so you don't have to tweak raw
-  parameters. Any value you specify in the song JSON overrides the preset.
+- **Presets:** Set `"preset": "Warm Cassette"`, `"Night Drive"`, `"Sunset VHS"`,
+  `"Neon Palms"`, or `"Night Swim"` in your song JSON to load bundled settings
+  from `src-tauri/python/presets.json`. Presets map HQ flags, limiter drive, and
+  wow/flutter depth so you don't have to tweak raw parameters. Any value you
+  specify in the song JSON overrides the preset. A new `"dreamy"` mood is also
+  available.
 


### PR DESCRIPTION
## Summary
- list Sunset VHS, Neon Palms, and Night Swim presets in README
- mention new "dreamy" mood option

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a67ed77d84832595be745746805fde