### PR TITLE
Use skeleton while stock data loads

### DIFF
--- a/src/components/StockRow.tsx
+++ b/src/components/StockRow.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useState } from "react";
-import { Box, Typography, IconButton, ListItem } from "@mui/material";
+import { Box, Typography, IconButton, ListItem, Skeleton, Fade } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import Sparkline from "./Sparkline";
 import { useStocks } from "../store/stocks";
@@ -47,16 +47,18 @@ function StockRow({ symbol }: { symbol: string }) {
                 {quote.error}
               </Typography>
             ) : (
-              <>
-                <Typography sx={{ width: 120, color }}>
-                  {quote.price.toFixed(2)} ({quote.changePercent.toFixed(2)}%)
-                </Typography>
-                <Typography sx={{ width: 80 }}>{quote.marketStatus}</Typography>
-                <Sparkline data={quote.history} color={color} />
-              </>
+              <Fade in={!!quote}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
+                  <Typography sx={{ width: 120, color }}>
+                    {quote.price.toFixed(2)} ({quote.changePercent.toFixed(2)}%)
+                  </Typography>
+                  <Typography sx={{ width: 80 }}>{quote.marketStatus}</Typography>
+                  <Sparkline data={quote.history} color={color} />
+                </Box>
+              </Fade>
             )
           ) : (
-            <Typography sx={{ width: 120 }}>...</Typography>
+            <Skeleton variant="text" width={120} />
           )}
         </Box>
         {forecast && (

--- a/src/components/__snapshots__/StockRow.test.tsx.snap
+++ b/src/components/__snapshots__/StockRow.test.tsx.snap
@@ -16,26 +16,31 @@ exports[`StockRow > renders quote data 1`] = `
         >
           AAPL
         </p>
-        <p
-          class="MuiTypography-root MuiTypography-body1 css-tsexvv-MuiTypography-root"
+        <div
+          class="MuiBox-root css-j0ozid"
+          style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         >
-          123.00 (1.00%)
-        </p>
-        <p
-          class="MuiTypography-root MuiTypography-body1 css-1019lio-MuiTypography-root"
-        >
-          OPEN
-        </p>
-        <svg
-          class="MuiBox-root css-1bayzp8"
-        >
-          <polyline
-            fill="none"
-            points="0,30 50,15 100,0"
-            stroke="#4caf50"
-            stroke-width="2"
-          />
-        </svg>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-tsexvv-MuiTypography-root"
+          >
+            123.00 (1.00%)
+          </p>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1019lio-MuiTypography-root"
+          >
+            OPEN
+          </p>
+          <svg
+            class="MuiBox-root css-1bayzp8"
+          >
+            <polyline
+              fill="none"
+              points="0,30 50,15 100,0"
+              stroke="#4caf50"
+              stroke-width="2"
+            />
+          </svg>
+        </div>
       </div>
     </div>
     <div


### PR DESCRIPTION
## Summary
- Show a Material UI `Skeleton` placeholder instead of ellipsis until stock data is available
- Fade in stock details once the quote arrives for a smoother transition

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a68c03c0988325b23847882e87970a