### PR TITLE
Refactor pages to Material UI and centralize theme tokens

### DIFF
--- a/src/components/AgendaView.tsx
+++ b/src/components/AgendaView.tsx
@@ -1,3 +1,4 @@
+import { Box, List, ListItem, Typography } from '@mui/material';
 import type { CalendarEvent } from "../features/calendar/types";
 
 interface Props {
@@ -10,11 +11,13 @@ export default function AgendaView({ events }: Props) {
   );
 
   return (
-    <div data-testid="agenda-view">
+    <Box data-testid="agenda-view">
       {sorted.length === 0 ? (
-        <div className="text-sm text-gray-500">No events</div>
+        <Typography variant="body2" color="text.secondary">
+          No events
+        </Typography>
       ) : (
-        <ul className="space-y-1">
+        <List dense sx={{ p: 0 }}>
           {sorted.map((ev) => {
             const start = new Date(ev.date);
             const end = new Date(ev.end);
@@ -28,14 +31,13 @@ export default function AgendaView({ events }: Props) {
               minute: "2-digit",
             });
             return (
-              <li key={ev.id} className="text-sm">
-                {`${dateStr} ${startStr} - ${endStr} ${ev.title}`}
-              </li>
+              <ListItem key={ev.id} sx={{ py: 0 }}>
+                <Typography variant="body2">{`${dateStr} ${startStr} - ${endStr} ${ev.title}`}</Typography>
+              </ListItem>
             );
           })}
-        </ul>
+        </List>
       )}
-    </div>
+    </Box>
   );
 }
-

--- a/src/components/CalendarDay.tsx
+++ b/src/components/CalendarDay.tsx
@@ -1,3 +1,4 @@
+import { Box, Typography } from '@mui/material';
 import React, { useCallback } from 'react';
 import { statusColors } from '../features/calendar/statusColors';
 import type { CalendarEvent } from '../features/calendar/types';
@@ -25,7 +26,7 @@ const CalendarDay = React.memo(
     holiday,
   }: Props) => {
     if (!day) {
-      return <div className="min-h-24 bg-gray-50" />;
+      return <Box sx={{ minHeight: 96, bgcolor: 'grey.50' }} />;
     }
 
     const handleClick = useCallback(
@@ -36,11 +37,8 @@ const CalendarDay = React.memo(
     );
 
     return (
-      <div
+      <Box
         data-testid={`day-${day}`}
-        className={`relative min-h-24 p-2 border border-gray-200 cursor-pointer transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 ${
-          isToday ? 'bg-blue-50 border-blue-300' : 'bg-white'
-        } ${isFocused ? 'ring-2 ring-blue-500' : ''}`}
         onClick={handleClick}
         onDoubleClick={() => onPrefill(day)}
         onKeyDown={(e) => e.key === 'Enter' && handleClick(e)}
@@ -49,21 +47,45 @@ const CalendarDay = React.memo(
         aria-label={`Day ${day}, ${events.length} events`}
         aria-selected={isSelected}
         aria-current={isToday ? 'date' : undefined}
+        sx={{
+          position: 'relative',
+          minHeight: 96,
+          p: 2,
+          border: '1px solid',
+          borderColor: isToday ? 'primary.light' : 'grey.200',
+          bgcolor: isToday ? 'primary.light' : 'background.paper',
+          cursor: 'pointer',
+          '&:focus': {
+            outline: 'none',
+            boxShadow: (theme) => `0 0 0 2px ${theme.palette.primary.main}`,
+          },
+        }}
       >
-        {holiday && <span className="absolute top-1 right-1 text-xs">🎉</span>}
-        <div className="font-semibold text-gray-900 mb-1">{day}</div>
-        <div className="flex gap-1 flex-wrap">
+        {holiday && (
+          <Box sx={{ position: 'absolute', top: 4, right: 4, fontSize: 12 }}>🎉</Box>
+        )}
+        <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+          {day}
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
           {events.slice(0, 3).map((ev) => (
-            <span
+            <Box
               key={ev.id}
-              className={`w-2 h-2 rounded-full ${statusColors[ev.status]}`}
+              sx={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                bgcolor: statusColors[ev.status],
+              }}
             />
           ))}
           {events.length > 3 && (
-            <span className="text-[10px] text-gray-500">+{events.length - 3}</span>
+            <Typography sx={{ fontSize: 10, color: 'text.secondary' }}>
+              +{events.length - 3}
+            </Typography>
           )}
-        </div>
-      </div>
+        </Box>
+      </Box>
     );
   }
 );

