### PR TITLE
Add rulebook and spellbook tabs to DND section

### DIFF
--- a/src/features/dnd/RuleForm.tsx
+++ b/src/features/dnd/RuleForm.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { Typography, TextField, Button } from "@mui/material";
+import { zRule } from "./schemas";
+import type { RuleData } from "./types";
+
+export default function RuleForm() {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [tags, setTags] = useState("");
+  const [result, setResult] = useState<RuleData | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: RuleData = {
+      id: crypto.randomUUID(),
+      name,
+      description,
+      tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
+    };
+    const parsed = zRule.parse(data);
+    setResult(parsed);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Typography variant="h6">Rulebook</Typography>
+      <TextField
+        label="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        fullWidth
+        multiline
+        margin="normal"
+      />
+      <TextField
+        label="Tags (comma separated)"
+        value={tags}
+        onChange={(e) => setTags(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+        Submit
+      </Button>
+      {result && <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>}
+    </form>
+  );
+}

--- a/src/features/dnd/SpellForm.tsx
+++ b/src/features/dnd/SpellForm.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { Typography, TextField, Button } from "@mui/material";
+import { zSpell } from "./schemas";
+import type { SpellData } from "./types";
+
+export default function SpellForm() {
+  const [name, setName] = useState("");
+  const [level, setLevel] = useState("");
+  const [school, setSchool] = useState("");
+  const [castingTime, setCastingTime] = useState("");
+  const [range, setRange] = useState("");
+  const [components, setComponents] = useState("");
+  const [duration, setDuration] = useState("");
+  const [description, setDescription] = useState("");
+  const [tags, setTags] = useState("");
+  const [result, setResult] = useState<SpellData | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: SpellData = {
+      id: crypto.randomUUID(),
+      name,
+      level: Number(level),
+      school,
+      castingTime,
+      range,
+      components: components.split(",").map((c) => c.trim()).filter(Boolean),
+      duration,
+      description,
+      tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
+    };
+    const parsed = zSpell.parse(data);
+    setResult(parsed);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Typography variant="h6">Spellbook</Typography>
+      <TextField
+        label="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Level"
+        value={level}
+        onChange={(e) => setLevel(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="School"
+        value={school}
+        onChange={(e) => setSchool(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Casting Time"
+        value={castingTime}
+        onChange={(e) => setCastingTime(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Range"
+        value={range}
+        onChange={(e) => setRange(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Components (comma separated)"
+        value={components}
+        onChange={(e) => setComponents(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Duration"
+        value={duration}
+        onChange={(e) => setDuration(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
+        label="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        fullWidth
+        multiline
+        margin="normal"
+      />
+      <TextField
+        label="Tags (comma separated)"
+        value={tags}
+        onChange={(e) => setTags(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+        Submit
+      </Button>
+      {result && <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>}
+    </form>
+  );
+}

--- a/src/features/dnd/schemas.ts
+++ b/src/features/dnd/schemas.ts
@@ -48,3 +48,19 @@ export const zEncounter = zDndBase.extend({
   scaling: z.string().min(1),
   theme: zDndTheme,
 });
+
+export const zRule = zDndBase.extend({
+  description: z.string().min(1),
+  tags: z.array(z.string()).nonempty(),
+});
+
+export const zSpell = zDndBase.extend({
+  level: z.number().int().nonnegative(),
+  school: z.string().min(1),
+  castingTime: z.string().min(1),
+  range: z.string().min(1),
+  components: z.array(z.string()).nonempty(),
+  duration: z.string().min(1),
+  description: z.string().min(1),
+  tags: z.array(z.string()).nonempty(),
+});

--- a/src/features/dnd/tests/schemas.test.ts
+++ b/src/features/dnd/tests/schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { zLore, zQuest, zEncounter } from "../schemas";
+import { zLore, zQuest, zEncounter, zRule, zSpell } from "../schemas";
 import { zNpc } from "../../../dnd/schemas/npc";
 
 describe("dnd schemas", () => {
@@ -229,5 +229,56 @@ describe("dnd schemas", () => {
       theme: "Minimal",
     } as any;
     expect(() => zEncounter.parse(encounter)).toThrowError();
+  });
+
+  it("parses Rule data", () => {
+    const rule = {
+      id: "r1",
+      name: "Flanking",
+      description: "Gain advantage when allies surround an enemy",
+      tags: ["combat"],
+    };
+    expect(zRule.parse(rule)).toEqual(rule);
+  });
+
+  it("rejects Rules missing required fields", () => {
+    const rule = {
+      id: "r1",
+      description: "Gain advantage",
+      tags: ["combat"],
+    };
+    expect(() => zRule.parse(rule)).toThrowError();
+  });
+
+  it("parses Spell data", () => {
+    const spell = {
+      id: "s1",
+      name: "Fireball",
+      level: 3,
+      school: "Evocation",
+      castingTime: "1 action",
+      range: "150 feet",
+      components: ["V", "S", "M"],
+      duration: "Instantaneous",
+      description: "A bright streak flashes from your pointing finger to a point you choose.",
+      tags: ["damage"],
+    };
+    expect(zSpell.parse(spell)).toEqual(spell);
+  });
+
+  it("rejects Spells with invalid level type", () => {
+    const spell = {
+      id: "s1",
+      name: "Fireball",
+      level: "3",
+      school: "Evocation",
+      castingTime: "1 action",
+      range: "150 feet",
+      components: ["V", "S", "M"],
+      duration: "Instantaneous",
+      description: "A bright streak flashes from your pointing finger to a point you choose.",
+      tags: ["damage"],
+    } as any;
+    expect(() => zSpell.parse(spell)).toThrowError();
   });
 });

--- a/src/features/dnd/types.ts
+++ b/src/features/dnd/types.ts
@@ -38,3 +38,19 @@ export interface EncounterData extends DndBase {
   scaling: string;
   theme: DndTheme;
 }
+
+export interface RuleData extends DndBase {
+  description: string;
+  tags: string[];
+}
+
+export interface SpellData extends DndBase {
+  level: number;
+  school: string;
+  castingTime: string;
+  range: string;
+  components: string[];
+  duration: string;
+  description: string;
+  tags: string[];
+}

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -4,6 +4,8 @@ import NpcForm from "../features/dnd/NpcForm";
 import LoreForm from "../features/dnd/LoreForm";
 import QuestForm from "../features/dnd/QuestForm";
 import EncounterForm from "../features/dnd/EncounterForm";
+import RuleForm from "../features/dnd/RuleForm";
+import SpellForm from "../features/dnd/SpellForm";
 
 export default function DND() {
   const [tab, setTab] = useState(0);
@@ -15,11 +17,15 @@ export default function DND() {
         <Tab label="Lore" />
         <Tab label="Quest" />
         <Tab label="Encounter" />
+        <Tab label="Rulebook" />
+        <Tab label="Spellbook" />
       </Tabs>
       {tab === 0 && <NpcForm />}
       {tab === 1 && <LoreForm />}
       {tab === 2 && <QuestForm />}
       {tab === 3 && <EncounterForm />}
+      {tab === 4 && <RuleForm />}
+      {tab === 5 && <SpellForm />}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add Rulebook and Spellbook tabs with corresponding forms
- define schemas and types for rules and spells
- extend tests to cover new DND schemas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8101144608325a1ec6fc760249649