### PR TITLE
Add task list component

### DIFF
--- a/src/components/TaskQueue/TaskList.tsx
+++ b/src/components/TaskQueue/TaskList.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from "react";
+import { Box, Button, LinearProgress, Typography } from "@mui/material";
+import { useTasks } from "../../store/tasks";
+import { useSystemInfo } from "../../features/system/useSystemInfo";
+
+export default function TaskList() {
+  const { tasks, cancelTask, subscribe } = useTasks();
+  const info = useSystemInfo();
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    subscribe().then((u) => {
+      unlisten = u;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, [subscribe]);
+
+  const entries = Object.values(tasks);
+
+  const cpuWarn = info && info.cpu_usage > 80;
+  const memWarn = info && info.mem_usage > 80;
+
+  if (entries.length === 0 && !info) return null;
+
+  return (
+    <Box sx={{ mt: 2, p: 2, border: "1px solid #ccc", borderRadius: 1 }}>
+      {info && (
+        <Typography
+          variant="caption"
+          sx={{
+            display: "block",
+            mb: 1,
+            color: cpuWarn || memWarn ? "error.main" : "text.primary",
+          }}
+        >
+          CPU {Math.round(info.cpu_usage)}% · Mem {Math.round(info.mem_usage)}%
+        </Typography>
+      )}
+      {entries.length === 0 ? (
+        <Typography variant="body2">No active tasks</Typography>
+      ) : (
+        entries.map((task) => (
+          <Box key={task.id} sx={{ mb: 1 }}>
+            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+              {task.label}
+            </Typography>
+            <LinearProgress
+              variant="determinate"
+              value={task.progress}
+              sx={{ my: 0.5 }}
+            />
+            <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+              <Typography variant="caption">{task.status}</Typography>
+              {task.status === "queued" || task.status === "running" ? (
+                <Button size="small" onClick={() => cancelTask(task.id)}>
+                  Cancel
+                </Button>
+              ) : null}
+            </Box>
+          </Box>
+        ))
+      )}
+    </Box>
+  );
+}
+

--- a/src/features/docs/UploadPdf.tsx
+++ b/src/features/docs/UploadPdf.tsx
@@ -1,5 +1,6 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { useDocs } from "./useDocs";
+import TaskList from "../../components/TaskQueue/TaskList";
 
 export function UploadPdf() {
   const { addDoc } = useDocs();
@@ -11,5 +12,10 @@ export function UploadPdf() {
     }
   }
 
-  return <button onClick={handleClick}>Upload PDF</button>;
+  return (
+    <div>
+      <button onClick={handleClick}>Upload PDF</button>
+      <TaskList />
+    </div>
+  );
 }

--- a/src/pages/Lofi.tsx
+++ b/src/pages/Lofi.tsx
@@ -1,11 +1,13 @@
 import SongForm from "../components/SongForm";
 import VersionBadge from "../components/VersionBadge";
+import TaskList from "../components/TaskQueue/TaskList";
 
 export default function Lofi() {
   return (
     <div style={{ padding: "2rem" }}>
       <VersionBadge />
       <SongForm />
+      <TaskList />
     </div>
   );
 }

--- a/src/pages/Shorts.tsx
+++ b/src/pages/Shorts.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Button, List, ListItemButton, ListItemText, Tabs, Tab } from "@mui/material";
 import { invoke } from "@tauri-apps/api/core";
 import { useShorts } from "../features/shorts/useShorts";
+import TaskList from "../components/TaskQueue/TaskList";
 
 export default function Shorts() {
   const { shorts, selectedId, create, select } = useShorts();
@@ -21,6 +22,7 @@ export default function Shorts() {
             </ListItemButton>
           ))}
         </List>
+        <TaskList />
       </div>
     );
   }
@@ -51,6 +53,7 @@ export default function Shorts() {
           </Button>
         </div>
       )}
+      <TaskList />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- display queued tasks with progress and cancel controls
- show CPU and memory usage alongside tasks
- integrate task list into Lofi, Shorts, and Upload PDF views

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7c0b2ea708325a8f19b632eddbaf1