### PR TITLE
refactor: replace SongForm inline styles with CSS modules

### DIFF
--- a/src/components/BatchActions.tsx
+++ b/src/components/BatchActions.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import HelpIcon from "./HelpIcon";
+import styles from "./SongForm.module.css";
+import clsx from "clsx";
 
 interface Props {
-  S: Record<string, React.CSSProperties>;
   numSongs: number;
   setNumSongs: (val: number) => void;
   titleSuffixMode: string;
@@ -24,7 +25,6 @@ interface Props {
 }
 
 export default function BatchActions({
-  S,
   numSongs,
   setNumSongs,
   titleSuffixMode,
@@ -46,9 +46,9 @@ export default function BatchActions({
 }: Props) {
   return (
     <>
-      <div style={S.grid2}>
-        <div style={S.panel}>
-          <label style={S.label}>
+      <div className={styles.grid2}>
+        <div className={styles.panel}>
+          <label className={styles.label}>
             How many songs?
             <HelpIcon text="Number of songs to render in this batch" />
           </label>
@@ -57,20 +57,14 @@ export default function BatchActions({
             min={1}
             value={numSongs}
             onChange={(e) => setNumSongs(Math.max(1, Number(e.target.value || 1)))}
-            style={S.input}
+            className={styles.input}
           />
-          <div style={{ ...S.small, marginTop: 8 }}>
+          <div className={clsx(styles.small, "mt-2")}>
             Titles will be suffixed with{" "}
             <select
               value={titleSuffixMode}
               onChange={(e) => setTitleSuffixMode(e.target.value)}
-              style={{
-                ...S.input,
-                padding: "4px 8px",
-                display: "inline-block",
-                width: 160,
-                marginLeft: 6,
-              }}
+              className={clsx(styles.input, "py-1 px-2 inline-block w-[160px] ml-1")}
             >
               <option value="number"># (1, 2, 3…)</option>
               <option value="timestamp">timestamp</option>
@@ -78,8 +72,8 @@ export default function BatchActions({
           </div>
         </div>
 
-        <div style={S.panel}>
-          <label style={S.label}>
+        <div className={styles.panel}>
+          <label className={styles.label}>
             BPM Jitter (per song)
             <HelpIcon text="Random tempo variation around base BPM" />
           </label>
@@ -89,23 +83,23 @@ export default function BatchActions({
             max={30}
             value={bpmJitterPct}
             onChange={(e) => setBpmJitterPct(Number(e.target.value))}
-            style={S.slider}
+            className={styles.slider}
           />
-          <div style={S.small}>±{bpmJitterPct}% around the base BPM</div>
-          <div style={{ ...S.toggle, marginTop: 8 }}>
+          <div className={styles.small}>±{bpmJitterPct}% around the base BPM</div>
+          <div className={clsx(styles.toggle, "mt-2") }>
             <input
               type="checkbox"
               checked={playLast}
               onChange={(e) => setPlayLast(e.target.checked)}
             />
-            <span style={S.small}>Auto‑play last successful render</span>
+            <span className={styles.small}>Auto‑play last successful render</span>
           </div>
         </div>
       </div>
 
-      <div style={S.actions}>
+      <div className={styles.actions}>
         <button
-          style={S.btn}
+          className={styles.btn}
           disabled={busy || !outDir || !titleBase || hasInvalidBars}
           onClick={onRender}
         >
@@ -118,11 +112,11 @@ export default function BatchActions({
             : "Render Songs"}
         </button>
 
-        <button style={S.playBtn} onClick={onPreview}>
+        <button className={styles.playBtn} onClick={onPreview}>
           {previewPlaying ? "Stop preview" : "Preview in browser"}
         </button>
 
-        <button style={S.playBtn} onClick={onPlayLastTrack}>
+        <button className={styles.playBtn} onClick={onPlayLastTrack}>
           {isPlaying ? "Pause" : "Play last track"}
         </button>
       </div>

--- a/src/components/PolishControls.tsx
+++ b/src/components/PolishControls.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import HelpIcon from "./HelpIcon";
+import styles from "./SongForm.module.css";
+import clsx from "clsx";
 
 interface Props {
-  S: Record<string, React.CSSProperties>;
   hqStereo: boolean;
   setHqStereo: (val: boolean) => void;
   hqReverb: boolean;
@@ -18,7 +19,6 @@ interface Props {
 }
 
 export default function PolishControls({
-  S,
   hqStereo,
   setHqStereo,
   hqReverb,
@@ -33,14 +33,14 @@ export default function PolishControls({
   setDither,
 }: Props) {
   return (
-    <div style={{ ...S.panel, marginTop: 12 }}>
+    <div className={clsx(styles.panel, "mt-3")}>
       <details open>
-        <summary style={{ cursor: "pointer", fontSize: 12, opacity: 0.8 }}>
+        <summary className="cursor-pointer text-xs opacity-80">
           Polish <HelpIcon text="Optional mix polish effects" />
         </summary>
-        <div style={{ marginTop: 8 }}>
-          <div style={S.optionGrid}>
-            <label style={S.optionCard}>
+        <div className="mt-2">
+          <div className={styles.optionGrid}>
+            <label className={styles.optionCard}>
               <span>Stereo widen</span>
               <input
                 type="checkbox"
@@ -48,7 +48,7 @@ export default function PolishControls({
                 onChange={(e) => setHqStereo(e.target.checked)}
               />
             </label>
-            <label style={S.optionCard}>
+            <label className={styles.optionCard}>
               <span>Room reverb</span>
               <input
                 type="checkbox"
@@ -56,7 +56,7 @@ export default function PolishControls({
                 onChange={(e) => setHqReverb(e.target.checked)}
               />
             </label>
-            <label style={S.optionCard}>
+            <label className={styles.optionCard}>
               <span>Sidechain (kick)</span>
               <input
                 type="checkbox"
@@ -64,7 +64,7 @@ export default function PolishControls({
                 onChange={(e) => setHqSidechain(e.target.checked)}
               />
             </label>
-            <label style={S.optionCard}>
+            <label className={styles.optionCard}>
               <span>Chorus</span>
               <input
                 type="checkbox"
@@ -73,12 +73,12 @@ export default function PolishControls({
               />
             </label>
           </div>
-          <details style={{ marginTop: 8 }}>
-            <summary style={{ cursor: "pointer", fontSize: 12, opacity: 0.8 }}>
+          <details className="mt-2">
+            <summary className="cursor-pointer text-xs opacity-80">
               Advanced
             </summary>
-            <div style={{ marginTop: 8 }}>
-              <label style={S.label}>
+            <div className="mt-2">
+              <label className={styles.label}>
                 Limiter Drive
                 <HelpIcon text="Amount of saturation added by the limiter" />
               </label>
@@ -89,16 +89,16 @@ export default function PolishControls({
                 step={0.01}
                 value={limiterDrive}
                 onChange={(e) => setLimiterDrive(Number(e.target.value))}
-                style={S.slider}
+                className={styles.slider}
               />
-              <div style={S.small}>{limiterDrive.toFixed(2)}× saturation</div>
-              <div style={{ ...S.toggle, marginTop: 8 }}>
+              <div className={styles.small}>{limiterDrive.toFixed(2)}× saturation</div>
+              <div className={clsx(styles.toggle, "mt-2")}>
                 <input
                   type="checkbox"
                   checked={dither}
                   onChange={(e) => setDither(e.target.checked)}
                 />
-                <span style={S.small}>Dither</span>
+                <span className={styles.small}>Dither</span>
               </div>
             </div>
           </details>

--- a/src/components/RhythmControls.tsx
+++ b/src/components/RhythmControls.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import HelpIcon from "./HelpIcon";
+import styles from "./SongForm.module.css";
+import clsx from "clsx";
 
 interface Props {
-  S: Record<string, React.CSSProperties>;
   DRUM_PATS: string[];
   drumPattern: string;
   setDrumPattern: (val: string) => void;
@@ -13,7 +14,6 @@ interface Props {
 }
 
 export default function RhythmControls({
-  S,
   DRUM_PATS,
   drumPattern,
   setDrumPattern,
@@ -23,16 +23,16 @@ export default function RhythmControls({
   setChordSpanBeats,
 }: Props) {
   return (
-    <div style={S.grid3}>
-      <div style={S.panel}>
-        <label style={S.label}>
+    <div className={styles.grid3}>
+      <div className={styles.panel}>
+        <label className={styles.label}>
           Drum Pattern
           <HelpIcon text="Choose a groove style or no drums" />
         </label>
         <select
           value={drumPattern}
           onChange={(e) => setDrumPattern(e.target.value)}
-          style={{ ...S.input, padding: "8px 12px" }}
+          className={clsx(styles.input, "py-2 px-3")}
         >
           {DRUM_PATS.map((p) => (
             <option key={p} value={p}>
@@ -40,11 +40,11 @@ export default function RhythmControls({
             </option>
           ))}
         </select>
-        <div style={S.small}>Choose a groove or leave random.</div>
+        <div className={styles.small}>Choose a groove or leave random.</div>
       </div>
 
-      <div style={S.panel}>
-        <label style={S.label}>
+      <div className={styles.panel}>
+        <label className={styles.label}>
           Variety
           <HelpIcon text="Amount of fills and swing" />
         </label>
@@ -54,20 +54,20 @@ export default function RhythmControls({
           max={100}
           value={variety}
           onChange={(e) => setVariety(Number(e.target.value))}
-          style={S.slider}
+          className={styles.slider}
         />
-        <div style={S.small}>{variety}% fills & swing</div>
+        <div className={styles.small}>{variety}% fills & swing</div>
       </div>
 
-      <div style={S.panel}>
-        <label style={S.label}>
+      <div className={styles.panel}>
+        <label className={styles.label}>
           Chord Span
           <HelpIcon text="Number of beats each chord lasts" />
         </label>
         <select
           value={chordSpanBeats}
           onChange={(e) => setChordSpanBeats(Number(e.target.value))}
-          style={{ ...S.input, padding: "8px 12px" }}
+          className={clsx(styles.input, "py-2 px-3")}
         >
           <option value={2}>½ bar</option>
           <option value={4}>1 bar</option>

--- a/src/components/SongForm.module.css
+++ b/src/components/SongForm.module.css
@@ -1,0 +1,170 @@
+.page {
+  position: relative;
+  min-height: 100vh;
+  background: #0f0f10;
+  color: #fff;
+  padding: 16px;
+}
+
+.card {
+  background: #17181b;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 10px 24px rgba(0,0,0,.32);
+  color: #fff;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.h1 {
+  margin: 0 0 12px 0;
+  font-size: 22px;
+  font-weight: 800;
+}
+
+.row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.input {
+  flex: 1;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #2b2e33;
+  background: #0e0f12;
+  color: #e7e7ea;
+}
+
+.btn {
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: none;
+  background: #3a82f6;
+  color: #fff;
+  cursor: pointer;
+  min-width: 140px;
+}
+
+.small {
+  font-size: 12px;
+  opacity: 0.75;
+  margin-top: 4px;
+}
+
+.grid3 {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0,1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.grid2 {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0,1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.panel {
+  background: #0e0f12;
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.label {
+  font-size: 12px;
+  opacity: 0.8;
+  margin-bottom: 6px;
+  display: block;
+}
+
+.actions {
+  margin-top: 12px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.status {
+  margin-top: 10px;
+  font-size: 12px;
+  opacity: 0.8;
+}
+
+.err {
+  margin-top: 8px;
+  color: #ff7b7b;
+  font-size: 12px;
+}
+
+.table {
+  width: 100%;
+  margin-top: 12px;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.th {
+  text-align: left;
+  padding: 8px 6px;
+  border-bottom: 1px solid #2b2e33;
+  opacity: 0.8;
+}
+
+.td {
+  padding: 8px 6px;
+  border-bottom: 1px solid #1e2025;
+}
+
+.optionGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px,1fr));
+  gap: 8px;
+}
+
+.optionCard {
+  background: #17191d;
+  border-radius: 8px;
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.toggle {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.slider {
+  width: 100%;
+}
+
+.playBtn {
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid #2b2e33;
+  background: transparent;
+  color: #e7e7ea;
+  cursor: pointer;
+  min-width: 120px;
+}
+
+.progressOuter {
+  height: 6px;
+  background: #2b2e33;
+  border-radius: 3px;
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+.progressInner {
+  height: 100%;
+  background: #3a82f6;
+  width: 0%;
+  transition: width 0.3s;
+}

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -41,6 +41,11 @@ describe('SongForm', () => {
     cleanup();
   });
 
+  it('renders default form', () => {
+    const { asFragment } = render(<SongForm />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   it('adds a job and shows progress', async () => {
     (open as any).mockResolvedValue('/tmp/out');
     let resolveRun: (p: string) => void;

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -13,6 +13,8 @@ import PolishControls from "./PolishControls";
 import BatchActions from "./BatchActions";
 import HelpIcon from "./HelpIcon";
 import { PRESET_TEMPLATES, SECTION_PRESETS } from "./songTemplates";
+import styles from "./SongForm.module.css";
+import clsx from "clsx";
 
 export type Section = { name: string; bars: number; chords: string[]; barsStr?: string };
 
@@ -635,41 +637,13 @@ export default function SongForm() {
     return new Promise((r) => setJobs((prev) => (r(prev), prev)));
   }
 
-  const S: Record<string, React.CSSProperties> = {
-    page: { position: "relative", minHeight: "100vh", background: "#0f0f10", color: "#fff", padding: 16 },
-    card: { background: "#17181b", borderRadius: 16, padding: 16, boxShadow: "0 10px 24px rgba(0,0,0,.32)", color: "#fff", maxWidth: 1100, margin: "0 auto" },
-    h1: { margin: "0 0 12px 0", fontSize: 22, fontWeight: 800 },
-    row: { display: "flex", gap: 8, alignItems: "center" },
-    input: { flex: 1, padding: "10px 12px", borderRadius: 10, border: "1px solid #2b2e33", background: "#0e0f12", color: "#e7e7ea" },
-    btn: { padding: "10px 14px", borderRadius: 10, border: "none", background: "#3a82f6", color: "#fff", cursor: "pointer", minWidth: 140 },
-    small: { fontSize: 12, opacity: 0.75, marginTop: 4 },
-    grid3: { display: "grid", gridTemplateColumns: "repeat(3, minmax(0,1fr))", gap: 12, marginTop: 12 },
-    grid2: { display: "grid", gridTemplateColumns: "repeat(2, minmax(0,1fr))", gap: 12, marginTop: 12 },
-    panel: { background: "#0e0f12", borderRadius: 10, padding: 12 },
-    label: { fontSize: 12, opacity: 0.8, marginBottom: 6, display: "block" },
-    actions: { marginTop: 12, display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" },
-    status: { marginTop: 10, fontSize: 12, opacity: 0.8 },
-    err: { marginTop: 8, color: "#ff7b7b", fontSize: 12 },
-    table: { width: "100%", marginTop: 12, borderCollapse: "collapse", fontSize: 13 },
-    th: { textAlign: "left", padding: "8px 6px", borderBottom: "1px solid #2b2e33", opacity: 0.8 },
-    td: { padding: "8px 6px", borderBottom: "1px solid #1e2025" },
-    optionGrid: { display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(120px,1fr))", gap: 8 },
-    optionCard: { background: "#17191d", borderRadius: 8, padding: "8px 12px", display: "flex", alignItems: "center", justifyContent: "space-between" },
-    toggle: { display: "flex", gap: 8, alignItems: "center" },
-    slider: { width: "100%" },
-    playBtn: { padding: "10px 14px", borderRadius: 10, border: "1px solid #2b2e33", background: "transparent", color: "#e7e7ea", cursor: "pointer", minWidth: 120 },
-    progressOuter: { height: 6, background: "#2b2e33", borderRadius: 3, overflow: "hidden", marginTop: 8 },
-    progressInner: { height: "100%", background: "#3a82f6", width: "0%", transition: "width 0.3s" },
-  };
-
   return (
-    <div style={S.page}>
-      <div style={S.card}>
-        <div style={S.h1}>Blossom — Song Builder (Batch + Vibes)</div>
+    <div className={styles.page}>
+      <div className={styles.card}>
+        <div className={styles.h1}>Blossom — Song Builder (Batch + Vibes)</div>
 
         {/* template selector */}
         <TemplateSelector
-          S={S}
           templates={SONG_TEMPLATES}
           selectedTemplate={selectedTemplate}
           setSelectedTemplate={setSelectedTemplate}
@@ -677,26 +651,26 @@ export default function SongForm() {
         />
 
         {/* title + output folder */}
-        <div style={S.row}>
+        <div className={styles.row}>
           <input
-            style={S.input}
+            className={styles.input}
             placeholder="Song title base"
             value={titleBase}
             onChange={(e) => setTitleBase(e.target.value)}
           />
-          <button style={S.btn} onClick={generateTitle} disabled={genTitleLoading}>
+          <button className={styles.btn} onClick={generateTitle} disabled={genTitleLoading}>
             {genTitleLoading ? "Generating..." : "Generate Title"}
           </button>
-          <button style={S.btn} onClick={pickFolder}>
+          <button className={styles.btn} onClick={pickFolder}>
             {outDir ? "Change folder" : "Choose folder"}
           </button>
         </div>
-        <div style={S.small}>{outDir || "No output folder selected"}</div>
+        <div className={styles.small}>{outDir || "No output folder selected"}</div>
 
         {/* core knobs */}
-        <div style={S.grid3}>
-          <div style={S.panel}>
-            <label style={S.label}>
+        <div className={styles.grid3}>
+          <div className={styles.panel}>
+            <label className={styles.label}>
               BPM: {bpm}
               <HelpIcon text="Song tempo in beats per minute" />
             </label>
@@ -706,28 +680,28 @@ export default function SongForm() {
               max={200}
               value={bpm}
               onChange={(e) => setBpm(Number(e.target.value))}
-              style={{ ...S.input, padding: 0 }}
+              className={clsx(styles.input, "p-0")}
             />
           </div>
-          <div style={S.panel}>
-            <label style={S.label}>
+          <div className={styles.panel}>
+            <label className={styles.label}>
               Key
               <HelpIcon text="Musical key; choose Auto for random" />
             </label>
-            <div style={S.row}>
-              <select value={key} onChange={(e) => setKey(e.target.value)} style={{ ...S.input, padding: "8px 12px" }}>
+            <div className={styles.row}>
+              <select value={key} onChange={(e) => setKey(e.target.value)} className={clsx(styles.input, "py-2 px-3") }>
                 {KEYS.map((k) => (
                   <option key={k} value={k}>{displayKey(k)}</option>
                 ))}
               </select>
             </div>
-            <div style={{ ...S.toggle, marginTop: 8 }}>
+            <div className={clsx(styles.toggle, "mt-2") }>
               <input type="checkbox" checked={autoKeyPerSong} onChange={(e) => setAutoKeyPerSong(e.target.checked)} disabled={key === "Auto"} />
-              <span style={S.small}>Rotate key per song{key === "Auto" ? " (disabled: Auto)" : ""}</span>
+              <span className={styles.small}>Rotate key per song{key === "Auto" ? " (disabled: Auto)" : ""}</span>
             </div>
           </div>
-          <div style={S.panel}>
-            <label style={S.label}>
+          <div className={styles.panel}>
+            <label className={styles.label}>
               Seed
               <HelpIcon text="Randomness seed for reproducibility" />
             </label>
@@ -735,13 +709,13 @@ export default function SongForm() {
               type="number"
               value={seedBase}
               onChange={(e) => setSeedBase(Number(e.target.value || 0))}
-              style={S.input}
+              className={styles.input}
             />
-            <div style={{ ...S.row, marginTop: 8 }}>
-              <label style={{ ...S.small, flex: 1 }}>
+            <div className={clsx(styles.row, "mt-2") }>
+              <label className={clsx(styles.small, "flex-1") }>
                 <input type="radio" name="seedmode" checked={seedMode === "increment"} onChange={() => setSeedMode("increment")} /> Increment (base + i)
               </label>
-              <label style={{ ...S.small, flex: 1 }}>
+              <label className={clsx(styles.small, "flex-1") }>
                 <input type="radio" name="seedmode" checked={seedMode === "random"} onChange={() => setSeedMode("random")} /> Deterministic random
               </label>
             </div>
@@ -749,8 +723,8 @@ export default function SongForm() {
         </div>
 
         {/* structure editor */}
-        <div style={{ ...S.panel, marginTop: 12 }}>
-          <div style={{ ...S.row, marginBottom: 8 }}>
+        <div className={clsx(styles.panel, "mt-3")}>
+          <div className={clsx(styles.row, "mb-2")}>
             <select
               value={selectedTemplate}
               onChange={(e) => {
@@ -762,7 +736,7 @@ export default function SongForm() {
                   applyTemplate(templates[name]);
                 }
               }}
-              style={{ ...S.input, padding: "8px 12px" }}
+              className={clsx(styles.input, "py-2 px-3")}
             >
               <option value="">Custom</option>
               {Object.keys(templates).map((name) => (
@@ -775,13 +749,13 @@ export default function SongForm() {
               (creatingTemplate ? (
                 <>
                   <input
-                    style={S.input}
+                    className={styles.input}
                     placeholder="Template name"
                     value={newTemplateName}
                     onChange={(e) => setNewTemplateName(e.target.value)}
                   />
                   <button
-                    style={S.btn}
+                    className={styles.btn}
                     onClick={() => {
                       const nm = newTemplateName.trim();
                       if (!nm) return;
@@ -823,7 +797,7 @@ export default function SongForm() {
                 </>
               ) : (
                 <button
-                  style={S.btn}
+                  className={styles.btn}
                   onClick={() => {
                     setSelectedTemplate("");
                     setCreatingTemplate(true);
@@ -834,7 +808,7 @@ export default function SongForm() {
                 </button>
               ))}
           </div>
-          <div style={{ ...S.row, marginBottom: 8 }}>
+          <div className={clsx(styles.row, "mb-2")}>
             <select
               value={sectionPreset}
               onChange={(e) => {
@@ -845,7 +819,7 @@ export default function SongForm() {
                   setSelectedTemplate("");
                 }
               }}
-              style={{ ...S.input, padding: "8px 12px" }}
+              className={clsx(styles.input, "py-2 px-3")}
             >
               <option value="">Preset layout…</option>
               {Object.keys(SECTION_PRESETS).map((name) => (
@@ -855,14 +829,14 @@ export default function SongForm() {
               ))}
             </select>
           </div>
-          <label style={S.label}>
+          <label className={styles.label}>
             Structure (bars)
             <HelpIcon text="Order of song sections with lengths and chords" />
           </label>
-          <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <div className="flex gap-2 flex-wrap">
             {structure.map((sec, i) => (
-              <div key={i} style={{ background: "#17191d", padding: 8, borderRadius: 8, minWidth: 120 }}>
-                <div style={S.small}>{sec.name}</div>
+              <div key={i} className="bg-[#17191d] p-2 rounded-lg min-w-[120px]">
+                <div className={styles.small}>{sec.name}</div>
                 <input
                   type="number"
                   value={sec.barsStr ?? String(sec.bars)}
@@ -881,8 +855,8 @@ export default function SongForm() {
                     setSelectedTemplate("");
                     setSectionPreset("");
                   }}
+                  className={styles.input}
                   style={{
-                    ...S.input,
                     border:
                       !/^[0-9]+$/.test(sec.barsStr ?? String(sec.bars)) ||
                       parseInt(sec.barsStr ?? String(sec.bars), 10) < 1
@@ -892,7 +866,7 @@ export default function SongForm() {
                 />
                 {!/^[0-9]+$/.test(sec.barsStr ?? String(sec.bars)) ||
                 parseInt(sec.barsStr ?? String(sec.bars), 10) < 1 ? (
-                  <div style={S.err}>Enter bars ≥1</div>
+                  <div className={styles.err}>Enter bars ≥1</div>
                 ) : null}
                 <input
                   type="text"
@@ -911,19 +885,18 @@ export default function SongForm() {
                     setSelectedTemplate("");
                     setSectionPreset("");
                   }}
-                  style={{ ...S.input, marginTop: 4 }}
+                  className={clsx(styles.input, "mt-1")}
                 />
               </div>
             ))}
           </div>
-          <div style={S.small}>
+          <div className={styles.small}>
             Total Bars: {totalBars} — Est. Time: {estMinutes}:{estSecs}
           </div>
         </div>
 
         {/* vibe controls */}
         <VibeControls
-          S={S}
           MOODS={MOODS}
           INSTR={INSTR}
           LEAD_INSTR={LEAD_INSTR}
@@ -942,7 +915,6 @@ export default function SongForm() {
 
         {/* rhythm & feel */}
         <RhythmControls
-          S={S}
           DRUM_PATS={DRUM_PATS}
           drumPattern={drumPattern}
           setDrumPattern={setDrumPattern}
@@ -954,7 +926,6 @@ export default function SongForm() {
 
         {/* polish accordion */}
         <PolishControls
-          S={S}
           hqStereo={hqStereo}
           setHqStereo={setHqStereo}
           hqReverb={hqReverb}
@@ -969,17 +940,17 @@ export default function SongForm() {
           setDither={setDither}
         />
         {/* album mode toggle */}
-        <div style={S.panel}>
-          <label style={S.toggle}>
+        <div className={styles.panel}>
+          <label className={styles.toggle}>
             <input type="checkbox" checked={albumMode} onChange={(e) => setAlbumMode(e.target.checked)} />
-            <span style={S.small}>
+            <span className={styles.small}>
               Album mode
               <HelpIcon text="Render multiple tracks as an album" />
             </span>
           </label>
           {albumMode && (
             <>
-              <label style={S.label}>
+              <label className={styles.label}>
                 Track Count
                 <HelpIcon text="Number of tracks in album mode" />
               </label>
@@ -993,14 +964,13 @@ export default function SongForm() {
                     Math.max(3, Math.min(12, Number(e.target.value || 3)))
                   )
                 }
-                style={S.input}
+                className={styles.input}
               />
             </>
           )}
         </div>
 
         <BatchActions
-          S={S}
           numSongs={numSongs}
           setNumSongs={setNumSongs}
           titleSuffixMode={titleSuffixMode}
@@ -1021,48 +991,48 @@ export default function SongForm() {
           onPlayLastTrack={handlePlayLastTrack}
         />
 
-        {globalStatus && <div style={S.status}>Status: {globalStatus}</div>}
+        {globalStatus && <div className={styles.status}>Status: {globalStatus}</div>}
         {busy && (
-          <div style={S.progressOuter}>
-            <div style={{ ...S.progressInner, width: `${progress}%` }} />
+          <div className={styles.progressOuter}>
+            <div className={styles.progressInner} style={{ width: `${progress}%` }} />
           </div>
         )}
-        {err && <div style={S.err}>Error: {err}</div>}
+        {err && <div className={styles.err}>Error: {err}</div>}
 
         {jobs.length > 0 && (
-          <table style={S.table}>
+          <table className={styles.table}>
             <thead>
               <tr>
-                <th style={S.th}>Title</th>
-                <th style={S.th}>Key</th>
-                <th style={S.th}>BPM</th>
-                <th style={S.th}>Seed</th>
-                <th style={S.th}>Status</th>
-                <th style={S.th}>Output</th>
+                <th className={styles.th}>Title</th>
+                <th className={styles.th}>Key</th>
+                <th className={styles.th}>BPM</th>
+                <th className={styles.th}>Seed</th>
+                <th className={styles.th}>Status</th>
+                <th className={styles.th}>Output</th>
               </tr>
             </thead>
             <tbody>
               {jobs.map((j) => (
                 <tr key={j.id}>
-                  <td style={S.td}>{j.title}</td>
-                  <td style={S.td}>{showKey(j.spec.key)}</td>
-                  <td style={S.td}>{j.spec.bpm}</td>
-                  <td style={S.td}>{j.spec.seed}</td>
-                  <td style={S.td}>
-                    {j.error ? <span style={{ color: "#ff7b7b" }}>error</span> : j.status || "—"}
+                  <td className={styles.td}>{j.title}</td>
+                  <td className={styles.td}>{showKey(j.spec.key)}</td>
+                  <td className={styles.td}>{j.spec.bpm}</td>
+                  <td className={styles.td}>{j.spec.seed}</td>
+                  <td className={styles.td}>
+                    {j.error ? <span className="text-[#ff7b7b]">error</span> : j.status || "—"}
                     {j.error && (
-                      <details style={{ marginTop: 4 }}>
-                        <summary style={{ opacity: 0.8, cursor: "pointer" }}>details</summary>
-                        <pre style={{ whiteSpace: "pre-wrap" }}>{j.error}</pre>
+                      <details className="mt-1">
+                        <summary className="opacity-80 cursor-pointer">details</summary>
+                        <pre className="whitespace-pre-wrap">{j.error}</pre>
                       </details>
                     )}
                   </td>
-                  <td style={S.td}>
+                  <td className={styles.td}>
                     {j.outPath ? (
-                      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <div className="flex items-center gap-2">
                         <Waveform src={convertFileSrc(j.outPath!.replace(/\\/g, "/"))} />
                         <button
-                          style={S.playBtn}
+                          className={styles.playBtn}
                           onClick={async () => {
                             const url = convertFileSrc(j.outPath!.replace(/\\/g, "/"));
                             const a = audioRef.current!;

--- a/src/components/TemplateSelector.tsx
+++ b/src/components/TemplateSelector.tsx
@@ -1,9 +1,10 @@
 import HelpIcon from "./HelpIcon";
 import type { TemplateSpec } from "./SongForm";
 import React from "react";
+import styles from "./SongForm.module.css";
+import clsx from "clsx";
 
 interface Props {
-  S: Record<string, React.CSSProperties>;
   templates: Record<string, TemplateSpec>;
   selectedTemplate: string;
   setSelectedTemplate: (name: string) => void;
@@ -11,15 +12,14 @@ interface Props {
 }
 
 export default function TemplateSelector({
-  S,
   templates,
   selectedTemplate,
   setSelectedTemplate,
   applyTemplate,
 }: Props) {
   return (
-    <div style={S.panel}>
-      <label style={S.label}>
+    <div className={styles.panel}>
+      <label className={styles.label}>
         Song Templates
         <HelpIcon text="Select a preset arrangement and settings" />
       </label>
@@ -33,7 +33,7 @@ export default function TemplateSelector({
             applyTemplate(templates[templateName]);
           }
         }}
-        style={{ ...S.input, padding: "8px 12px" }}
+        className={clsx(styles.input, "py-2 px-3")}
       >
         <option value="">Custom Structure</option>
         {Object.keys(templates).map((name) => (

--- a/src/components/VibeControls.tsx
+++ b/src/components/VibeControls.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import HelpIcon from "./HelpIcon";
+import styles from "./SongForm.module.css";
 
 interface Props {
-  S: Record<string, React.CSSProperties>;
   MOODS: string[];
   INSTR: string[];
   LEAD_INSTR: { value: string; label: string }[];
@@ -24,7 +24,6 @@ function toggle(list: string[], val: string) {
 }
 
 export default function VibeControls({
-  S,
   MOODS,
   INSTR,
   LEAD_INSTR,
@@ -41,15 +40,15 @@ export default function VibeControls({
   setAmbienceLevel,
 }: Props) {
   return (
-    <div style={S.grid3}>
-      <div style={S.panel}>
-        <label style={S.label}>
+    <div className={styles.grid3}>
+      <div className={styles.panel}>
+        <label className={styles.label}>
           Mood
           <HelpIcon text="Tags describing the vibe" />
         </label>
-        <div style={S.optionGrid}>
+        <div className={styles.optionGrid}>
           {MOODS.map((m) => (
-            <label key={m} style={S.optionCard}>
+            <label key={m} className={styles.optionCard}>
               <span>{m}</span>
               <input
                 type="checkbox"
@@ -61,14 +60,14 @@ export default function VibeControls({
         </div>
       </div>
 
-      <div style={S.panel}>
-        <label style={S.label}>
+      <div className={styles.panel}>
+        <label className={styles.label}>
           Instruments
           <HelpIcon text="Select instruments to include" />
         </label>
-        <div style={S.optionGrid}>
+        <div className={styles.optionGrid}>
           {INSTR.map((i) => (
-            <label key={i} style={S.optionCard}>
+            <label key={i} className={styles.optionCard}>
               <span>{i}</span>
               <input
                 type="checkbox"
@@ -78,17 +77,17 @@ export default function VibeControls({
             </label>
           ))}
         </div>
-        <div style={S.small}>Drums are synthesized automatically.</div>
+        <div className={styles.small}>Drums are synthesized automatically.</div>
       </div>
 
-      <div style={S.panel}>
-        <label style={S.label}>
+      <div className={styles.panel}>
+        <label className={styles.label}>
           Lead Instrument
           <HelpIcon text="Main instrument for the melody" />
         </label>
-        <div style={S.optionGrid}>
+        <div className={styles.optionGrid}>
           {LEAD_INSTR.map((l) => (
-            <label key={l.value} style={S.optionCard}>
+            <label key={l.value} className={styles.optionCard}>
               <span>{l.label}</span>
               <input
                 type="radio"
@@ -102,8 +101,8 @@ export default function VibeControls({
         </div>
       </div>
 
-      <div style={S.panel}>
-        <label style={S.label} htmlFor="ambience-select">
+      <div className={styles.panel}>
+        <label className={styles.label} htmlFor="ambience-select">
           Ambience
           <HelpIcon text="Background ambience sounds" />
         </label>
@@ -114,7 +113,7 @@ export default function VibeControls({
           onChange={(e) =>
             setAmbience(Array.from(e.target.selectedOptions).map((o) => o.value))
           }
-          style={S.input}
+          className={styles.input}
         >
           {AMBI.map((a) => (
             <option key={a} value={a}>
@@ -129,9 +128,9 @@ export default function VibeControls({
           step={0.01}
           value={ambienceLevel}
           onChange={(e) => setAmbienceLevel(Number(e.target.value))}
-          style={S.slider}
+          className={styles.slider}
         />
-        <div style={S.small}>{Math.round(ambienceLevel * 100)}% intensity</div>
+        <div className={styles.small}>{Math.round(ambienceLevel * 100)}% intensity</div>
       </div>
     </div>
   );

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -1,0 +1,2010 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SongForm > renders default form 1`] = `
+<DocumentFragment>
+  <div
+    class="_page_62bdff"
+  >
+    <div
+      class="_card_62bdff"
+    >
+      <div
+        class="_h1_62bdff"
+      >
+        Blossom — Song Builder (Batch + Vibes)
+      </div>
+      <div
+        class="_panel_62bdff"
+      >
+        <label
+          class="_label_62bdff"
+        >
+          Song Templates
+          <svg
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            style="margin-left: 4px; cursor: help; opacity: 0.6;"
+            viewBox="0 0 512 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>
+              Select a preset arrangement and settings
+            </title>
+            <path
+              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+            />
+          </svg>
+        </label>
+        <select
+          aria-label="Song Templates"
+          class="_input_62bdff py-2 px-3"
+        >
+          <option
+            value=""
+          >
+            Custom Structure
+          </option>
+          <option
+            value="Classic Lofi"
+          >
+            Classic Lofi
+          </option>
+          <option
+            value="Study Session"
+          >
+            Study Session
+          </option>
+          <option
+            value="Jazz Cafe"
+          >
+            Jazz Cafe
+          </option>
+          <option
+            value="Midnight Drive"
+          >
+            Midnight Drive
+          </option>
+          <option
+            value="Rain & Coffee"
+          >
+            Rain & Coffee
+          </option>
+          <option
+            value="Bossa Nova"
+          >
+            Bossa Nova
+          </option>
+          <option
+            value="Quick Beat"
+          >
+            Quick Beat
+          </option>
+          <option
+            value="New Fantasy"
+          >
+            New Fantasy
+          </option>
+          <option
+            value="Sleep"
+          >
+            Sleep
+          </option>
+          <option
+            value="Sunset Sketches"
+          >
+            Sunset Sketches
+          </option>
+          <option
+            value="Neon Rain"
+          >
+            Neon Rain
+          </option>
+          <option
+            value="Loft Morning"
+          >
+            Loft Morning
+          </option>
+          <option
+            value="Late Night Coding"
+          >
+            Late Night Coding
+          </option>
+          <option
+            value="Forest Spirits"
+          >
+            Forest Spirits
+          </option>
+          <option
+            value="Linear Drift"
+          >
+            Linear Drift
+          </option>
+          <option
+            value="Odd Odyssey"
+          >
+            Odd Odyssey
+          </option>
+          <option
+            value="Arcane Clash"
+          >
+            Arcane Clash
+          </option>
+          <option
+            value="King's Last Stand"
+          >
+            King's Last Stand
+          </option>
+          <option
+            value="Ocean Breeze"
+          >
+            Ocean Breeze
+          </option>
+          <option
+            value="City Lights"
+          >
+            City Lights
+          </option>
+          <option
+            value="Starlit Voyage"
+          >
+            Starlit Voyage
+          </option>
+          <option
+            value="Sunset VHS"
+          >
+            Sunset VHS
+          </option>
+          <option
+            value="Neon Palms"
+          >
+            Neon Palms
+          </option>
+          <option
+            value="Night Swim"
+          >
+            Night Swim
+          </option>
+        </select>
+      </div>
+      <div
+        class="_row_62bdff"
+      >
+        <input
+          class="_input_62bdff"
+          placeholder="Song title base"
+          value="Midnight Coffee"
+        />
+        <button
+          class="_btn_62bdff"
+        >
+          Generate Title
+        </button>
+        <button
+          class="_btn_62bdff"
+        >
+          Choose folder
+        </button>
+      </div>
+      <div
+        class="_small_62bdff"
+      >
+        No output folder selected
+      </div>
+      <div
+        class="_grid3_62bdff"
+      >
+        <div
+          class="_panel_62bdff"
+        >
+          <label
+            class="_label_62bdff"
+          >
+            BPM: 80
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Song tempo in beats per minute
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </label>
+          <input
+            class="_input_62bdff p-0"
+            max="200"
+            min="60"
+            type="range"
+            value="80"
+          />
+        </div>
+        <div
+          class="_panel_62bdff"
+        >
+          <label
+            class="_label_62bdff"
+          >
+            Key
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Musical key; choose Auto for random
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </label>
+          <div
+            class="_row_62bdff"
+          >
+            <select
+              class="_input_62bdff py-2 px-3"
+            >
+              <option
+                value="Auto"
+              >
+                Auto
+              </option>
+              <option
+                value="C"
+              >
+                C
+              </option>
+              <option
+                value="C#"
+              >
+                C♯
+              </option>
+              <option
+                value="D"
+              >
+                D
+              </option>
+              <option
+                value="D#"
+              >
+                D♯
+              </option>
+              <option
+                value="E"
+              >
+                E
+              </option>
+              <option
+                value="F"
+              >
+                F
+              </option>
+              <option
+                value="F#"
+              >
+                F♯
+              </option>
+              <option
+                value="G"
+              >
+                G
+              </option>
+              <option
+                value="G#"
+              >
+                G♯
+              </option>
+              <option
+                value="A"
+              >
+                A
+              </option>
+              <option
+                value="A#"
+              >
+                A♯
+              </option>
+              <option
+                value="B"
+              >
+                B
+              </option>
+              <option
+                value="Db"
+              >
+                D♭
+              </option>
+              <option
+                value="Eb"
+              >
+                E♭
+              </option>
+              <option
+                value="Gb"
+              >
+                G♭
+              </option>
+              <option
+                value="Ab"
+              >
+                A♭
+              </option>
+              <option
+                value="Bb"
+              >
+                B♭
+              </option>
+              <option
+                value="Am"
+              >
+                Am
+              </option>
+              <option
+                value="Em"
+              >
+                Em
+              </option>
+              <option
+                value="Dm"
+              >
+                Dm
+              </option>
+            </select>
+          </div>
+          <div
+            class="_toggle_62bdff mt-2"
+          >
+            <input
+              disabled=""
+              type="checkbox"
+            />
+            <span
+              class="_small_62bdff"
+            >
+              Rotate key per song (disabled: Auto)
+            </span>
+          </div>
+        </div>
+        <div
+          class="_panel_62bdff"
+        >
+          <label
+            class="_label_62bdff"
+          >
+            Seed
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Randomness seed for reproducibility
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </label>
+          <input
+            class="_input_62bdff"
+            type="number"
+            value="12345"
+          />
+          <div
+            class="_row_62bdff mt-2"
+          >
+            <label
+              class="_small_62bdff flex-1"
+            >
+              <input
+                name="seedmode"
+                type="radio"
+              />
+               Increment (base + i)
+            </label>
+            <label
+              class="_small_62bdff flex-1"
+            >
+              <input
+                checked=""
+                name="seedmode"
+                type="radio"
+              />
+               Deterministic random
+            </label>
+          </div>
+        </div>
+      </div>
+      <div
+        class="_panel_62bdff mt-3"
+      >
+        <div
+          class="_row_62bdff mb-2"
+        >
+          <select
+            class="_input_62bdff py-2 px-3"
+          >
+            <option
+              value=""
+            >
+              Custom
+            </option>
+            <option
+              value="Classic Lofi"
+            >
+              Classic Lofi
+            </option>
+            <option
+              value="Study Session"
+            >
+              Study Session
+            </option>
+            <option
+              value="Jazz Cafe"
+            >
+              Jazz Cafe
+            </option>
+            <option
+              value="Midnight Drive"
+            >
+              Midnight Drive
+            </option>
+            <option
+              value="Rain & Coffee"
+            >
+              Rain & Coffee
+            </option>
+            <option
+              value="Bossa Nova"
+            >
+              Bossa Nova
+            </option>
+            <option
+              value="Quick Beat"
+            >
+              Quick Beat
+            </option>
+            <option
+              value="New Fantasy"
+            >
+              New Fantasy
+            </option>
+            <option
+              value="Sleep"
+            >
+              Sleep
+            </option>
+            <option
+              value="Sunset Sketches"
+            >
+              Sunset Sketches
+            </option>
+            <option
+              value="Neon Rain"
+            >
+              Neon Rain
+            </option>
+            <option
+              value="Loft Morning"
+            >
+              Loft Morning
+            </option>
+            <option
+              value="Late Night Coding"
+            >
+              Late Night Coding
+            </option>
+            <option
+              value="Forest Spirits"
+            >
+              Forest Spirits
+            </option>
+            <option
+              value="Linear Drift"
+            >
+              Linear Drift
+            </option>
+            <option
+              value="Odd Odyssey"
+            >
+              Odd Odyssey
+            </option>
+            <option
+              value="Arcane Clash"
+            >
+              Arcane Clash
+            </option>
+            <option
+              value="King's Last Stand"
+            >
+              King's Last Stand
+            </option>
+            <option
+              value="Ocean Breeze"
+            >
+              Ocean Breeze
+            </option>
+            <option
+              value="City Lights"
+            >
+              City Lights
+            </option>
+            <option
+              value="Starlit Voyage"
+            >
+              Starlit Voyage
+            </option>
+            <option
+              value="Sunset VHS"
+            >
+              Sunset VHS
+            </option>
+            <option
+              value="Neon Palms"
+            >
+              Neon Palms
+            </option>
+            <option
+              value="Night Swim"
+            >
+              Night Swim
+            </option>
+          </select>
+          <button
+            class="_btn_62bdff"
+          >
+            New Template
+          </button>
+        </div>
+        <div
+          class="_row_62bdff mb-2"
+        >
+          <select
+            class="_input_62bdff py-2 px-3"
+          >
+            <option
+              value=""
+            >
+              Preset layout…
+            </option>
+            <option
+              value="Intro(4)-A(8)-B(8)-Break(4)-A(8)-Outro(4)"
+            >
+              Intro(4)-A(8)-B(8)-Break(4)-A(8)-Outro(4)
+            </option>
+            <option
+              value="A(16)-B(16)-Outro(8)"
+            >
+              A(16)-B(16)-Outro(8)
+            </option>
+            <option
+              value="A(8)x4"
+            >
+              A(8)x4
+            </option>
+            <option
+              value="Intro(4)-A(8)-B(8)-C(8)-D(8)-E(8)-F(8)-Outro(4)"
+            >
+              Intro(4)-A(8)-B(8)-C(8)-D(8)-E(8)-F(8)-Outro(4)
+            </option>
+            <option
+              value="Intro(4)-A(7)-B(5)-C(7)-D(5)-E(7)-F(5)-Outro(4)"
+            >
+              Intro(4)-A(7)-B(5)-C(7)-D(5)-E(7)-F(5)-Outro(4)
+            </option>
+          </select>
+        </div>
+        <label
+          class="_label_62bdff"
+        >
+          Structure (bars)
+          <svg
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            style="margin-left: 4px; cursor: help; opacity: 0.6;"
+            viewBox="0 0 512 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>
+              Order of song sections with lengths and chords
+            </title>
+            <path
+              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+            />
+          </svg>
+        </label>
+        <div
+          class="flex gap-2 flex-wrap"
+        >
+          <div
+            class="bg-[#17191d] p-2 rounded-lg min-w-[120px]"
+          >
+            <div
+              class="_small_62bdff"
+            >
+              Intro
+            </div>
+            <input
+              class="_input_62bdff"
+              type="number"
+              value="4"
+            />
+            <input
+              class="_input_62bdff mt-1"
+              placeholder="Chords"
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="bg-[#17191d] p-2 rounded-lg min-w-[120px]"
+          >
+            <div
+              class="_small_62bdff"
+            >
+              A
+            </div>
+            <input
+              class="_input_62bdff"
+              type="number"
+              value="8"
+            />
+            <input
+              class="_input_62bdff mt-1"
+              placeholder="Chords"
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="bg-[#17191d] p-2 rounded-lg min-w-[120px]"
+          >
+            <div
+              class="_small_62bdff"
+            >
+              B
+            </div>
+            <input
+              class="_input_62bdff"
+              type="number"
+              value="8"
+            />
+            <input
+              class="_input_62bdff mt-1"
+              placeholder="Chords"
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="bg-[#17191d] p-2 rounded-lg min-w-[120px]"
+          >
+            <div
+              class="_small_62bdff"
+            >
+              A
+            </div>
+            <input
+              class="_input_62bdff"
+              type="number"
+              value="8"
+            />
+            <input
+              class="_input_62bdff mt-1"
+              placeholder="Chords"
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="bg-[#17191d] p-2 rounded-lg min-w-[120px]"
+          >
+            <div
+              class="_small_62bdff"
+            >
+              B
+            </div>
+            <input
+              class="_input_62bdff"
+              type="number"
+              value="8"
+            />
+            <input
+              class="_input_62bdff mt-1"
+              placeholder="Chords"
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="bg-[#17191d] p-2 rounded-lg min-w-[120px]"
+          >
+            <div
+              class="_small_62bdff"
+            >
+              Outro
+            </div>
+            <input
+              class="_input_62bdff"
+              type="number"
+              value="4"
+            />
+            <input
+              class="_input_62bdff mt-1"
+              placeholder="Chords"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="_small_62bdff"
+        >
+          Total Bars: 40 — Est. Time: 2:00
+        </div>
+      </div>
+      <div
+        class="_grid3_62bdff"
+      >
+        <div
+          class="_panel_62bdff"
+        >
+          <label
+            class="_label_62bdff"
+          >
+            Mood
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Tags describing the vibe
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </label>
+          <div
+            class="_optionGrid_62bdff"
+          >
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                calm
+              </span>
+              <input
+                checked=""
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                melancholy
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                cozy
+              </span>
+              <input
+                checked=""
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                nostalgic
+              </span>
+              <input
+                checked=""
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                fantasy
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                dreamy
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+          </div>
+        </div>
+        <div
+          class="_panel_62bdff"
+        >
+          <label
+            class="_label_62bdff"
+          >
+            Instruments
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Select instruments to include
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </label>
+          <div
+            class="_optionGrid_62bdff"
+          >
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                rhodes
+              </span>
+              <input
+                checked=""
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                nylon guitar
+              </span>
+              <input
+                checked=""
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                upright bass
+              </span>
+              <input
+                checked=""
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                pads
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                electric piano
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                piano
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                clean electric guitar
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                airy pads
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                vinyl sounds
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                acoustic guitar
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                violin
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                cello
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                flute
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                saxophone
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                trumpet
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                synth lead
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                string squeaks
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                key clicks
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                breath noise
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                harp
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                lute
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                pan flute
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                brush kit
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                shaker
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                tambourine
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                808 sub-kick
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                wurlitzer
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                celesta
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                music box
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                glockenspiel
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                vibraphone
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                marimba
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                muted electric guitar
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                muted trumpet
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                clarinet
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                oboe
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                field recordings
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                synth plucks
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                timpani
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                pipe organ
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                choir
+              </span>
+              <input
+                type="checkbox"
+              />
+            </label>
+          </div>
+          <div
+            class="_small_62bdff"
+          >
+            Drums are synthesized automatically.
+          </div>
+        </div>
+        <div
+          class="_panel_62bdff"
+        >
+          <label
+            class="_label_62bdff"
+          >
+            Lead Instrument
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Main instrument for the melody
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </label>
+          <div
+            class="_optionGrid_62bdff"
+          >
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                flute
+              </span>
+              <input
+                name="leadInstrument"
+                type="radio"
+                value="flute"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                sax
+              </span>
+              <input
+                name="leadInstrument"
+                type="radio"
+                value="saxophone"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                synth
+              </span>
+              <input
+                checked=""
+                name="leadInstrument"
+                type="radio"
+                value="synth lead"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                violin
+              </span>
+              <input
+                name="leadInstrument"
+                type="radio"
+                value="violin"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                clarinet
+              </span>
+              <input
+                name="leadInstrument"
+                type="radio"
+                value="clarinet"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                oboe
+              </span>
+              <input
+                name="leadInstrument"
+                type="radio"
+                value="oboe"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                muted trumpet
+              </span>
+              <input
+                name="leadInstrument"
+                type="radio"
+                value="muted trumpet"
+              />
+            </label>
+            <label
+              class="_optionCard_62bdff"
+            >
+              <span>
+                glockenspiel
+              </span>
+              <input
+                name="leadInstrument"
+                type="radio"
+                value="glockenspiel"
+              />
+            </label>
+          </div>
+        </div>
+        <div
+          class="_panel_62bdff"
+        >
+          <label
+            class="_label_62bdff"
+            for="ambience-select"
+          >
+            Ambience
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Background ambience sounds
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </label>
+          <select
+            class="_input_62bdff"
+            id="ambience-select"
+            multiple=""
+          >
+            <option
+              value="rain"
+            >
+              rain
+            </option>
+            <option
+              value="cafe"
+            >
+              cafe
+            </option>
+            <option
+              value="street"
+            >
+              street
+            </option>
+            <option
+              value="birds"
+            >
+              birds
+            </option>
+            <option
+              value="cicadas"
+            >
+              cicadas
+            </option>
+            <option
+              value="train"
+            >
+              train
+            </option>
+            <option
+              value="vinyl"
+            >
+              vinyl
+            </option>
+            <option
+              value="forest"
+            >
+              forest
+            </option>
+            <option
+              value="fireplace"
+            >
+              fireplace
+            </option>
+            <option
+              value="ocean"
+            >
+              ocean
+            </option>
+          </select>
+          <input
+            class="_slider_62bdff"
+            max="1"
+            min="0"
+            step="0.01"
+            type="range"
+            value="0.5"
+          />
+          <div
+            class="_small_62bdff"
+          >
+            50% intensity
+          </div>
+        </div>
+      </div>
+      <div
+        class="_grid3_62bdff"
+      >
+        <div
+          class="_panel_62bdff"
+        >
+          <label
+            class="_label_62bdff"
+          >
+            Drum Pattern
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Choose a groove style or no drums
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </label>
+          <select
+            class="_input_62bdff py-2 px-3"
+          >
+            <option
+              value="random"
+            >
+              random
+            </option>
+            <option
+              value="no_drums"
+            >
+              no_drums
+            </option>
+            <option
+              value="boom_bap_A"
+            >
+              boom_bap_A
+            </option>
+            <option
+              value="boom_bap_B"
+            >
+              boom_bap_B
+            </option>
+            <option
+              value="laidback"
+            >
+              laidback
+            </option>
+            <option
+              value="half_time"
+            >
+              half_time
+            </option>
+            <option
+              value="swing"
+            >
+              swing
+            </option>
+            <option
+              value="half_time_shuffle"
+            >
+              half_time_shuffle
+            </option>
+            <option
+              value="bossa_nova"
+            >
+              bossa_nova
+            </option>
+          </select>
+          <div
+            class="_small_62bdff"
+          >
+            Choose a groove or leave random.
+          </div>
+        </div>
+        <div
+          class="_panel_62bdff"
+        >
+          <label
+            class="_label_62bdff"
+          >
+            Variety
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Amount of fills and swing
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </label>
+          <input
+            class="_slider_62bdff"
+            max="100"
+            min="0"
+            type="range"
+            value="45"
+          />
+          <div
+            class="_small_62bdff"
+          >
+            45% fills & swing
+          </div>
+        </div>
+        <div
+          class="_panel_62bdff"
+        >
+          <label
+            class="_label_62bdff"
+          >
+            Chord Span
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Number of beats each chord lasts
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </label>
+          <select
+            class="_input_62bdff py-2 px-3"
+          >
+            <option
+              value="2"
+            >
+              ½ bar
+            </option>
+            <option
+              value="4"
+            >
+              1 bar
+            </option>
+            <option
+              value="8"
+            >
+              2 bars
+            </option>
+          </select>
+        </div>
+      </div>
+      <div
+        class="_panel_62bdff mt-3"
+      >
+        <details
+          open=""
+        >
+          <summary
+            class="cursor-pointer text-xs opacity-80"
+          >
+            Polish 
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Optional mix polish effects
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </summary>
+          <div
+            class="mt-2"
+          >
+            <div
+              class="_optionGrid_62bdff"
+            >
+              <label
+                class="_optionCard_62bdff"
+              >
+                <span>
+                  Stereo widen
+                </span>
+                <input
+                  checked=""
+                  type="checkbox"
+                />
+              </label>
+              <label
+                class="_optionCard_62bdff"
+              >
+                <span>
+                  Room reverb
+                </span>
+                <input
+                  checked=""
+                  type="checkbox"
+                />
+              </label>
+              <label
+                class="_optionCard_62bdff"
+              >
+                <span>
+                  Sidechain (kick)
+                </span>
+                <input
+                  checked=""
+                  type="checkbox"
+                />
+              </label>
+              <label
+                class="_optionCard_62bdff"
+              >
+                <span>
+                  Chorus
+                </span>
+                <input
+                  checked=""
+                  type="checkbox"
+                />
+              </label>
+            </div>
+            <details
+              class="mt-2"
+            >
+              <summary
+                class="cursor-pointer text-xs opacity-80"
+              >
+                Advanced
+              </summary>
+              <div
+                class="mt-2"
+              >
+                <label
+                  class="_label_62bdff"
+                >
+                  Limiter Drive
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    style="margin-left: 4px; cursor: help; opacity: 0.6;"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <title>
+                      Amount of saturation added by the limiter
+                    </title>
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </label>
+                <input
+                  class="_slider_62bdff"
+                  max="2"
+                  min="0.5"
+                  step="0.01"
+                  type="range"
+                  value="1.02"
+                />
+                <div
+                  class="_small_62bdff"
+                >
+                  1.02× saturation
+                </div>
+                <div
+                  class="_toggle_62bdff mt-2"
+                >
+                  <input
+                    checked=""
+                    type="checkbox"
+                  />
+                  <span
+                    class="_small_62bdff"
+                  >
+                    Dither
+                  </span>
+                </div>
+              </div>
+            </details>
+          </div>
+        </details>
+      </div>
+      <div
+        class="_panel_62bdff"
+      >
+        <label
+          class="_toggle_62bdff"
+        >
+          <input
+            type="checkbox"
+          />
+          <span
+            class="_small_62bdff"
+          >
+            Album mode
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Render multiple tracks as an album
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </span>
+        </label>
+      </div>
+      <div
+        class="_grid2_62bdff"
+      >
+        <div
+          class="_panel_62bdff"
+        >
+          <label
+            class="_label_62bdff"
+          >
+            How many songs?
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Number of songs to render in this batch
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </label>
+          <input
+            class="_input_62bdff"
+            min="1"
+            type="number"
+            value="1"
+          />
+          <div
+            class="_small_62bdff mt-2"
+          >
+            Titles will be suffixed with 
+            <select
+              class="_input_62bdff py-1 px-2 inline-block w-[160px] ml-1"
+            >
+              <option
+                value="number"
+              >
+                # (1, 2, 3…)
+              </option>
+              <option
+                value="timestamp"
+              >
+                timestamp
+              </option>
+            </select>
+          </div>
+        </div>
+        <div
+          class="_panel_62bdff"
+        >
+          <label
+            class="_label_62bdff"
+          >
+            BPM Jitter (per song)
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              style="margin-left: 4px; cursor: help; opacity: 0.6;"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                Random tempo variation around base BPM
+              </title>
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </label>
+          <input
+            class="_slider_62bdff"
+            max="30"
+            min="0"
+            type="range"
+            value="5"
+          />
+          <div
+            class="_small_62bdff"
+          >
+            ±5% around the base BPM
+          </div>
+          <div
+            class="_toggle_62bdff mt-2"
+          >
+            <input
+              checked=""
+              type="checkbox"
+            />
+            <span
+              class="_small_62bdff"
+            >
+              Auto‑play last successful render
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="_actions_62bdff"
+      >
+        <button
+          class="_btn_62bdff"
+          disabled=""
+        >
+          Render Songs
+        </button>
+        <button
+          class="_playBtn_62bdff"
+        >
+          Preview in browser
+        </button>
+        <button
+          class="_playBtn_62bdff"
+        >
+          Play last track
+        </button>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+declare module "*.module.css";


### PR DESCRIPTION
## Summary
- create `SongForm.module.css` for reusable panel, button, and option-card styles
- refactor SongForm and subcomponents to use className-based styling
- add snapshot test for SongForm rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7d68603ec8325bededb21a4c3dea0