--- a/src/components/TagStats.tsx
+++ b/src/components/TagStats.tsx
@@ -1,21 +1,24 @@
-import { useCalendar } from "../features/calendar/useCalendar";
+import { List, ListItem, Typography, Paper } from '@mui/material';
+import { useCalendar } from '../features/calendar/useCalendar';
 
 export default function TagStats() {
   const { tagTotals } = useCalendar();
   const entries = Object.entries(tagTotals).sort((a, b) => b[1] - a[1]);
-
   if (entries.length === 0) return null;
-
   return (
-    <div className="bg-white rounded-lg shadow-md p-6 mt-6">
-      <h3 className="text-lg font-semibold mb-4">Tag Stats</h3>
-      <ul className="space-y-1">
+    <Paper sx={{ p: 3, mt: 6 }}>
+      <Typography variant="h6" gutterBottom>
+        Tag Stats
+      </Typography>
+      <List dense sx={{ p: 0 }}>
         {entries.map(([tag, ms]) => (
-          <li key={tag} className="text-sm text-gray-700">
-            {tag}: {(ms / (1000 * 60 * 60)).toFixed(2)}h
-          </li>
+          <ListItem key={tag} sx={{ py: 0 }}>
+            <Typography variant="body2" color="text.secondary">
+              {tag}: {(ms / (1000 * 60 * 60)).toFixed(2)}h
+            </Typography>
+          </ListItem>
         ))}
-      </ul>
-    </div>
+      </List>
+    </Paper>
   );
 }

--- a/src/components/WeekView.tsx
+++ b/src/components/WeekView.tsx
@@ -1,3 +1,4 @@
+import { Box, List, ListItem, Typography } from '@mui/material';
 import type { CalendarEvent } from "../features/calendar/types";
 
 interface Props {
@@ -35,9 +36,11 @@ export default function WeekView({ current, events }: Props) {
   });
 
   return (
-    <div data-testid="week-view">
+    <Box data-testid="week-view">
       {weekEvents.length === 0 ? (
-        <div className="text-sm text-gray-500">No events this week</div>
+        <Typography variant="body2" color="text.secondary">
+          No events this week
+        </Typography>
       ) : (
         Object.keys(grouped)
           .sort((a, b) => Number(a) - Number(b))
@@ -61,9 +64,9 @@ export default function WeekView({ current, events }: Props) {
               weekday: "long",
             });
             return (
-              <div key={day} className="mb-2">
-                <div className="font-medium">{dayName}</div>
-                <ul className="space-y-1">
+              <Box key={day} sx={{ mb: 2 }}>
+                <Typography fontWeight={500}>{dayName}</Typography>
+                <List dense sx={{ p: 0 }}>
                   {dayEvents.map((ev) => {
                     const evStart = new Date(ev.date).getTime();
                     const evEnd = new Date(ev.end).getTime();
@@ -80,17 +83,16 @@ export default function WeekView({ current, events }: Props) {
                       minute: "2-digit",
                     });
                     return (
-                      <li key={ev.id} className="text-sm">
-                        {`${displayStart} - ${displayEnd} ${ev.title}`}
-                      </li>
+                      <ListItem key={ev.id} sx={{ py: 0 }}>
+                        <Typography variant="body2">{`${displayStart} - ${displayEnd} ${ev.title}`}</Typography>
+                      </ListItem>
                     );
                   })}
-                </ul>
-              </div>
+                </List>
+              </Box>
             );
           })
       )}
