### PR TITLE
Add ambience level to song templates

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -41,6 +41,7 @@ type TemplateSpec = {
   mood: string[];
   instruments: string[];
   ambience: string[];
+  ambienceLevel?: number;
   leadInstrument?: string;
   drumPattern: string;
   variety: number;
@@ -792,6 +793,7 @@ export default function SongForm() {
     setInstruments(tpl.instruments);
     setLeadInstrument(tpl.leadInstrument ?? inferLeadInstrument(tpl.instruments));
     setAmbience(tpl.ambience);
+    setAmbienceLevel(tpl.ambienceLevel ?? 0.5);
     setDrumPattern(tpl.drumPattern);
     setVariety(tpl.variety);
     setChordSpanBeats(tpl.chordSpanBeats ?? 4);
@@ -1342,6 +1344,7 @@ export default function SongForm() {
                         instruments,
                         leadInstrument,
                         ambience,
+                        ambienceLevel,
                         drumPattern,
                         variety,
                         chordSpanBeats,


### PR DESCRIPTION
## Summary
- allow SongForm templates to persist an ambience level setting
- apply template ambience level when switching templates
- store ambience level when saving a custom song template

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a67e7aa374832586a628111dc14832