### PR TITLE
Add system info page and widget

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -778,6 +779,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2080,7 +2100,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2730,6 +2750,15 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num-bigint-dig"
@@ -3692,6 +3721,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -4779,6 +4828,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4845,8 +4909,8 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]
@@ -4916,7 +4980,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5057,7 +5121,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.12",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -5099,7 +5163,7 @@ dependencies = [
  "tauri-utils",
  "thiserror 2.0.12",
  "url",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5125,7 +5189,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -6022,8 +6086,8 @@ checksum = "d4ba622a989277ef3886dd5afb3e280e3dd6d974b766118950a08f8f678ad6a4"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
 ]
@@ -6046,8 +6110,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36695906a1b53a3bf5c4289621efedac12b73eeb0b89e7e1a89b517302d5d75c"
 dependencies = [
  "thiserror 2.0.12",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6119,12 +6183,22 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link",
  "windows-numerics",
@@ -6136,7 +6210,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6158,7 +6241,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link",
  "windows-threading",
 ]
@@ -6197,7 +6280,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link",
 ]
 
@@ -6622,8 +6705,8 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,4 +39,5 @@ chrono-tz = "0.8"
 nyse-holiday-cal = "0.2.3"
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio-rustls"] }
 futures = "0.3"
+sysinfo = "0.30"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -69,6 +69,7 @@ fn main() {
             commands::load_shorts,
             commands::save_shorts,
             commands::generate_short,
+            commands::system_info,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import DND from "./pages/DND";
 import Stocks from "./pages/Stocks";
 import Shorts from "./pages/Shorts";
 import User from "./pages/User";
+import SystemInfo from "./pages/SystemInfo";
 
 export default function App() {
   return (
@@ -39,6 +40,7 @@ export default function App() {
         <Route path="/lofi" element={<Lofi />} />
         <Route path="/stocks" element={<Stocks />} />
         <Route path="/shorts" element={<Shorts />} />
+        <Route path="/system" element={<SystemInfo />} />
         <Route path="/dnd" element={<DND />} />
         <Route path="/user" element={<User />} />
         <Route path="*" element={<NotFound />} />

--- a/src/components/SystemInfoWidget.tsx
+++ b/src/components/SystemInfoWidget.tsx
@@ -1,0 +1,46 @@
+import { Box } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+import { useSystemInfo } from "../features/system/useSystemInfo";
+import { Theme, useTheme } from "../features/theme/ThemeContext";
+
+const themeColors: Record<Theme, string> = {
+  default: "rgba(255,255,255,0.22)",
+  ocean: "rgba(0,150,255,0.22)",
+  forest: "rgba(0,255,150,0.22)",
+  sunset: "rgba(255,150,0,0.22)",
+  sakura: "rgba(255,150,200,0.22)",
+  studio: "rgba(0,255,255,0.22)",
+  galaxy: "rgba(150,200,255,0.22)",
+};
+
+export default function SystemInfoWidget() {
+  const info = useSystemInfo();
+  const { theme } = useTheme();
+  const nav = useNavigate();
+
+  return (
+    <Box
+      onClick={() => nav("/system")}
+      sx={{
+        backgroundColor: themeColors[theme],
+        color: "#fff",
+        px: 2,
+        py: 1,
+        borderRadius: "0.5rem",
+        fontSize: "0.875rem",
+        cursor: "pointer",
+        minWidth: "8rem",
+      }}
+    >
+      {info ? (
+        <>
+          <div>CPU: {Math.round(info.cpu_usage)}%</div>
+          {info.gpu_usage !== null && <div>GPU: {Math.round(info.gpu_usage)}%</div>}
+          <div>Mem: {Math.round(info.mem_usage)}%</div>
+        </>
+      ) : (
+        <div>Loading...</div>
+      )}
+    </Box>
+  );
+}

--- a/src/features/system/useSystemInfo.ts
+++ b/src/features/system/useSystemInfo.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export interface SystemInfo {
+  cpu_usage: number;
+  mem_usage: number;
+  gpu_usage: number | null;
+}
+
+export function useSystemInfo() {
+  const [info, setInfo] = useState<SystemInfo | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    const fetchInfo = async () => {
+      try {
+        const data = await invoke<SystemInfo>("system_info");
+        if (mounted) setInfo(data);
+      } catch {
+        // ignore errors
+      }
+    };
+    fetchInfo();
+    const id = setInterval(fetchInfo, 5000);
+    return () => {
+      mounted = false;
+      clearInterval(id);
+    };
+  }, []);
+
+  return info;
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,10 +8,12 @@ import FeatureNav from "../components/FeatureNav";
 import VersionBadge from "../components/VersionBadge";
 import { Theme, useTheme } from "../features/theme/ThemeContext";
 import HomeChat from "../components/HomeChat";
+import SystemInfoWidget from "../components/SystemInfoWidget";
 import {
   countdownContainerSx,
   countdownTextSx,
   versionBadgeContainerSx,
+  systemInfoWidgetSx,
 } from "./homeStyles";
 
 export default function Home() {
@@ -62,6 +64,11 @@ export default function Home() {
 
       {/* Floating chat box */}
       <HomeChat />
+
+      {/* System info widget */}
+      <Box sx={systemInfoWidgetSx}>
+        <SystemInfoWidget />
+      </Box>
     </>
   );
 }

--- a/src/pages/SystemInfo.tsx
+++ b/src/pages/SystemInfo.tsx
@@ -1,0 +1,49 @@
+import { Box, Typography } from "@mui/material";
+import { useSystemInfo } from "../features/system/useSystemInfo";
+import { Theme, useTheme } from "../features/theme/ThemeContext";
+
+const themeColors: Record<Theme, string> = {
+  default: "rgba(255,255,255,0.22)",
+  ocean: "rgba(0,150,255,0.22)",
+  forest: "rgba(0,255,150,0.22)",
+  sunset: "rgba(255,150,0,0.22)",
+  sakura: "rgba(255,150,200,0.22)",
+  studio: "rgba(0,255,255,0.22)",
+  galaxy: "rgba(150,200,255,0.22)",
+};
+
+export default function SystemInfo() {
+  const info = useSystemInfo();
+  const { theme } = useTheme();
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        height: "100vh",
+        color: "#fff",
+        backgroundColor: themeColors[theme],
+        textAlign: "center",
+        p: 4,
+      }}
+    >
+      <Typography variant="h4" gutterBottom>
+        System Info
+      </Typography>
+      {info ? (
+        <>
+          <Typography>CPU Usage: {info.cpu_usage.toFixed(1)}%</Typography>
+          {info.gpu_usage !== null && (
+            <Typography>GPU Usage: {info.gpu_usage.toFixed(1)}%</Typography>
+          )}
+          <Typography>Memory Usage: {info.mem_usage.toFixed(1)}%</Typography>
+        </>
+      ) : (
+        <Typography>Loading...</Typography>
+      )}
+    </Box>
+  );
+}

--- a/src/pages/homeStyles.ts
+++ b/src/pages/homeStyles.ts
@@ -23,3 +23,10 @@ export const versionBadgeContainerSx: SxProps<Theme> = {
   textAlign: "center",
   color: "#fff",
 };
+
+export const systemInfoWidgetSx: SxProps<Theme> = {
+  position: "absolute",
+  bottom: { xs: "1rem", sm: "1.5rem" },
+  left: { xs: "1rem", sm: "1.5rem" },
+  zIndex: 50,
+};


### PR DESCRIPTION
## Summary
- add Tauri `system_info` command using `sysinfo` and `nvidia-smi`
- add reusable hook and widget to display CPU/GPU/memory stats
- expose dedicated System Info page and home widget with theme-aware styling

## Testing
- `npm test`
- `cargo check` *(fails: type annotations needed for `Arc` and sized `SeriesPoint` values in `src/stocks.rs`)*

------
https://chatgpt.com/codex/tasks/task_e_68a76d14161c8325bfd1267a51ca2d55