-    </div>
+    </Box>
   );
 }
-

--- a/src/features/calendar/statusColors.ts
+++ b/src/features/calendar/statusColors.ts
@@ -1,8 +1,9 @@
 import type { CalendarEvent } from './types';
+import { colors } from '../../theme';
 
 export const statusColors: Record<CalendarEvent['status'], string> = {
-  scheduled: 'bg-blue-500',
-  canceled: 'bg-red-500',
-  missed: 'bg-amber-500',
-  completed: 'bg-emerald-500',
+  scheduled: colors.status.scheduled,
+  canceled: colors.status.canceled,
+  missed: colors.status.missed,
+  completed: colors.status.completed,
 };

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -8,8 +8,8 @@ import {
   ThemeProvider as MuiThemeProvider,
   CssBaseline,
   PaletteMode,
-  createTheme,
 } from "@mui/material";
+import { createAppTheme } from "../../theme";
 import { useUsers } from "../users/useUsers";
 
 export type Theme =
@@ -58,13 +58,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     document.documentElement.style.colorScheme = mode;
   }, [mode]);
 
-  const muiTheme = useMemo(
-    () =>
-      createTheme({
-        palette: { mode },
-      }),
-    [mode]
-  );
+  const muiTheme = useMemo(() => createAppTheme(mode), [mode]);
 
   return (
     <ThemeContext.Provider value={{ theme, setTheme, mode, setMode }}>

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,5 +1,19 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import {
+  Box,
+  Button,
+  ButtonGroup,
+  Checkbox,
+  FormControlLabel,
+  Grid,
+  IconButton,
+  MenuItem,
+  Paper,
+  Select,
+  TextField,
+  Typography,
+} from "@mui/material";
+import {
   ChevronLeftIcon,
   ChevronRightIcon,
   PencilIcon,
@@ -199,32 +213,28 @@ export default function Calendar() {
   }, [quickAdd, closeQuickAdd]);
 
   const agendaEvents = selectedDay ? dayEvents(selectedDay) : [];
-
   const monthNames = Array.from({ length: 12 }, (_, i) =>
     new Date(0, i).toLocaleString("default", { month: "long" })
   );
 
   return (
-    <div className="p-5 pt-20 mx-auto max-w-7xl">
-      {/* Toolbar */}
-      <div className="flex items-center justify-between mb-6 relative">
-        <div className="flex items-center space-x-2">
-          <button
-            className="p-2 rounded-lg hover:bg-gray-100"
+    <Box sx={{ p: 5, pt: 20, mx: "auto", maxWidth: 1200 }}>
+      <Box display="flex" alignItems="center" justifyContent="space-between" mb={6} position="relative">
+        <Box display="flex" alignItems="center" gap={2}>
+          <IconButton
             onClick={() => setCurrent(new Date(year, month - 1, 1))}
             aria-label="Previous month"
           >
-            <ChevronLeftIcon className="w-6 h-6" />
-          </button>
-          <button
-            className="p-2 rounded-lg hover:bg-gray-100"
+            <ChevronLeftIcon width={24} height={24} />
+          </IconButton>
+          <IconButton
             onClick={() => setCurrent(new Date(year, month + 1, 1))}
             aria-label="Next month"
           >
-            <ChevronRightIcon className="w-6 h-6" />
-          </button>
-          <button
-            className="px-3 py-1 border rounded-md"
+            <ChevronRightIcon width={24} height={24} />
+          </IconButton>
+          <Button
+            variant="outlined"
             onClick={() => {
               const now = new Date();
               setCurrent(new Date(now.getFullYear(), now.getMonth(), 1));
@@ -232,55 +242,60 @@ export default function Calendar() {
             }}
           >
             Today
-          </button>
-        </div>
-        <h2 className="text-2xl font-bold absolute left-1/2 -translate-x-1/2">
+          </Button>
+        </Box>
+        <Typography variant="h5" fontWeight={700} sx={{ position: "absolute", left: "50%", transform: "translateX(-50%)" }}>
           {current.toLocaleString("default", { month: "long" })} {year}
-        </h2>
-        <div className="flex items-center space-x-2">
-          <select
-            className="border rounded-md p-1"
+        </Typography>
+        <Box display="flex" alignItems="center" gap={2}>
+          <Select
+            size="small"
             value={month}
-            onChange={(e) =>
-              setCurrent(new Date(year, Number(e.target.value), 1))
-            }
+            onChange={(e) => setCurrent(new Date(year, Number(e.target.value), 1))}
           >
             {monthNames.map((m, i) => (
-              <option value={i} key={m}>
+              <MenuItem value={i} key={m}>
                 {m}
-              </option>
+              </MenuItem>
             ))}
-          </select>
-          <div className="inline-flex border rounded-md overflow-hidden">
+          </Select>
+          <ButtonGroup size="small">
             {(["month", "week", "agenda"] as const).map((v) => (
-              <button
+              <Button
                 key={v}
-                className={`px-3 py-1 text-sm capitalize ${
-                  view === v
-                    ? "bg-blue-600 text-white"
-                    : "bg-white"
-                }`}
+                variant={view === v ? "contained" : "outlined"}
                 onClick={() => setView(v)}
+                sx={{ textTransform: "capitalize" }}
               >
                 {v}
-              </button>
+              </Button>
             ))}
-          </div>
-        </div>
-      </div>
+          </ButtonGroup>
+        </Box>
+      </Box>
 
-      <div className="md:flex md:gap-6">
+      <Box display={{ md: "flex" }} gap={6}>
         {view === "month" ? (
           <>
-            <div className="flex-1">
-              <div className="grid grid-cols-7 gap-1 mb-8" role="grid">
+            <Box flex={1}>
+              <Box
+                role="grid"
+                sx={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(7, 1fr)",
+                  gap: 1,
+                  mb: 8,
+                }}
+              >
                 {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
-                  <div
+                  <Typography
                     key={d}
-                    className="text-center font-semibold text-gray-700 py-2"
+                    align="center"
+                    fontWeight={600}
+                    color="text.secondary"
                   >
                     {d}
-                  </div>
+                  </Typography>
                 ))}
                 {cells.map((day, idx) => (
                   <CalendarDay
@@ -301,253 +316,251 @@ export default function Calendar() {
                     }
                   />
                 ))}
-              </div>
-            </div>
+              </Box>
+            </Box>
 
-            <aside className="w-full md:w-80 space-y-6">
-              <div className="bg-white rounded-lg shadow-md p-4">
-                <h3 className="text-lg font-semibold mb-4">Agenda</h3>
+            <Box sx={{ width: { xs: "100%", md: 320 }, display: "flex", flexDirection: "column", gap: 6 }}>
+              <Paper sx={{ p: 2 }}>
+                <Typography variant="h6" gutterBottom>
+                  Agenda
+                </Typography>
                 {selectedDay == null ? (
-                  <div className="text-sm text-gray-500">Select a day</div>
+                  <Typography variant="body2" color="text.secondary">
+                    Select a day
+                  </Typography>
                 ) : agendaEvents.length === 0 ? (
-                  <div className="text-sm text-gray-500">No events yet</div>
+                  <Typography variant="body2" color="text.secondary">
+                    No events yet
+                  </Typography>
                 ) : (
-                  <ul className="space-y-1">
+                  <Box component="ul" sx={{ listStyle: "none", p: 0, m: 0 }}>
                     {agendaEvents.map((ev) => (
-                      <li key={ev.id} className="text-sm flex items-center gap-2">
-                        <span
-                          className={`px-2 py-0.5 rounded text-white text-xs ${statusColors[ev.status]}`}
+                      <Box
+                        component="li"
+                        key={ev.id}
+                        sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1 }}
+                      >
+                        <Box
+                          sx={{
+                            px: 0.5,
+                            py: 0.25,
+                            borderRadius: 1,
+                            bgcolor: statusColors[ev.status],
+                            color: "#fff",
+                            fontSize: 12,
+                          }}
                         >
                           {ev.status}
-                        </span>
-                        <span className="flex-1">{ev.title}</span>
-                        <button
-                          type="button"
+                        </Box>
+                        <Typography sx={{ flexGrow: 1, fontSize: 14 }}>
+                          {ev.title}
+                        </Typography>
+                        <IconButton
                           aria-label="Edit event"
-                          className="text-blue-500"
+                          size="small"
                           onClick={() => startEdit(ev)}
+                          sx={{ color: "primary.main" }}
                         >
-                          <PencilIcon className="w-4 h-4" />
-                        </button>
-                        <button
-                          type="button"
+                          <PencilIcon width={16} height={16} />
+                        </IconButton>
+                        <IconButton
                           aria-label="Delete event"
-                          className="text-red-500"
+                          size="small"
                           onClick={() => removeEvent(ev.id)}
+                          sx={{ color: "error.main" }}
                         >
-                          <TrashIcon className="w-4 h-4" />
-                        </button>
-                      </li>
+                          <TrashIcon width={16} height={16} />
+                        </IconButton>
+                      </Box>
                     ))}
-                  </ul>
+                  </Box>
                 )}
