### PR TITLE
Add noir theme with neon flicker styling

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -203,6 +203,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               <MenuItem value="sakura">Sakura</MenuItem>
               <MenuItem value="studio">Studio</MenuItem>
               <MenuItem value="galaxy">Galaxy</MenuItem>
+              <MenuItem value="noir">Noir</MenuItem>
             </Select>
           </FormControl>
           <FormControlLabel

--- a/src/components/SystemInfoWidget.tsx
+++ b/src/components/SystemInfoWidget.tsx
@@ -11,6 +11,7 @@ const themeColors: Record<Theme, string> = {
   sakura: "rgba(255,150,200,0.22)",
   studio: "rgba(0,255,255,0.22)",
   galaxy: "rgba(150,200,255,0.22)",
+  noir: "rgba(255,0,255,0.22)",
 };
 
 export default function SystemInfoWidget() {

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -19,7 +19,8 @@ export type Theme =
   | "sunset"
   | "sakura"
   | "studio"
-  | "galaxy";
+  | "galaxy"
+  | "noir";
 
 interface ThemeContextType {
   theme: Theme;
@@ -51,6 +52,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       "theme-sakura",
       "theme-studio",
       "theme-galaxy",
+      "theme-noir",
     ];
     document.body.classList.remove(...classes);
     document.body.classList.add(`theme-${theme}`);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -26,6 +26,7 @@ export default function Home() {
     sakura: "rgba(255,150,200,0.22)",
     studio: "rgba(0,255,255,0.22)",
     galaxy: "rgba(150,200,255,0.22)",
+    noir: "rgba(255,0,255,0.22)",
   };
   const [hoverColor, setHoverColor] = useState(themeColors[theme]);
   useEffect(() => {

--- a/src/pages/SystemInfo.tsx
+++ b/src/pages/SystemInfo.tsx
@@ -10,6 +10,7 @@ const themeColors: Record<Theme, string> = {
   sakura: "rgba(255,150,200,0.22)",
   studio: "rgba(0,255,255,0.22)",
   galaxy: "rgba(150,200,255,0.22)",
+  noir: "rgba(255,0,255,0.22)",
 };
 
 export default function SystemInfo() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -36,6 +36,37 @@ body.theme-galaxy {
   background: #000 url("/galaxy.svg") center / cover no-repeat;
 }
 
+body.theme-noir {
+  background: #1a1a1a;
+}
+
+@keyframes neon-flicker {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.9;
+  }
+  60% {
+    opacity: 0.95;
+  }
+  70% {
+    opacity: 0.85;
+  }
+}
+
+body.theme-noir .neon-text {
+  color: #0ff;
+  text-shadow: 0 0 5px rgba(0, 255, 255, 0.7);
+  animation: neon-flicker 1.5s infinite alternate;
+}
+
+body.theme-noir .neon-accent {
+  border-color: #0ff;
+  box-shadow: 0 0 6px rgba(0, 255, 255, 0.7);
+  animation: neon-flicker 1.5s infinite alternate;
+}
+
 body.theme-studio button,
 body.theme-studio input,
 body.theme-studio select {


### PR DESCRIPTION
## Summary
- add "noir" option to theme system and settings
- introduce deep-charcoal noir background with neon flicker accents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a773a99dcc83258d8d7d026b0e427e