### PR TITLE
feat: make HomeChat movable and collapsible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "nanoid": "^5.1.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-draggable": "^4.5.0",
         "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.8.0",
@@ -6225,6 +6226,20 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "nanoid": "^5.1.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-draggable": "^4.5.0",
     "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.8.0",

--- a/src/components/HomeChat.tsx
+++ b/src/components/HomeChat.tsx
@@ -1,6 +1,9 @@
 import { useState, useRef, useEffect } from "react";
 import { Box, IconButton, Stack, TextField, Typography } from "@mui/material";
 import SendIcon from "@mui/icons-material/Send";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
+import Draggable from "react-draggable";
 import { nanoid } from "nanoid";
 import { invoke } from "@tauri-apps/api/core";
 import { PRESET_TEMPLATES } from "./SongForm";
@@ -15,6 +18,8 @@ export default function HomeChat() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
+  const [minimized, setMinimized] = useState(false);
+  const nodeRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -75,56 +80,84 @@ export default function HomeChat() {
   };
 
   return (
-    <Box
-      sx={{
-        position: "fixed",
-        bottom: 16,
-        right: 16,
-        width: 320,
-        bgcolor: "rgba(0,0,0,0.7)",
-        color: "#fff",
-        p: 2,
-        borderRadius: 2,
-        display: "flex",
-        flexDirection: "column",
-        gap: 1,
-      }}
-    >
-      <Box ref={scrollRef} sx={{ flex: 1, overflowY: "auto" }}>
-        {messages.map((m) => (
-          <Typography
-            key={m.id}
-            sx={{ mb: 1, textAlign: m.role === "user" ? "right" : "left" }}
-          >
-            {m.content}
-          </Typography>
-        ))}
-      </Box>
-      <Stack direction="row" spacing={1}>
-        <TextField
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          size="small"
-          fullWidth
-          placeholder="Ask Blossom..."
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              send();
-            }
+    <Draggable nodeRef={nodeRef} handle=".homechat-handle">
+      <Box
+        ref={nodeRef}
+        sx={{
+          position: "fixed",
+          bottom: 16,
+          right: 16,
+          width: 320,
+          bgcolor: "rgba(0,0,0,0.7)",
+          color: "#fff",
+          p: 2,
+          borderRadius: 2,
+          display: "flex",
+          flexDirection: "column",
+          gap: 1,
+        }}
+      >
+        <Box
+          className="homechat-handle"
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            cursor: "move",
           }}
-          InputProps={{ sx: { bgcolor: "#fff", borderRadius: 1 } }}
-        />
-        <IconButton
-          color="primary"
-          onClick={send}
-          disabled={loading}
-          aria-label="Send"
         >
-          <SendIcon />
-        </IconButton>
-      </Stack>
-    </Box>
+          <Typography variant="subtitle1">Chat</Typography>
+          <IconButton
+            size="small"
+            onClick={() => setMinimized((m) => !m)}
+            aria-label={minimized ? "Expand" : "Collapse"}
+          >
+            {minimized ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          </IconButton>
+        </Box>
+        {!minimized && (
+          <>
+            <Box ref={scrollRef} sx={{ flex: 1, overflowY: "auto" }}>
+              {messages.map((m) => (
+                <Typography
+                  key={m.id}
+                  sx={{
+                    mb: 1,
+                    textAlign: m.role === "user" ? "right" : "left",
+                  }}
+                >
+                  {m.content}
+                </Typography>
+              ))}
+            </Box>
+            <Stack direction="row" spacing={1}>
+              <TextField
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                size="small"
+                fullWidth
+                placeholder="Ask Blossom..."
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    send();
+                  }
+                }}
+                InputProps={{ sx: { bgcolor: "#fff", borderRadius: 1 } }}
+              />
+              <IconButton
+                color="primary"
+                onClick={send}
+                disabled={loading}
+                aria-label="Send"
+              >
+                <SendIcon />
+              </IconButton>
+            </Stack>
+          </>
+        )}
+      </Box>
+    </Draggable>
   );
 }
 


### PR DESCRIPTION
## Summary
- allow HomeChat to be dragged around the screen
- add collapse/expand toggle in chat header
- include react-draggable dependency

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a68c073c648325a47175c509f3d855