### PR TITLE
Add noir theme and neon flicker

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -203,6 +203,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               <MenuItem value="sakura">Sakura</MenuItem>
               <MenuItem value="studio">Studio</MenuItem>
               <MenuItem value="galaxy">Galaxy</MenuItem>
+              <MenuItem value="noir">Noir</MenuItem>
               <MenuItem value="aurora">Aurora</MenuItem>
             </Select>
           </FormControl>

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -20,6 +20,7 @@ export type Theme =
   | "sakura"
   | "studio"
   | "galaxy"
+  | "noir"
   | "aurora";
 
 interface ThemeContextType {
@@ -52,6 +53,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       "theme-sakura",
       "theme-studio",
       "theme-galaxy",
+      "theme-noir",
       "theme-aurora",
     ];
     document.body.classList.remove(...classes);

--- a/src/styles.css
+++ b/src/styles.css
@@ -42,6 +42,10 @@ body.theme-galaxy {
   background: #000 url("/galaxy.svg") center / cover no-repeat;
 }
 
+body.theme-noir {
+  background: #1a1a1a;
+}
+
 body.theme-studio button,
 body.theme-studio input,
 body.theme-studio select {
@@ -75,4 +79,25 @@ body.theme-studio input[type="range"]::-moz-range-thumb {
   100% {
     background-position: 0% 50%;
   }
+}
+
+@keyframes neonFlicker {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.8;
+  }
+}
+
+.neon-text {
+  color: #0ff;
+  text-shadow: 0 0 4px #0ff, 0 0 8px #0ff;
+  animation: neonFlicker 1.5s infinite alternate;
+}
+
+.neon-accent {
+  border-color: #0ff;
+  box-shadow: 0 0 4px #0ff, 0 0 8px #0ff;
+  animation: neonFlicker 1.5s infinite alternate;
 }


### PR DESCRIPTION
## Summary
- include new `noir` option in theme definitions and settings
- style `body.theme-noir` with deep charcoal background
- introduce neon flicker animation and helper classes for accent effects

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a776ad7b8883258888e94905a212f9