### PR TITLE
Show placeholder when no tag stats

### DIFF
--- a/src/components/TagStats.tsx
+++ b/src/components/TagStats.tsx
@@ -4,21 +4,24 @@ import { useCalendar } from '../features/calendar/useCalendar';
 export default function TagStats() {
   const { tagTotals } = useCalendar();
   const entries = Object.entries(tagTotals).sort((a, b) => b[1] - a[1]);
-  if (entries.length === 0) return null;
   return (
     <Paper sx={{ p: 3, mt: 6 }}>
       <Typography variant="h6" gutterBottom>
         Tag Stats
       </Typography>
-      <List dense sx={{ p: 0 }}>
-        {entries.map(([tag, ms]) => (
-          <ListItem key={tag} sx={{ py: 0 }}>
-            <Typography variant="body2" color="text.secondary">
-              {tag}: {(ms / (1000 * 60 * 60)).toFixed(2)}h
-            </Typography>
-          </ListItem>
-        ))}
-      </List>
+      {entries.length === 0 ? (
+        <Typography>No tags yet</Typography>
+      ) : (
+        <List dense sx={{ p: 0 }}>
+          {entries.map(([tag, ms]) => (
+            <ListItem key={tag} sx={{ py: 0 }}>
+              <Typography variant="body2" color="text.secondary">
+                {tag}: {(ms / (1000 * 60 * 60)).toFixed(2)}h
+              </Typography>
+            </ListItem>
+          ))}
+        </List>
+      )}
     </Paper>
   );
 }


### PR DESCRIPTION
## Summary
- Show "No tags yet" inside TagStats when no tag totals exist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a76d1dd2fc8325aa0dd91259d3cdb0