### PR TITLE
feat: add pastel theme option

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -207,6 +207,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               <MenuItem value="noir">Noir</MenuItem>
               <MenuItem value="aurora">Aurora</MenuItem>
               <MenuItem value="rainy">Rainy</MenuItem>
+              <MenuItem value="pastel">Pastel</MenuItem>
               <MenuItem value="mono">Mono</MenuItem>
             </Select>
           </FormControl>

--- a/src/components/SystemInfoWidget.tsx
+++ b/src/components/SystemInfoWidget.tsx
@@ -12,6 +12,10 @@ const themeColors: Record<Theme, string> = {
   studio: "rgba(0,255,255,0.22)",
   galaxy: "rgba(150,200,255,0.22)",
   retro: "rgba(0,255,0,0.22)",
+  noir: "rgba(50,50,50,0.22)",
+  aurora: "rgba(150,255,210,0.22)",
+  rainy: "rgba(0,120,255,0.22)",
+  pastel: "rgba(255,182,193,0.22)",
   mono: "rgba(128,128,128,0.22)",
 };
 

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -24,6 +24,7 @@ export type Theme =
   | "noir"
   | "aurora"
   | "rainy"
+  | "pastel"
   | "mono";
 
 interface ThemeContextType {
@@ -60,6 +61,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       "theme-noir",
       "theme-aurora",
       "theme-rainy",
+      "theme-pastel",
       "theme-mono",
     ];
     document.body.classList.remove(...classes);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -27,6 +27,10 @@ export default function Home() {
     studio: "rgba(0,255,255,0.22)",
     galaxy: "rgba(150,200,255,0.22)",
     retro: "rgba(0,255,0,0.22)",
+    noir: "rgba(50,50,50,0.22)",
+    aurora: "rgba(150,255,210,0.22)",
+    rainy: "rgba(0,120,255,0.22)",
+    pastel: "rgba(255,182,193,0.22)",
     mono: "rgba(128,128,128,0.22)",
   };
   const [hoverColor, setHoverColor] = useState(themeColors[theme]);

--- a/src/pages/SystemInfo.tsx
+++ b/src/pages/SystemInfo.tsx
@@ -11,6 +11,10 @@ const themeColors: Record<Theme, string> = {
   studio: "rgba(0,255,255,0.22)",
   galaxy: "rgba(150,200,255,0.22)",
   retro: "rgba(0,255,0,0.22)",
+  noir: "rgba(50,50,50,0.22)",
+  aurora: "rgba(150,255,210,0.22)",
+  rainy: "rgba(0,120,255,0.22)",
+  pastel: "rgba(255,182,193,0.22)",
   mono: "rgba(128,128,128,0.22)",
 };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -57,6 +57,10 @@ body.theme-mono {
   color: #fff;
 }
 
+body.theme-pastel {
+  background: radial-gradient(circle at center, #ffe4e1, #e0e7ff, #e8ffe8);
+}
+
 body.theme-rainy {
   background: radial-gradient(circle at center, #0a1e3d, #081229);
   overflow: hidden;
@@ -111,6 +115,22 @@ body.theme-mono input:hover,
 body.theme-mono select:hover,
 body.theme-mono textarea:hover {
   background: #eee;
+}
+
+body.theme-pastel button,
+body.theme-pastel input,
+body.theme-pastel select,
+body.theme-pastel textarea {
+  background: rgba(255, 255, 255, 0.85);
+  color: #555;
+  border: 1px solid #d8bfd8;
+}
+
+body.theme-pastel button:hover,
+body.theme-pastel input:hover,
+body.theme-pastel select:hover,
+body.theme-pastel textarea:hover {
+  background: rgba(255, 255, 255, 0.9);
 }
 
 body.theme-studio button:hover,


### PR DESCRIPTION
## Summary
- add "pastel" to available themes and update settings selection
- style `body.theme-pastel` with multi-pastel radial gradient and muted UI colors
- extend theme color mappings for system info and home components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7c0a6408c83258d1be87aa640c7e6