### PR TITLE
Align calendar with current theme

### DIFF
--- a/src/components/CalendarDay.tsx
+++ b/src/components/CalendarDay.tsx
@@ -1,6 +1,6 @@
 import { Box, Typography, Tooltip } from '@mui/material';
 import React, { useCallback } from 'react';
-import { statusColors } from '../features/calendar/statusColors';
+import { useStatusColors } from '../features/calendar/statusColors';
 import type { CalendarEvent } from '../features/calendar/types';
 
 interface Props {
@@ -25,6 +25,7 @@ const CalendarDay = React.memo(
     isSelected,
     holiday,
   }: Props) => {
+    const statusColors = useStatusColors();
     if (!day) {
       return <Box sx={{ minHeight: 96, bgcolor: 'grey.50' }} />;
     }

--- a/src/features/calendar/statusColors.ts
+++ b/src/features/calendar/statusColors.ts
@@ -1,9 +1,14 @@
-import type { CalendarEvent } from './types';
-import { colors } from '../../theme';
+import { useTheme } from "@mui/material/styles";
+import type { CalendarEvent } from "./types";
 
-export const statusColors: Record<CalendarEvent['status'], string> = {
-  scheduled: colors.status.scheduled,
-  canceled: colors.status.canceled,
-  missed: colors.status.missed,
-  completed: colors.status.completed,
-};
+// Provide status colors that adapt to the current MUI theme.
+export function useStatusColors(): Record<CalendarEvent["status"], string> {
+  const theme = useTheme();
+  return {
+    scheduled: theme.palette.primary.main,
+    canceled: theme.palette.error.main,
+    missed: theme.palette.warning.main,
+    completed: theme.palette.success.main,
+  };
+}
+

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -13,6 +13,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -24,7 +25,7 @@ import TagStats from "../components/TagStats";
 import WeekView from "../components/WeekView";
 import AgendaView from "../components/AgendaView";
 import { useCalendar } from "../features/calendar/useCalendar";
-import { statusColors } from "../features/calendar/statusColors";
+import { useStatusColors } from "../features/calendar/statusColors";
 import type { CalendarEvent } from "../features/calendar/types";
 import { toLocalNaive } from "../utils/time";
 
@@ -74,6 +75,8 @@ export default function Calendar() {
   const addEvent = useCalendar((s) => s.addEvent);
   const updateEvent = useCalendar((s) => s.updateEvent);
   const removeEvent = useCalendar((s) => s.removeEvent);
+  const statusColors = useStatusColors();
+  const theme = useTheme();
   const eventsRef = useRef(events);
   useEffect(() => {
     eventsRef.current = events;
@@ -382,7 +385,9 @@ export default function Calendar() {
                             py: 0.25,
                             borderRadius: 1,
                             bgcolor: statusColors[ev.status],
-                            color: "#fff",
+                            color: theme.palette.getContrastText(
+                              statusColors[ev.status]
+                            ),
                             fontSize: 12,
                           }}
                         >
@@ -554,7 +559,9 @@ export default function Calendar() {
                           py: 0.25,
                           borderRadius: 1,
                           bgcolor: statusColors[ev.status],
-                          color: "#fff",
+                          color: theme.palette.getContrastText(
+                            statusColors[ev.status]
+                          ),
                           fontSize: 12,
                         }}
                       >


### PR DESCRIPTION
## Summary
- Convert static calendar status colors to a hook that derives colors from the active MUI theme.
- Update CalendarDay and Calendar to use theme-based status colors and contrast text.

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a8109573988325b29cb5ac4fec7bbf