### PR TITLE
feat: add rainy theme

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -205,6 +205,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               <MenuItem value="galaxy">Galaxy</MenuItem>
               <MenuItem value="noir">Noir</MenuItem>
               <MenuItem value="aurora">Aurora</MenuItem>
+              <MenuItem value="rainy">Rainy</MenuItem>
             </Select>
           </FormControl>
           <FormControlLabel

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -21,7 +21,8 @@ export type Theme =
   | "studio"
   | "galaxy"
   | "noir"
-  | "aurora";
+  | "aurora"
+  | "rainy";
 
 interface ThemeContextType {
   theme: Theme;
@@ -55,6 +56,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       "theme-galaxy",
       "theme-noir",
       "theme-aurora",
+      "theme-rainy",
     ];
     document.body.classList.remove(...classes);
     document.body.classList.add(`theme-${theme}`);

--- a/src/styles.css
+++ b/src/styles.css
@@ -46,6 +46,28 @@ body.theme-noir {
   background: #1a1a1a;
 }
 
+body.theme-rainy {
+  background: radial-gradient(circle at center, #0a1e3d, #081229);
+  overflow: hidden;
+}
+
+body.theme-rainy::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.4) 50%,
+    rgba(255, 255, 255, 0) 50%
+  );
+  background-size: 2px 10px;
+  animation: rain 0.5s linear infinite;
+}
+
 body.theme-studio button,
 body.theme-studio input,
 body.theme-studio select {
@@ -78,6 +100,15 @@ body.theme-studio input[type="range"]::-moz-range-thumb {
   }
   100% {
     background-position: 0% 50%;
+  }
+}
+
+@keyframes rain {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 0 10px;
   }
 }
 


### PR DESCRIPTION
## Summary
- add "rainy" theme option to ThemeContext and settings
- style rainy theme with dark blue background and animated raindrops

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a786f6d8f88325b258cd7377d89d99