### PR TITLE
Add mono theme option

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -206,6 +206,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               <MenuItem value="noir">Noir</MenuItem>
               <MenuItem value="aurora">Aurora</MenuItem>
               <MenuItem value="rainy">Rainy</MenuItem>
+              <MenuItem value="mono">Mono</MenuItem>
             </Select>
           </FormControl>
           <FormControlLabel

--- a/src/components/SystemInfoWidget.tsx
+++ b/src/components/SystemInfoWidget.tsx
@@ -11,6 +11,10 @@ const themeColors: Record<Theme, string> = {
   sakura: "rgba(255,150,200,0.22)",
   studio: "rgba(0,255,255,0.22)",
   galaxy: "rgba(150,200,255,0.22)",
+  noir: "rgba(255,255,255,0.15)",
+  aurora: "rgba(0,255,200,0.22)",
+  rainy: "rgba(0,100,200,0.22)",
+  mono: "rgba(128,128,128,0.22)",
 };
 
 export default function SystemInfoWidget() {

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -22,7 +22,8 @@ export type Theme =
   | "galaxy"
   | "noir"
   | "aurora"
-  | "rainy";
+  | "rainy"
+  | "mono";
 
 interface ThemeContextType {
   theme: Theme;
@@ -57,6 +58,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       "theme-noir",
       "theme-aurora",
       "theme-rainy",
+      "theme-mono",
     ];
     document.body.classList.remove(...classes);
     document.body.classList.add(`theme-${theme}`);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -26,6 +26,10 @@ export default function Home() {
     sakura: "rgba(255,150,200,0.22)",
     studio: "rgba(0,255,255,0.22)",
     galaxy: "rgba(150,200,255,0.22)",
+    noir: "rgba(255,255,255,0.15)",
+    aurora: "rgba(0,255,200,0.22)",
+    rainy: "rgba(0,100,200,0.22)",
+    mono: "rgba(128,128,128,0.22)",
   };
   const [hoverColor, setHoverColor] = useState(themeColors[theme]);
   useEffect(() => {

--- a/src/pages/SystemInfo.tsx
+++ b/src/pages/SystemInfo.tsx
@@ -10,6 +10,10 @@ const themeColors: Record<Theme, string> = {
   sakura: "rgba(255,150,200,0.22)",
   studio: "rgba(0,255,255,0.22)",
   galaxy: "rgba(150,200,255,0.22)",
+  noir: "rgba(255,255,255,0.15)",
+  aurora: "rgba(0,255,200,0.22)",
+  rainy: "rgba(0,100,200,0.22)",
+  mono: "rgba(128,128,128,0.22)",
 };
 
 export default function SystemInfo() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -46,6 +46,11 @@ body.theme-noir {
   background: #1a1a1a;
 }
 
+body.theme-mono {
+  background: #000;
+  color: #fff;
+}
+
 body.theme-rainy {
   background: radial-gradient(circle at center, #0a1e3d, #081229);
   overflow: hidden;
@@ -89,6 +94,20 @@ body.theme-studio input[type="range"]::-webkit-slider-thumb {
 
 body.theme-studio input[type="range"]::-moz-range-thumb {
   box-shadow: 0 0 10px #0ff;
+}
+
+body.theme-mono button,
+body.theme-mono input,
+body.theme-mono select {
+  background: #fff;
+  color: #000;
+  border: 1px solid #888;
+}
+
+body.theme-mono button:hover,
+body.theme-mono input:hover,
+body.theme-mono select:hover {
+  background: #e5e5e5;
 }
 
 @keyframes auroraShift {


### PR DESCRIPTION
## Summary
- add `mono` to theme union and include in settings selection
- style `theme-mono` with black/white/gray palette for body and form controls
- extend theme color mappings to support `mono`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a78ebdd9c883258dfe58519efb9c56