### PR TITLE
Add aria-labels to calendar navigation buttons

### DIFF
--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -212,12 +212,14 @@ export default function Calendar() {
           <button
             className="p-2 rounded-lg hover:bg-gray-100"
             onClick={() => setCurrent(new Date(year, month - 1, 1))}
+            aria-label="Previous month"
           >
             <ChevronLeftIcon className="w-6 h-6" />
           </button>
           <button
             className="p-2 rounded-lg hover:bg-gray-100"
             onClick={() => setCurrent(new Date(year, month + 1, 1))}
+            aria-label="Next month"
           >
             <ChevronRightIcon className="w-6 h-6" />
           </button>


### PR DESCRIPTION
## Summary
- add "Previous month" and "Next month" labels to calendar nav arrows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a688432e8c83259b8bbacc3867f924