-              </div>
+              </Paper>
 
-              <div className="bg-white rounded-lg shadow-md p-6">
-                <h3 className="text-lg font-semibold mb-4">
+              <Paper sx={{ p: 2 }}>
+                <Typography variant="h6" gutterBottom>
                   {editingId ? "Edit Event" : "Add Event"}
-                </h3>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label
-                      htmlFor="title"
-                      className="block text-sm font-medium text-gray-700 mb-1"
-                    >
-                      Title
-                    </label>
-                    <input
+                </Typography>
+                <Grid container spacing={2}>
+                  <Grid item xs={12} md={6}>
+                    <TextField
                       id="title"
-                      type="text"
-                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
-                      placeholder="Event title..."
+                      label="Title"
+                      fullWidth
                       value={title}
                       onChange={(e) => setTitle(e.target.value)}
                     />
-                  </div>
-                  <div>
-                    <label
-                      htmlFor="start"
-                      className="block text-sm font-medium text-gray-700 mb-1"
-                    >
-                      Start Time
-                    </label>
-                    <input
+                  </Grid>
+                  <Grid item xs={12} md={6}>
+                    <TextField
                       id="start"
-                      data-testid="date-input"
                       type="datetime-local"
-                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
+                      label="Start Time"
+                      fullWidth
                       value={date}
                       onChange={(e) => setDate(e.target.value)}
