### PR TITLE
Add monochrome theme option

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -207,6 +207,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               <MenuItem value="noir">Noir</MenuItem>
               <MenuItem value="aurora">Aurora</MenuItem>
               <MenuItem value="rainy">Rainy</MenuItem>
+              <MenuItem value="mono">Mono</MenuItem>
             </Select>
           </FormControl>
           <FormControlLabel

--- a/src/components/SystemInfoWidget.tsx
+++ b/src/components/SystemInfoWidget.tsx
@@ -12,6 +12,7 @@ const themeColors: Record<Theme, string> = {
   studio: "rgba(0,255,255,0.22)",
   galaxy: "rgba(150,200,255,0.22)",
   retro: "rgba(0,255,0,0.22)",
+  mono: "rgba(128,128,128,0.22)",
 };
 
 export default function SystemInfoWidget() {

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -23,7 +23,8 @@ export type Theme =
   | "retro"
   | "noir"
   | "aurora"
-  | "rainy";
+  | "rainy"
+  | "mono";
 
 interface ThemeContextType {
   theme: Theme;
@@ -59,6 +60,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       "theme-noir",
       "theme-aurora",
       "theme-rainy",
+      "theme-mono",
     ];
     document.body.classList.remove(...classes);
     document.body.classList.add(`theme-${theme}`);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -27,6 +27,7 @@ export default function Home() {
     studio: "rgba(0,255,255,0.22)",
     galaxy: "rgba(150,200,255,0.22)",
     retro: "rgba(0,255,0,0.22)",
+    mono: "rgba(128,128,128,0.22)",
   };
   const [hoverColor, setHoverColor] = useState(themeColors[theme]);
   useEffect(() => {

--- a/src/pages/SystemInfo.tsx
+++ b/src/pages/SystemInfo.tsx
@@ -11,6 +11,7 @@ const themeColors: Record<Theme, string> = {
   studio: "rgba(0,255,255,0.22)",
   galaxy: "rgba(150,200,255,0.22)",
   retro: "rgba(0,255,0,0.22)",
+  mono: "rgba(128,128,128,0.22)",
 };
 
 export default function SystemInfo() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -52,6 +52,11 @@ body.theme-noir {
   background: #1a1a1a;
 }
 
+body.theme-mono {
+  background: #000;
+  color: #fff;
+}
+
 body.theme-rainy {
   background: radial-gradient(circle at center, #0a1e3d, #081229);
   overflow: hidden;
@@ -90,6 +95,22 @@ body.theme-retro textarea {
   background: #000;
   color: #0f0;
   border: 1px solid #0f0;
+}
+
+body.theme-mono button,
+body.theme-mono input,
+body.theme-mono select,
+body.theme-mono textarea {
+  background: #fff;
+  color: #000;
+  border: 1px solid #888;
+}
+
+body.theme-mono button:hover,
+body.theme-mono input:hover,
+body.theme-mono select:hover,
+body.theme-mono textarea:hover {
+  background: #eee;
 }
 
 body.theme-studio button:hover,


### PR DESCRIPTION
## Summary
- add `mono` theme to ThemeContext union and class list
- expose Mono theme in settings drawer select
- style `.theme-mono` with a black/white/gray palette and adjust form controls
- include Mono in system info color maps

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a7939c50ec8325bf78e846a157b6f7