### PR TITLE
feat: throttle tasks based on system usage

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1177,3 +1177,9 @@ pub async fn cancel_task(queue: State<'_, TaskQueue>, id: u64) -> Result<bool, S
 pub async fn list_tasks(queue: State<'_, TaskQueue>) -> Result<Vec<Task>, String> {
     Ok(queue.list())
 }
+
+#[tauri::command]
+pub async fn set_task_limits(queue: State<'_, TaskQueue>, cpu: f32, memory: f32) -> Result<(), String> {
+    queue.set_limits(cpu, memory);
+    Ok(())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,7 +10,7 @@ use tauri_plugin_sql::{Builder as SqlBuilder, Migration, MigrationKind};
 
 fn main() {
     env_logger::init();
-    let queue = TaskQueue::new(1);
+    let queue = TaskQueue::new(1, 90.0, 90.0);
     tauri::Builder::default()
         .manage(queue)
         .plugin(tauri_plugin_dialog::init())
@@ -80,6 +80,7 @@ fn main() {
             commands::task_status,
             commands::cancel_task,
             commands::list_tasks,
+            commands::set_task_limits,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { useUsers, defaultModules, type ModuleKey } from "../users/useUsers";
 
 export function useSettings() {
@@ -6,7 +8,22 @@ export function useSettings() {
     return id ? state.users[id].modules : defaultModules;
   });
   const toggleModule = useUsers((state) => state.toggleModule);
-  return { modules, toggleModule };
+  const cpuLimit = useUsers((state) => {
+    const id = state.currentUserId;
+    return id ? state.users[id].cpuLimit : 90;
+  });
+  const memLimit = useUsers((state) => {
+    const id = state.currentUserId;
+    return id ? state.users[id].memLimit : 90;
+  });
+  const setCpuLimit = useUsers((state) => state.setCpuLimit);
+  const setMemLimit = useUsers((state) => state.setMemLimit);
+
+  useEffect(() => {
+    invoke("set_task_limits", { cpu: cpuLimit, memory: memLimit }).catch(() => {});
+  }, [cpuLimit, memLimit]);
+
+  return { modules, toggleModule, cpuLimit, memLimit, setCpuLimit, setMemLimit };
 }
 
 export type { ModuleKey };

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -28,24 +28,28 @@ const defaultModules: ModulesState = {
   shorts: true,
 };
 
-interface User {
-  id: string;
-  name: string;
-  theme: Theme;
-  mode: PaletteMode;
-  money: number;
-  modules: ModulesState;
-}
+  interface User {
+    id: string;
+    name: string;
+    theme: Theme;
+    mode: PaletteMode;
+    money: number;
+    modules: ModulesState;
+    cpuLimit: number;
+    memLimit: number;
+  }
 
-interface UsersState {
-  users: Record<string, User>;
-  currentUserId: string | null;
-  addUser: (name: string) => void;
-  switchUser: (id: string) => void;
-  setTheme: (theme: Theme) => void;
-  setMode: (mode: PaletteMode) => void;
-  toggleModule: (key: ModuleKey) => void;
-}
+  interface UsersState {
+    users: Record<string, User>;
+    currentUserId: string | null;
+    addUser: (name: string) => void;
+    switchUser: (id: string) => void;
+    setTheme: (theme: Theme) => void;
+    setMode: (mode: PaletteMode) => void;
+    toggleModule: (key: ModuleKey) => void;
+    setCpuLimit: (limit: number) => void;
+    setMemLimit: (limit: number) => void;
+  }
 
 export const useUsers = create<UsersState>()(
   persist(
@@ -54,21 +58,23 @@ export const useUsers = create<UsersState>()(
       currentUserId: null,
       addUser: (name) => {
         const id = Date.now().toString();
-        set((state) => ({
-          users: {
-            ...state.users,
-            [id]: {
-              id,
-              name,
-              theme: 'default',
-              mode: 'dark',
-              money: 5000,
-              modules: { ...defaultModules },
+          set((state) => ({
+            users: {
+              ...state.users,
+              [id]: {
+                id,
+                name,
+                theme: 'default',
+                mode: 'dark',
+                money: 5000,
+                modules: { ...defaultModules },
+                cpuLimit: 90,
+                memLimit: 90,
+              },
             },
-          },
-          currentUserId: id,
-        }));
-      },
+            currentUserId: id,
+          }));
+        },
       switchUser: (id) => set(() => ({ currentUserId: id })),
       setTheme: (theme) => {
         const id = get().currentUserId;
@@ -90,25 +96,45 @@ export const useUsers = create<UsersState>()(
           },
         }));
       },
-      toggleModule: (key) => {
-        const id = get().currentUserId;
-        if (!id) return;
-        set((state) => {
-          const user = state.users[id];
-          return {
+        toggleModule: (key) => {
+          const id = get().currentUserId;
+          if (!id) return;
+          set((state) => {
+            const user = state.users[id];
+            return {
+              users: {
+                ...state.users,
+                [id]: {
+                  ...user,
+                  modules: { ...user.modules, [key]: !user.modules[key] },
+                },
+              },
+            };
+          });
+        },
+        setCpuLimit: (limit) => {
+          const id = get().currentUserId;
+          if (!id) return;
+          set((state) => ({
             users: {
               ...state.users,
-              [id]: {
-                ...user,
-                modules: { ...user.modules, [key]: !user.modules[key] },
-              },
+              [id]: { ...state.users[id], cpuLimit: limit },
             },
-          };
-        });
-      },
-    }),
-    { name: 'user-store' }
-  )
-);
+          }));
+        },
+        setMemLimit: (limit) => {
+          const id = get().currentUserId;
+          if (!id) return;
+          set((state) => ({
+            users: {
+              ...state.users,
+              [id]: { ...state.users[id], memLimit: limit },
+            },
+          }));
+        },
+      }),
+      { name: 'user-store' }
+    )
+  );
 
 export { type ModuleKey, type ModulesState, defaultModules };


### PR DESCRIPTION
## Summary
- throttle task execution when CPU or memory usage exceed configurable limits
- expose a `set_task_limits` Tauri command and hook settings to call it
- store CPU and memory limits per user and sync them to the backend

## Testing
- `npm test -- --run`
- `cargo test` *(fails: `javascriptcoregtk-4.1.pc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ce791ff08325975d01b443458ff5