### PR TITLE
feat: replace JSON prints with structured logging

### DIFF
--- a/src-tauri/python/tests/test_determinism.py
+++ b/src-tauri/python/tests/test_determinism.py
@@ -1,6 +1,7 @@
 import hashlib
 import os
 import sys
+import logging
 import numpy as np
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import lofi_gpu_hq  # noqa: E402
@@ -10,7 +11,8 @@ EXPECTED_RMS = 0.165903
 EXPECTED_HASH = "82fdd90872a6d191afc972db5890d113a419fa53c9239d7970063d64d1e3ad90"
 
 
-def test_deterministic_render():
+def test_deterministic_render(caplog):
+    caplog.set_level(logging.DEBUG)
     spec = {
         "title": "test",
         "bpm": 80,
@@ -23,6 +25,9 @@ def test_deterministic_render():
         "instruments": ["piano"],
     }
     audio, _ = lofi_gpu_hq.render_from_spec(spec)
+    assert any(
+        isinstance(r.msg, dict) and r.msg.get("stage") == "debug" for r in caplog.records
+    )
     samples = np.array(audio.get_array_of_samples()).astype(np.int16)
     rms = np.sqrt(np.mean((samples / 32768.0) ** 2))
     buf_hash = hashlib.sha256(samples.tobytes()).hexdigest()


### PR DESCRIPTION
## Summary
- switch lofi_gpu_hq Python logging to JSON-formatted logging
- add configurable `--log-level` CLI argument
- adjust tests to capture debug logs via `caplog`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a76dbed914832585214f928f7268a8