### PR TITLE
refactor: modularize SongForm controls

### DIFF
--- a/src/components/BatchActions.tsx
+++ b/src/components/BatchActions.tsx
@@ -1,0 +1,131 @@
+import React from "react";
+import HelpIcon from "./HelpIcon";
+
+interface Props {
+  S: Record<string, React.CSSProperties>;
+  numSongs: number;
+  setNumSongs: (val: number) => void;
+  titleSuffixMode: string;
+  setTitleSuffixMode: (val: string) => void;
+  bpmJitterPct: number;
+  setBpmJitterPct: (val: number) => void;
+  playLast: boolean;
+  setPlayLast: (val: boolean) => void;
+  busy: boolean;
+  outDir: string;
+  titleBase: string;
+  hasInvalidBars: boolean;
+  albumMode: boolean;
+  onRender: () => void;
+  previewPlaying: boolean;
+  onPreview: () => Promise<void> | void;
+  isPlaying: boolean;
+  onPlayLastTrack: () => Promise<void> | void;
+}
+
+export default function BatchActions({
+  S,
+  numSongs,
+  setNumSongs,
+  titleSuffixMode,
+  setTitleSuffixMode,
+  bpmJitterPct,
+  setBpmJitterPct,
+  playLast,
+  setPlayLast,
+  busy,
+  outDir,
+  titleBase,
+  hasInvalidBars,
+  albumMode,
+  onRender,
+  previewPlaying,
+  onPreview,
+  isPlaying,
+  onPlayLastTrack,
+}: Props) {
+  return (
+    <>
+      <div style={S.grid2}>
+        <div style={S.panel}>
+          <label style={S.label}>
+            How many songs?
+            <HelpIcon text="Number of songs to render in this batch" />
+          </label>
+          <input
+            type="number"
+            min={1}
+            value={numSongs}
+            onChange={(e) => setNumSongs(Math.max(1, Number(e.target.value || 1)))}
+            style={S.input}
+          />
+          <div style={{ ...S.small, marginTop: 8 }}>
+            Titles will be suffixed with{" "}
+            <select
+              value={titleSuffixMode}
+              onChange={(e) => setTitleSuffixMode(e.target.value)}
+              style={{
+                ...S.input,
+                padding: "4px 8px",
+                display: "inline-block",
+                width: 160,
+                marginLeft: 6,
+              }}
+            >
+              <option value="number"># (1, 2, 3…)</option>
+              <option value="timestamp">timestamp</option>
+            </select>
+          </div>
+        </div>
+
+        <div style={S.panel}>
+          <label style={S.label}>
+            BPM Jitter (per song)
+            <HelpIcon text="Random tempo variation around base BPM" />
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={30}
+            value={bpmJitterPct}
+            onChange={(e) => setBpmJitterPct(Number(e.target.value))}
+            style={S.slider}
+          />
+          <div style={S.small}>±{bpmJitterPct}% around the base BPM</div>
+          <div style={{ ...S.toggle, marginTop: 8 }}>
+            <input
+              type="checkbox"
+              checked={playLast}
+              onChange={(e) => setPlayLast(e.target.checked)}
+            />
+            <span style={S.small}>Auto‑play last successful render</span>
+          </div>
+        </div>
+      </div>
+
+      <div style={S.actions}>
+        <button
+          style={S.btn}
+          disabled={busy || !outDir || !titleBase || hasInvalidBars}
+          onClick={onRender}
+        >
+          {albumMode
+            ? busy
+              ? "Creating album…"
+              : "Create Album"
+            : busy
+            ? "Rendering batch…"
+            : "Render Songs"}
+        </button>
+
+        <button style={S.playBtn} onClick={onPreview}>
+          {previewPlaying ? "Stop preview" : "Preview in browser"}
+        </button>
+
+        <button style={S.playBtn} onClick={onPlayLastTrack}>
+          {isPlaying ? "Pause" : "Play last track"}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/components/HelpIcon.tsx
+++ b/src/components/HelpIcon.tsx
@@ -1,0 +1,10 @@
+import { FaQuestionCircle } from "react-icons/fa";
+
+export default function HelpIcon({ text }: { text: string }) {
+  return (
+    <FaQuestionCircle
+      title={text}
+      style={{ marginLeft: 4, cursor: "help", opacity: 0.6 }}
+    />
+  );
+}

--- a/src/components/PolishControls.tsx
+++ b/src/components/PolishControls.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import HelpIcon from "./HelpIcon";
+
+interface Props {
+  S: Record<string, React.CSSProperties>;
+  hqStereo: boolean;
+  setHqStereo: (val: boolean) => void;
+  hqReverb: boolean;
+  setHqReverb: (val: boolean) => void;
+  hqSidechain: boolean;
+  setHqSidechain: (val: boolean) => void;
+  hqChorus: boolean;
+  setHqChorus: (val: boolean) => void;
+  limiterDrive: number;
+  setLimiterDrive: (val: number) => void;
+  dither: boolean;
+  setDither: (val: boolean) => void;
+}
+
+export default function PolishControls({
+  S,
+  hqStereo,
+  setHqStereo,
+  hqReverb,
+  setHqReverb,
+  hqSidechain,
+  setHqSidechain,
+  hqChorus,
+  setHqChorus,
+  limiterDrive,
+  setLimiterDrive,
+  dither,
+  setDither,
+}: Props) {
+  return (
+    <div style={{ ...S.panel, marginTop: 12 }}>
+      <details open>
+        <summary style={{ cursor: "pointer", fontSize: 12, opacity: 0.8 }}>
+          Polish <HelpIcon text="Optional mix polish effects" />
+        </summary>
+        <div style={{ marginTop: 8 }}>
+          <div style={S.optionGrid}>
+            <label style={S.optionCard}>
+              <span>Stereo widen</span>
+              <input
+                type="checkbox"
+                checked={hqStereo}
+                onChange={(e) => setHqStereo(e.target.checked)}
+              />
+            </label>
+            <label style={S.optionCard}>
+              <span>Room reverb</span>
+              <input
+                type="checkbox"
+                checked={hqReverb}
+                onChange={(e) => setHqReverb(e.target.checked)}
+              />
+            </label>
+            <label style={S.optionCard}>
+              <span>Sidechain (kick)</span>
+              <input
+                type="checkbox"
+                checked={hqSidechain}
+                onChange={(e) => setHqSidechain(e.target.checked)}
+              />
+            </label>
+            <label style={S.optionCard}>
+              <span>Chorus</span>
+              <input
+                type="checkbox"
+                checked={hqChorus}
+                onChange={(e) => setHqChorus(e.target.checked)}
+              />
+            </label>
+          </div>
+          <details style={{ marginTop: 8 }}>
+            <summary style={{ cursor: "pointer", fontSize: 12, opacity: 0.8 }}>
+              Advanced
+            </summary>
+            <div style={{ marginTop: 8 }}>
+              <label style={S.label}>
+                Limiter Drive
+                <HelpIcon text="Amount of saturation added by the limiter" />
+              </label>
+              <input
+                type="range"
+                min={0.5}
+                max={2}
+                step={0.01}
+                value={limiterDrive}
+                onChange={(e) => setLimiterDrive(Number(e.target.value))}
+                style={S.slider}
+              />
+              <div style={S.small}>{limiterDrive.toFixed(2)}× saturation</div>
+              <div style={{ ...S.toggle, marginTop: 8 }}>
+                <input
+                  type="checkbox"
+                  checked={dither}
+                  onChange={(e) => setDither(e.target.checked)}
+                />
+                <span style={S.small}>Dither</span>
+              </div>
+            </div>
+          </details>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/src/components/RhythmControls.tsx
+++ b/src/components/RhythmControls.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import HelpIcon from "./HelpIcon";
+
+interface Props {
+  S: Record<string, React.CSSProperties>;
+  DRUM_PATS: string[];
+  drumPattern: string;
+  setDrumPattern: (val: string) => void;
+  variety: number;
+  setVariety: (val: number) => void;
+  chordSpanBeats: number;
+  setChordSpanBeats: (val: number) => void;
+}
+
+export default function RhythmControls({
+  S,
+  DRUM_PATS,
+  drumPattern,
+  setDrumPattern,
+  variety,
+  setVariety,
+  chordSpanBeats,
+  setChordSpanBeats,
+}: Props) {
+  return (
+    <div style={S.grid3}>
+      <div style={S.panel}>
+        <label style={S.label}>
+          Drum Pattern
+          <HelpIcon text="Choose a groove style or no drums" />
+        </label>
+        <select
+          value={drumPattern}
+          onChange={(e) => setDrumPattern(e.target.value)}
+          style={{ ...S.input, padding: "8px 12px" }}
+        >
+          {DRUM_PATS.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <div style={S.small}>Choose a groove or leave random.</div>
+      </div>
+
+      <div style={S.panel}>
+        <label style={S.label}>
+          Variety
+          <HelpIcon text="Amount of fills and swing" />
+        </label>
+        <input
+          type="range"
+          min={0}
+          max={100}
+          value={variety}
+          onChange={(e) => setVariety(Number(e.target.value))}
+          style={S.slider}
+        />
+        <div style={S.small}>{variety}% fills & swing</div>
+      </div>
+
+      <div style={S.panel}>
+        <label style={S.label}>
+          Chord Span
+          <HelpIcon text="Number of beats each chord lasts" />
+        </label>
+        <select
+          value={chordSpanBeats}
+          onChange={(e) => setChordSpanBeats(Number(e.target.value))}
+          style={{ ...S.input, padding: "8px 12px" }}
+        >
+          <option value={2}>½ bar</option>
+          <option value={4}>1 bar</option>
+          <option value={8}>2 bars</option>
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TemplateSelector.tsx
+++ b/src/components/TemplateSelector.tsx
@@ -1,0 +1,47 @@
+import HelpIcon from "./HelpIcon";
+import type { TemplateSpec } from "./SongForm";
+import React from "react";
+
+interface Props {
+  S: Record<string, React.CSSProperties>;
+  templates: Record<string, TemplateSpec>;
+  selectedTemplate: string;
+  setSelectedTemplate: (name: string) => void;
+  applyTemplate: (tpl: TemplateSpec) => void;
+}
+
+export default function TemplateSelector({
+  S,
+  templates,
+  selectedTemplate,
+  setSelectedTemplate,
+  applyTemplate,
+}: Props) {
+  return (
+    <div style={S.panel}>
+      <label style={S.label}>
+        Song Templates
+        <HelpIcon text="Select a preset arrangement and settings" />
+      </label>
+      <select
+        aria-label="Song Templates"
+        value={selectedTemplate}
+        onChange={(e) => {
+          const templateName = e.target.value;
+          setSelectedTemplate(templateName);
+          if (templateName && templates[templateName]) {
+            applyTemplate(templates[templateName]);
+          }
+        }}
+        style={{ ...S.input, padding: "8px 12px" }}
+      >
+        <option value="">Custom Structure</option>
+        {Object.keys(templates).map((name) => (
+          <option key={name} value={name}>
+            {name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/VibeControls.tsx
+++ b/src/components/VibeControls.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import HelpIcon from "./HelpIcon";
+
+interface Props {
+  S: Record<string, React.CSSProperties>;
+  MOODS: string[];
+  INSTR: string[];
+  LEAD_INSTR: { value: string; label: string }[];
+  AMBI: string[];
+  mood: string[];
+  setMood: (updater: (prev: string[]) => string[]) => void;
+  instruments: string[];
+  setInstruments: (updater: (prev: string[]) => string[]) => void;
+  leadInstrument: string;
+  setLeadInstrument: (val: string) => void;
+  ambience: string[];
+  setAmbience: (vals: string[]) => void;
+  ambienceLevel: number;
+  setAmbienceLevel: (val: number) => void;
+}
+
+function toggle(list: string[], val: string) {
+  return list.includes(val) ? list.filter((x) => x !== val) : [...list, val];
+}
+
+export default function VibeControls({
+  S,
+  MOODS,
+  INSTR,
+  LEAD_INSTR,
+  AMBI,
+  mood,
+  setMood,
+  instruments,
+  setInstruments,
+  leadInstrument,
+  setLeadInstrument,
+  ambience,
+  setAmbience,
+  ambienceLevel,
+  setAmbienceLevel,
+}: Props) {
+  return (
+    <div style={S.grid3}>
+      <div style={S.panel}>
+        <label style={S.label}>
+          Mood
+          <HelpIcon text="Tags describing the vibe" />
+        </label>
+        <div style={S.optionGrid}>
+          {MOODS.map((m) => (
+            <label key={m} style={S.optionCard}>
+              <span>{m}</span>
+              <input
+                type="checkbox"
+                checked={mood.includes(m)}
+                onChange={() => setMood((prev) => toggle(prev, m))}
+              />
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div style={S.panel}>
+        <label style={S.label}>
+          Instruments
+          <HelpIcon text="Select instruments to include" />
+        </label>
+        <div style={S.optionGrid}>
+          {INSTR.map((i) => (
+            <label key={i} style={S.optionCard}>
+              <span>{i}</span>
+              <input
+                type="checkbox"
+                checked={instruments.includes(i)}
+                onChange={() => setInstruments((prev) => toggle(prev, i))}
+              />
+            </label>
+          ))}
+        </div>
+        <div style={S.small}>Drums are synthesized automatically.</div>
+      </div>
+
+      <div style={S.panel}>
+        <label style={S.label}>
+          Lead Instrument
+          <HelpIcon text="Main instrument for the melody" />
+        </label>
+        <div style={S.optionGrid}>
+          {LEAD_INSTR.map((l) => (
+            <label key={l.value} style={S.optionCard}>
+              <span>{l.label}</span>
+              <input
+                type="radio"
+                name="leadInstrument"
+                value={l.value}
+                checked={leadInstrument === l.value}
+                onChange={() => setLeadInstrument(l.value)}
+              />
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div style={S.panel}>
+        <label style={S.label} htmlFor="ambience-select">
+          Ambience
+          <HelpIcon text="Background ambience sounds" />
+        </label>
+        <select
+          id="ambience-select"
+          multiple
+          value={ambience}
+          onChange={(e) =>
+            setAmbience(Array.from(e.target.selectedOptions).map((o) => o.value))
+          }
+          style={S.input}
+        >
+          {AMBI.map((a) => (
+            <option key={a} value={a}>
+              {a}
+            </option>
+          ))}
+        </select>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={ambienceLevel}
+          onChange={(e) => setAmbienceLevel(Number(e.target.value))}
+          style={S.slider}
+        />
+        <div style={S.small}>{Math.round(ambienceLevel * 100)}% intensity</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extract TemplateSelector, VibeControls, RhythmControls, PolishControls, and BatchActions into their own components
- wire SongForm to use new subcomponents and shared HelpIcon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7c0cffa4c832587d028f6bd957bc9