+                      inputProps={{ "data-testid": "date-input" }}
+                      InputLabelProps={{ shrink: true }}
                     />
-                  </div>
-                  <div>
-                    <label
-                      htmlFor="end"
-                      className="block text-sm font-medium text-gray-700 mb-1"
-                    >
-                      End Time
-                    </label>
-                    <input
+                  </Grid>
+                  <Grid item xs={12} md={6}>
+                    <TextField
                       id="end"
-                      data-testid="end-input"
                       type="datetime-local"
-                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
+                      label="End Time"
+                      fullWidth
                       value={end}
                       onChange={(e) => setEnd(e.target.value)}
+                      inputProps={{ "data-testid": "end-input" }}
+                      InputLabelProps={{ shrink: true }}
                     />
                     {timeError && (
-                      <div
-                        className="text-red-600 text-sm mt-1"
-                        data-testid="time-error"
-                      >
+                      <Typography color="error" variant="body2" data-testid="time-error">
                         End time must be after start time
-                      </div>
+                      </Typography>
                     )}
-                  </div>
-                  <div>
-                    <label
-                      htmlFor="tags"
-                      className="block text-sm font-medium text-gray-700 mb-1"
-                    >
-                      Tags
-                    </label>
-                    <input
+                  </Grid>
+                  <Grid item xs={12} md={6}>
+                    <TextField
                       id="tags"
