### PR TITLE
feat: add retro theme

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -203,6 +203,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               <MenuItem value="sakura">Sakura</MenuItem>
               <MenuItem value="studio">Studio</MenuItem>
               <MenuItem value="galaxy">Galaxy</MenuItem>
+              <MenuItem value="retro">Retro</MenuItem>
               <MenuItem value="noir">Noir</MenuItem>
               <MenuItem value="aurora">Aurora</MenuItem>
               <MenuItem value="rainy">Rainy</MenuItem>

--- a/src/components/SystemInfoWidget.tsx
+++ b/src/components/SystemInfoWidget.tsx
@@ -11,6 +11,7 @@ const themeColors: Record<Theme, string> = {
   sakura: "rgba(255,150,200,0.22)",
   studio: "rgba(0,255,255,0.22)",
   galaxy: "rgba(150,200,255,0.22)",
+  retro: "rgba(0,255,0,0.22)",
 };
 
 export default function SystemInfoWidget() {

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -20,6 +20,7 @@ export type Theme =
   | "sakura"
   | "studio"
   | "galaxy"
+  | "retro"
   | "noir"
   | "aurora"
   | "rainy";
@@ -54,6 +55,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       "theme-sakura",
       "theme-studio",
       "theme-galaxy",
+      "theme-retro",
       "theme-noir",
       "theme-aurora",
       "theme-rainy",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -26,6 +26,7 @@ export default function Home() {
     sakura: "rgba(255,150,200,0.22)",
     studio: "rgba(0,255,255,0.22)",
     galaxy: "rgba(150,200,255,0.22)",
+    retro: "rgba(0,255,0,0.22)",
   };
   const [hoverColor, setHoverColor] = useState(themeColors[theme]);
   useEffect(() => {

--- a/src/pages/SystemInfo.tsx
+++ b/src/pages/SystemInfo.tsx
@@ -10,6 +10,7 @@ const themeColors: Record<Theme, string> = {
   sakura: "rgba(255,150,200,0.22)",
   studio: "rgba(0,255,255,0.22)",
   galaxy: "rgba(150,200,255,0.22)",
+  retro: "rgba(0,255,0,0.22)",
 };
 
 export default function SystemInfo() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -42,6 +42,12 @@ body.theme-galaxy {
   background: #000 url("/galaxy.svg") center / cover no-repeat;
 }
 
+body.theme-retro {
+  background: #000;
+  color: #0f0;
+  font-family: "Courier New", monospace;
+}
+
 body.theme-noir {
   background: #1a1a1a;
 }
@@ -75,6 +81,15 @@ body.theme-studio select {
   color: #0ff;
   border: 1px solid #0ff;
   box-shadow: 0 0 6px rgba(0, 255, 255, 0.7);
+}
+
+body.theme-retro button,
+body.theme-retro input,
+body.theme-retro select,
+body.theme-retro textarea {
+  background: #000;
+  color: #0f0;
+  border: 1px solid #0f0;
 }
 
 body.theme-studio button:hover,


### PR DESCRIPTION
## Summary
- add retro theme option to ThemeContext and settings drawer
- style theme-retro with green-on-black monospace styling
- wire retro theme color into system info components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78ed45994832586be81fc3f79e9c4