### PR TITLE
feat: schedule tasks on calendar

### DIFF
--- a/src/features/calendar/tests/useCalendar.test.ts
+++ b/src/features/calendar/tests/useCalendar.test.ts
@@ -23,6 +23,19 @@ describe('useCalendar store', () => {
     expect(state.events[0].title).toBe('Test');
   });
 
+  it('schedules a task with tags', () => {
+    useCalendar.getState().scheduleTask(
+      'Music gen',
+      '2024-01-01T09:00',
+      '2024-01-01T10:00',
+      ['music']
+    );
+    const ev = useCalendar.getState().events[0];
+    expect(ev.title).toBe('Music gen');
+    expect(ev.tags).toEqual(['task', 'music']);
+    expect(ev.status).toBe('scheduled');
+  });
+
   it('rejects invalid additions', () => {
     const add = useCalendar.getState().addEvent;
     add({

--- a/src/features/calendar/useCalendar.ts
+++ b/src/features/calendar/useCalendar.ts
@@ -8,11 +8,18 @@ interface Actions {
   updateEvent: (id: string, patch: Partial<CalendarEvent>) => void;
   removeEvent: (id: string) => void;
   setSelectedCountdownId: (id: string | null) => void;
+  /** Schedule a task and tag it for the calendar */
+  scheduleTask: (
+    title: string,
+    date: string,
+    end: string,
+    tags?: string[]
+  ) => void;
 }
 
 export const useCalendar = create<CalendarState & Actions>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       events: [],
       selectedCountdownId: null,
       tagTotals: {},
@@ -34,6 +41,15 @@ export const useCalendar = create<CalendarState & Actions>()(
           return { events, tagTotals };
         });
       },
+      scheduleTask: (title, date, end, tags = []) =>
+        get().addEvent({
+          title,
+          date,
+          end,
+          tags: ['task', ...tags],
+          status: 'scheduled',
+          hasCountdown: false,
+        }),
       updateEvent: (id, patch) =>
         set((state) => {
           const ev = state.events.find((e) => e.id === id);


### PR DESCRIPTION
## Summary
- add `scheduleTask` action to calendar store
- default new task events to include `task` tag plus custom tags
- test scheduling and tagging of calendar tasks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7db8d33f4832580eaa72f1dfa97f8