-                      type="text"
-                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
+                      label="Tags"
+                      fullWidth
                       placeholder="tag1, tag2"
                       value={tags}
                       onChange={(e) => setTags(e.target.value)}
                     />
-                  </div>
-                  <div>
-                    <label
-                      htmlFor="status"
-                      className="block text-sm font-medium text-gray-700 mb-1"
-                    >
-                      Status
-                    </label>
-                    <select
+                  </Grid>
+                  <Grid item xs={12} md={6}>
+                    <TextField
                       id="status"
+                      label="Status"
+                      select
+                      fullWidth
                       value={status}
                       onChange={(e) => setStatus(e.target.value as any)}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
                     >
-                      <option value="scheduled">Scheduled</option>
-                      <option value="canceled">Canceled</option>
-                      <option value="missed">Missed</option>
-                      <option value="completed">Completed</option>
-                    </select>
-                  </div>
-                  <div className="flex items-center mt-2">
-                    <input
-                      id="countdown"
-                      type="checkbox"
-                      className="h-4 w-4 text-blue-600 border-gray-300 rounded"
-                      checked={hasCountdown}
-                      onChange={(e) => setHasCountdown(e.target.checked)}
+                      <MenuItem value="scheduled">Scheduled</MenuItem>
+                      <MenuItem value="canceled">Canceled</MenuItem>
+                      <MenuItem value="missed">Missed</MenuItem>
+                      <MenuItem value="completed">Completed</MenuItem>
+                    </TextField>
+                  </Grid>
+                  <Grid item xs={12}>
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          id="countdown"
+                          checked={hasCountdown}
+                          onChange={(e) => setHasCountdown(e.target.checked)}
+                        />
+                      }
+                      label="Countdown"
                     />
-                    <label htmlFor="countdown" className="ml-2 text-sm text-gray-700">
-                      Countdown
-                    </label>
-                  </div>
-                </div>
-                <div className="flex justify-end mt-6">
-                  <button
+                  </Grid>
+                </Grid>
+                <Box display="flex" justifyContent="flex-end" mt={3}>
+                  <Button
+                    variant="contained"
                     onClick={save}
                     disabled={timeError || !title || !date || !end}
-                    className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                     data-testid="add-button"
                   >
                     {editingId ? "Update Event" : "Add Event"}
-                  </button>
-                </div>
-              </div>
+                  </Button>
+                </Box>
+              </Paper>
 
               <TagStats />
-            </aside>
+            </Box>
           </>
         ) : view === "week" ? (
           <WeekView current={current} events={events} />
         ) : (
           <AgendaView events={events} />
         )}
