### PR TITLE
test: add bossa nova checks

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -157,9 +157,13 @@ describe('SongForm', () => {
     expect(screen.getAllByText('Arcane Clash')[0]).toBeInTheDocument();
   });
 
-  it('shows Bossa Nova template option and applies it', () => {
+  it('shows Bossa Nova template option', () => {
     render(<SongForm />);
     expect(screen.getAllByText('Bossa Nova')[0]).toBeInTheDocument();
+  });
+
+  it('applies Bossa Nova template', () => {
+    render(<SongForm />);
     const select = screen.getByLabelText(/song templates/i) as HTMLSelectElement;
     fireEvent.change(select, { target: { value: 'Bossa Nova' } });
     const label = screen.getByText('Drum Pattern');


### PR DESCRIPTION
## Summary
- test drum pattern select includes bossa_nova option
- test Bossa Nova template shows in dropdown and applies correctly

## Testing
- `npm test src/components/SongForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a67e8201f88325b202d4f3d34f40dd