### PR TITLE
Add missing song templates to selector

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -1354,6 +1354,9 @@ export default function SongForm() {
             <option value="King's Last Stand">King's Last Stand</option>
             <option value="Ocean Breeze">Ocean Breeze</option>
             <option value="City Lights">City Lights</option>
+            <option value="Sunset VHS">Sunset VHS</option>
+            <option value="Neon Palms">Neon Palms</option>
+            <option value="Night Swim">Night Swim</option>
             <option value="Starlit Voyage">Starlit Voyage</option>
           </select>
         </div>


### PR DESCRIPTION
## Summary
- add "Sunset VHS", "Neon Palms", and "Night Swim" options to the SongForm template selector

## Testing
- `npm test -- src/components/SongForm.test.tsx --run`


------
https://chatgpt.com/codex/tasks/task_e_68a68be7916c83258ca305aeec8c784f