### PR TITLE
Use local naive ISO for calendar events

### DIFF
--- a/src/components/WeekView.test.tsx
+++ b/src/components/WeekView.test.tsx
@@ -4,15 +4,15 @@ import WeekView from './WeekView';
 import type { CalendarEvent } from '../features/calendar/types';
 
 describe('WeekView', () => {
-  const current = new Date('2024-05-15T12:00:00Z');
+  const current = new Date('2024-05-15T12:00');
 
   it('includes events that overlap the week', () => {
     const events: CalendarEvent[] = [
       {
         id: '1',
         title: 'Weekend',
-        date: '2024-05-11T23:00:00Z',
-        end: '2024-05-12T01:00:00Z',
+        date: '2024-05-11T23:00',
+        end: '2024-05-12T01:00',
         tags: [],
         status: 'scheduled',
         hasCountdown: false,
@@ -31,8 +31,8 @@ describe('WeekView', () => {
       {
         id: '2',
         title: 'Overnight',
-        date: '2024-05-13T23:00:00Z',
-        end: '2024-05-14T01:00:00Z',
+        date: '2024-05-13T23:00',
+        end: '2024-05-14T01:00',
         tags: [],
         status: 'scheduled',
         hasCountdown: false,

--- a/src/features/calendar/tests/Countdown.test.tsx
+++ b/src/features/calendar/tests/Countdown.test.tsx
@@ -7,7 +7,7 @@ describe('Countdown', () => {
   it('counts down until due', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2024-01-01T00:00:00'));
-    const target = new Date('2024-01-01T00:00:03').toISOString();
+    const target = '2024-01-01T00:00:03';
     render(<Countdown target={target} />);
     expect(screen.getByText('0d 0h 0m 3s')).toBeInTheDocument();
     act(() => {

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -26,6 +26,7 @@ import AgendaView from "../components/AgendaView";
 import { useCalendar } from "../features/calendar/useCalendar";
 import { statusColors } from "../features/calendar/statusColors";
 import type { CalendarEvent } from "../features/calendar/types";
+import { toLocalNaive } from "../utils/time";
 
 function pad(n: number) {
   return n.toString().padStart(2, "0");
@@ -192,8 +193,8 @@ export default function Calendar() {
     const endTime = new Date(start.getTime() + quickDuration * 60000);
     addEvent({
       title: quickTitle,
-      date: start.toISOString(),
-      end: endTime.toISOString(),
+      date: toLocalNaive(start),
+      end: toLocalNaive(endTime),
       tags: [],
       status: "scheduled",
       hasCountdown: false,

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,8 @@
+export function toLocalNaive(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}


### PR DESCRIPTION
## Summary
- store calendar quick-add times in naive local ISO format
- add `toLocalNaive` utility for local datetime strings
- update calendar tests to expect local times

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a6d102603883259d7793eb26f06b87