### PR TITLE
Add galaxy theme with animated background

### DIFF
--- a/public/galaxy.svg
+++ b/public/galaxy.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice">
+  <rect width="100" height="100" fill="#000"/>
+  <g transform="translate(50 50)">
+    <g stroke="#8fd6ff" stroke-width="2" fill="none" stroke-linecap="round">
+      <path d="M0 0 C20 -5 30 -15 40 -30"/>
+      <path d="M0 0 C20 -5 30 -15 40 -30" transform="rotate(90)"/>
+      <path d="M0 0 C20 -5 30 -15 40 -30" transform="rotate(180)"/>
+      <path d="M0 0 C20 -5 30 -15 40 -30" transform="rotate(270)"/>
+    </g>
+    <circle r="3" fill="#fff"/>
+    <animateTransform attributeName="transform" attributeType="XML" type="rotate" from="0" to="360" dur="60s" repeatCount="indefinite"/>
+  </g>
+</svg>

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -202,6 +202,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               <MenuItem value="sunset">Sunset</MenuItem>
               <MenuItem value="sakura">Sakura</MenuItem>
               <MenuItem value="studio">Studio</MenuItem>
+              <MenuItem value="galaxy">Galaxy</MenuItem>
             </Select>
           </FormControl>
           <FormControlLabel

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -18,7 +18,8 @@ export type Theme =
   | "forest"
   | "sunset"
   | "sakura"
-  | "studio";
+  | "studio"
+  | "galaxy";
 
 interface ThemeContextType {
   theme: Theme;
@@ -49,6 +50,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       "theme-sunset",
       "theme-sakura",
       "theme-studio",
+      "theme-galaxy",
     ];
     document.body.classList.remove(...classes);
     document.body.classList.add(`theme-${theme}`);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -22,6 +22,8 @@ export default function Home() {
     forest: "rgba(0,255,150,0.22)",
     sunset: "rgba(255,150,0,0.22)",
     sakura: "rgba(255,150,200,0.22)",
+    studio: "rgba(0,255,255,0.22)",
+    galaxy: "rgba(150,200,255,0.22)",
   };
   const [hoverColor, setHoverColor] = useState(themeColors[theme]);
   useEffect(() => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -32,6 +32,10 @@ body.theme-studio {
   background: #000;
 }
 
+body.theme-galaxy {
+  background: #000 url("/galaxy.svg") center / cover no-repeat;
+}
+
 body.theme-studio button,
 body.theme-studio input,
 body.theme-studio select {


### PR DESCRIPTION
## Summary
- add a "galaxy" theme with an animated SVG background
- expose the theme in settings and hover colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d1732ef08325bf98839d88e2d5da