### PR TITLE
feat: add eclipse theme

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -209,6 +209,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               <MenuItem value="rainy">Rainy</MenuItem>
               <MenuItem value="pastel">Pastel</MenuItem>
               <MenuItem value="mono">Mono</MenuItem>
+              <MenuItem value="eclipse">Eclipse</MenuItem>
             </Select>
           </FormControl>
           <FormControlLabel

--- a/src/components/SystemInfoWidget.tsx
+++ b/src/components/SystemInfoWidget.tsx
@@ -17,6 +17,7 @@ const themeColors: Record<Theme, string> = {
   rainy: "rgba(0,120,255,0.22)",
   pastel: "rgba(255,182,193,0.22)",
   mono: "rgba(128,128,128,0.22)",
+  eclipse: "rgba(255,204,0,0.22)",
 };
 
 export default function SystemInfoWidget() {

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -25,7 +25,8 @@ export type Theme =
   | "aurora"
   | "rainy"
   | "pastel"
-  | "mono";
+  | "mono"
+  | "eclipse";
 
 interface ThemeContextType {
   theme: Theme;
@@ -63,6 +64,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       "theme-rainy",
       "theme-pastel",
       "theme-mono",
+      "theme-eclipse",
     ];
     document.body.classList.remove(...classes);
     document.body.classList.add(`theme-${theme}`);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -32,6 +32,7 @@ export default function Home() {
     rainy: "rgba(0,120,255,0.22)",
     pastel: "rgba(255,182,193,0.22)",
     mono: "rgba(128,128,128,0.22)",
+    eclipse: "rgba(255,204,0,0.22)",
   };
   const [hoverColor, setHoverColor] = useState(themeColors[theme]);
   useEffect(() => {

--- a/src/pages/SystemInfo.tsx
+++ b/src/pages/SystemInfo.tsx
@@ -16,6 +16,7 @@ const themeColors: Record<Theme, string> = {
   rainy: "rgba(0,120,255,0.22)",
   pastel: "rgba(255,182,193,0.22)",
   mono: "rgba(128,128,128,0.22)",
+  eclipse: "rgba(255,204,0,0.22)",
 };
 
 export default function SystemInfo() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -83,6 +83,26 @@ body.theme-rainy::before {
   animation: rain 0.5s linear infinite;
 }
 
+body.theme-eclipse {
+  background: radial-gradient(circle at center, #000, #1a1a1a);
+  overflow: hidden;
+}
+
+body.theme-eclipse::before {
+  content: "";
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 200vmax;
+  height: 200vmax;
+  pointer-events: none;
+  background: radial-gradient(circle, rgba(255, 204, 0, 0.25) 40%, rgba(255, 204, 0, 0) 60%);
+  border-radius: 50%;
+  animation: coronaRotate 120s linear infinite;
+  transform: translate(-50%, -50%);
+  z-index: -1;
+}
+
 body.theme-studio button,
 body.theme-studio input,
 body.theme-studio select {
@@ -165,6 +185,15 @@ body.theme-studio input[type="range"]::-moz-range-thumb {
   }
   100% {
     background-position: 0 10px;
+  }
+}
+
+@keyframes coronaRotate {
+  from {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
   }
 }
 


### PR DESCRIPTION
## Summary
- add "eclipse" to theme definitions and switchable body classes
- style new theme with radial gradient background and rotating solar corona
- expose Eclipse option and colors in settings and components

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a7ce597d9c8325a20f6e75c7395e74