-      </div>
+      </Box>
 
       {view === "month" && quickAdd && (
         <>
-          <div
-            className="fixed inset-0 z-10"
+          <Box
             data-testid="quick-add-overlay"
             onClick={closeQuickAdd}
+            sx={{ position: "fixed", inset: 0, zIndex: 10 }}
           />
-          <div
-            className="absolute z-20 bg-white border rounded-lg shadow-md p-4 w-56"
+          <Paper
+            sx={{ position: "absolute", zIndex: 20, p: 2, width: 224 }}
             style={{ top: quickAdd.top, left: quickAdd.left }}
           >
-            <div className="mb-2">
+            <Box sx={{ mb: 2 }}>
               {dayEvents(quickAdd.day).length > 0 && (
-                <ul className="mb-2 space-y-1">
+                <Box component="ul" sx={{ listStyle: "none", p: 0, m: 0, mb: 2 }}>
                   {dayEvents(quickAdd.day).map((ev) => (
-                    <li
+                    <Box
+                      component="li"
                       key={ev.id}
-                      className="text-sm flex items-center gap-2"
+                      sx={{ display: "flex", alignItems: "center", gap: 1, mb: 0.5 }}
                     >
-                      <span
-                        className={`px-2 py-0.5 rounded text-white text-xs ${statusColors[ev.status]}`}
+                      <Box
+                        sx={{
+                          px: 0.5,
+                          py: 0.25,
+                          borderRadius: 1,
+                          bgcolor: statusColors[ev.status],
+                          color: "#fff",
+                          fontSize: 12,
+                        }}
                       >
                         {ev.status}
-                      </span>
-                      <button
-                        type="button"
-                        className="flex-1 text-left"
+                      </Box>
+                      <Button
                         onClick={() => startEdit(ev)}
+                        sx={{ flexGrow: 1, justifyContent: "flex-start", textTransform: "none" }}
                       >
                         {ev.title}
-                      </button>
-                    </li>
+                      </Button>
+                    </Box>
                   ))}
-                </ul>
+                </Box>
               )}
-              <input
-                ref={quickTitleRef}
+              <TextField
+                inputRef={quickTitleRef}
                 type="text"
-                className="w-full px-2 py-1 border rounded mb-2"
+                fullWidth
                 placeholder="Title"
                 value={quickTitle}
                 onChange={(e) => setQuickTitle(e.target.value)}
+                sx={{ mb: 2 }}
               />
-              <input
+              <TextField
                 type="time"
                 aria-label="Start time"
-                data-testid="quick-time"
-                className="w-full px-2 py-1 border rounded mb-2"
+                inputProps={{ "data-testid": "quick-time" }}
+                fullWidth
                 value={quickTime}
                 onChange={(e) => setQuickTime(e.target.value)}
+                sx={{ mb: 2 }}
               />
-              <select
-                aria-label="Duration"
-                data-testid="quick-duration"
-                className="w-full px-2 py-1 border rounded mb-2"
+              <TextField
+                select
+                fullWidth
                 value={quickDuration}
                 onChange={(e) => setQuickDuration(parseInt(e.target.value))}
+                SelectProps={{ native: true, inputProps: { "data-testid": "quick-duration" } }}
+                sx={{ mb: 2 }}
               >
                 <option value={30}>30m</option>
                 <option value={60}>1h</option>
                 <option value={90}>1h 30m</option>
                 <option value={120}>2h</option>
-              </select>
-              <button
-                className="w-full bg-blue-600 text-white py-1 rounded"
-                onClick={addQuick}
-              >
+              </TextField>
+              <Button fullWidth variant="contained" onClick={addQuick}>
                 Add
-              </button>
-            </div>
-          </div>
+              </Button>
+            </Box>
+          </Paper>
         </>
       )}
-    </div>
+    </Box>
   );
 }
 
@@ -598,4 +611,3 @@ function useKeyboardNavigation(
 
   return { focusedDay, setFocusedDay };
 }
-

--- a/src/pages/WorldBuilder.tsx
+++ b/src/pages/WorldBuilder.tsx
@@ -29,7 +29,7 @@ export default function WorldBuilder() {
               {w}
             </Button>
             <IconButton onClick={() => removeWorld(w)}>
-              <TrashIcon className="h-5 w-5" />
+              <TrashIcon width={20} height={20} />
             </IconButton>
           </Stack>
         ))}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,27 @@
+import { createTheme, PaletteMode } from '@mui/material/styles';
+
+export const colors = {
+  primary: '#1976d2',
+  secondary: '#9c27b0',
+  background: '#f5f5f5',
+  surface: '#ffffff',
+  status: {
+    scheduled: '#1976d2',
+    canceled: '#d32f2f',
+    missed: '#ed6c02',
+    completed: '#2e7d32',
+  },
+};
+
+export const spacing = 8;
+
+export const createAppTheme = (mode: PaletteMode) =>
+  createTheme({
+    palette: {
+      mode,
+      primary: { main: colors.primary },
+      secondary: { main: colors.secondary },
+      background: { default: colors.background, paper: colors.surface },
+    },
+    spacing,
+  });


### PR DESCRIPTION
## Summary
- adopt Material UI as the primary styling system with shared color & spacing tokens
- refactor calendar and supporting components from Tailwind to MUI primitives
- clean up world builder icon styling

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a68ead323c8325b643e349f4a7f53f