### PR TITLE
feat: add glockenspiel and oboe instruments

### DIFF
--- a/src-tauri/python/data/instruments.json
+++ b/src-tauri/python/data/instruments.json
@@ -47,6 +47,8 @@
     "muted trumpet",
     "clarinet",
     "field recordings",
-    "synth plucks"
+    "synth plucks",
+    "glockenspiel",
+    "oboe"
   ]
 }

--- a/src-tauri/python/lofi_gpu_hq.py
+++ b/src-tauri/python/lofi_gpu_hq.py
@@ -1031,9 +1031,11 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60, chords=None
         "pan flute",
         "vibraphone",
         "celesta",
+        "glockenspiel",
         "muted electric guitar",
         "synth plucks",
         "wurlitzer",
+        "oboe",
     }
     add_rhodes_default = not any(src in instrs for src in melodic_sources)
 

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -123,11 +123,13 @@ const INSTR = [
   "wurlitzer",
   "celesta",
   "music box",
+  "glockenspiel",
   "vibraphone",
   "marimba",
   "muted electric guitar",
   "muted trumpet",
   "clarinet",
+  "oboe",
   "field recordings",
   "synth plucks",
   "timpani",
@@ -152,7 +154,9 @@ const LEAD_INSTR = [
   { value: "synth lead", label: "synth" },
   { value: "violin", label: "violin" },
   { value: "clarinet", label: "clarinet" },
+  { value: "oboe", label: "oboe" },
   { value: "muted trumpet", label: "muted trumpet" },
+  { value: "glockenspiel", label: "glockenspiel" },
 ];
 const DRUM_PATS = [
   "random",
@@ -171,7 +175,9 @@ function inferLeadInstrument(instrs: string[]): string {
   if (instrs.includes("saxophone")) return "saxophone";
   if (instrs.includes("violin")) return "violin";
   if (instrs.includes("clarinet")) return "clarinet";
+  if (instrs.includes("oboe")) return "oboe";
   if (instrs.includes("muted trumpet")) return "muted trumpet";
+  if (instrs.includes("glockenspiel")) return "glockenspiel";
   if (instrs.includes("synth lead")) return "synth lead";
   return "synth lead";
 }


### PR DESCRIPTION
## Summary
- add glockenspiel and oboe to instrument options and metadata
- allow selection as lead instruments and infer lead automatically
- treat glockenspiel and oboe as melodic sources in Python renderer

## Testing
- `npm test`
- `pytest` *(fails: ffmpeg not found; please install ffmpeg and ensure it is on PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68a76d6cba2083259dd98a460bb59cd4