### PR TITLE
Add PDF ingestion pipeline with local LLM and UI trigger

### DIFF
--- a/scripts/validate-dnd.ts
+++ b/scripts/validate-dnd.ts
@@ -1,0 +1,23 @@
+import { zNpc, zLore, zQuest } from "../src/features/dnd/schemas";
+
+const schemas: Record<string, any> = {
+  npc: zNpc,
+  lore: zLore,
+  quest: zQuest,
+};
+
+const [, , kind, jsonStr] = process.argv;
+
+if (!kind || !(kind in schemas)) {
+  console.error("unknown schema type");
+  process.exit(1);
+}
+
+try {
+  const data = JSON.parse(jsonStr || "{}");
+  const parsed = schemas[kind as keyof typeof schemas].parse(data);
+  process.stdout.write(JSON.stringify(parsed));
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -380,6 +380,12 @@ pub async fn pdf_search<R: Runtime>(
     serde_json::from_value(v["results"].clone()).map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+pub async fn pdf_ingest<R: Runtime>(app: AppHandle<R>, doc_id: String) -> Result<Value, String> {
+    let out = run_pdf_tool(&app, &["ingest", &doc_id])?;
+    serde_json::from_str(&out).map_err(|e| e.to_string())
+}
+
 /* ==============================
 Serde-mapped types (camelCase)
 ============================== */

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -54,6 +54,7 @@ fn main() {
             commands::pdf_remove,
             commands::pdf_list,
             commands::pdf_search,
+            commands::pdf_ingest,
             // Blender:
             commands::blender_run_script,
             commands::save_npc,

--- a/src/features/docs/UploadPdf.tsx
+++ b/src/features/docs/UploadPdf.tsx
@@ -1,0 +1,15 @@
+import { open } from "@tauri-apps/plugin-dialog";
+import { useDocs } from "./useDocs";
+
+export function UploadPdf() {
+  const { addDoc } = useDocs();
+
+  async function handleClick() {
+    const selected = await open({ filters: [{ name: "PDF", extensions: ["pdf"] }] });
+    if (typeof selected === "string") {
+      await addDoc(selected, true);
+    }
+  }
+
+  return <button onClick={handleClick}>Upload PDF</button>;
+}

--- a/src/features/docs/useDocs.ts
+++ b/src/features/docs/useDocs.ts
@@ -24,9 +24,17 @@ export function useDocs() {
     refresh();
   }, []);
 
-  async function addDoc(path: string) {
-    await invoke("pdf_add", { path });
+  async function ingestDoc(docId: string) {
+    await invoke("pdf_ingest", { docId });
+  }
+
+  async function addDoc(path: string, ingest = false) {
+    const meta = await invoke<DocMeta>("pdf_add", { path });
+    if (ingest) {
+      await ingestDoc(meta.doc_id);
+    }
     refresh();
+    return meta;
   }
 
   async function removeDoc(docId: string) {
@@ -38,7 +46,7 @@ export function useDocs() {
     return invoke("pdf_search", { query });
   }
 
-  return { docs, refresh, addDoc, removeDoc, searchDocs };
+  return { docs, refresh, addDoc, removeDoc, searchDocs, ingestDoc };
 }
 
 export type { DocMeta };


### PR DESCRIPTION
## Summary
- Extend Python PDF tools with ingestion that calls a local LLM, validates output with zod schemas, and saves entries
- Expose new `pdf_ingest` Tauri command and React hooks/component to trigger ingestion from the UI
- Add TypeScript script for schema validation

## Testing
- `npm run reindex`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a76c91e4b083259dec88ec7c01e787