### PR TITLE
feat: add configurable stock metrics view

### DIFF
--- a/src-tauri/src/stocks.rs
+++ b/src-tauri/src/stocks.rs
@@ -26,6 +26,8 @@ pub struct Quote {
     pub change_percent: f64,
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub volume: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 
@@ -140,6 +142,9 @@ impl Provider for YahooProvider {
             .and_then(|v| v.as_str())
             .unwrap_or("UNKNOWN")
             .to_string();
+        let volume = result
+            .get("regularMarketVolume")
+            .and_then(|v| v.as_u64());
         log::info!(
             "quote {} fetched in {} ms ({} bytes)",
             ticker,
@@ -151,6 +156,7 @@ impl Provider for YahooProvider {
             price,
             change_percent,
             status,
+            volume,
             error: None,
         })
     }
@@ -208,6 +214,7 @@ impl Provider for StubProvider {
             price: 100.0,
             change_percent: 0.0,
             status: "STUB".into(),
+            volume: Some(0),
             error: None,
         })
     }

--- a/src/components/StockRow.test.tsx
+++ b/src/components/StockRow.test.tsx
@@ -8,6 +8,7 @@ const baseQuote = {
   changePercent: 1,
   history: [1, 2, 3],
   marketStatus: 'OPEN',
+  volume: 1000,
   lastFetched: Date.now(),
 };
 
@@ -28,14 +29,24 @@ describe('StockRow', () => {
 
   it('renders quote data', async () => {
     useStocks.setState({ quotes: { AAPL: baseQuote } });
-    const { asFragment } = render(<StockRow symbol="AAPL" />);
+    const { asFragment } = render(
+      <StockRow
+        symbol="AAPL"
+        metrics={{ price: true, change: true, volume: true, trend: true }}
+      />
+    );
     await Promise.resolve();
     expect(asFragment()).toMatchSnapshot();
   });
 
   it('renders error message when present', () => {
     useStocks.setState({ quotes: { AAPL: { ...baseQuote, error: 'fail' } } });
-    const { getByText } = render(<StockRow symbol="AAPL" />);
+    const { getByText } = render(
+      <StockRow
+        symbol="AAPL"
+        metrics={{ price: true, change: true, volume: true, trend: true }}
+      />
+    );
     expect(getByText('fail')).toBeInTheDocument();
   });
 });

--- a/src/components/StockRow.tsx
+++ b/src/components/StockRow.tsx
@@ -4,7 +4,14 @@ import DeleteIcon from "@mui/icons-material/Delete";
 import Sparkline from "./Sparkline";
 import { useStocks } from "../store/stocks";
 
-function StockRow({ symbol }: { symbol: string }) {
+interface MetricConfig {
+  price: boolean;
+  change: boolean;
+  volume: boolean;
+  trend: boolean;
+}
+
+function StockRow({ symbol, metrics }: { symbol: string; metrics: MetricConfig }) {
   const quote = useStocks((state) => state.quotes[symbol]);
   const removeStock = useStocks((state) => state.removeStock);
   const [forecast, setForecast] = useState<{ shortTerm: string; longTerm: string } | null>(null);
@@ -48,12 +55,25 @@ function StockRow({ symbol }: { symbol: string }) {
               </Typography>
             ) : (
               <Fade in={!!quote}>
-                <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
-                  <Typography sx={{ width: 120, color }}>
-                    {quote.price.toFixed(2)} ({quote.changePercent.toFixed(2)}%)
-                  </Typography>
-                  <Typography sx={{ width: 80 }}>{quote.marketStatus}</Typography>
-                  <Sparkline data={quote.history} color={color} />
+                <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}>
+                  {metrics.price && (
+                    <Typography sx={{ width: 100, color }}>
+                      {quote.price.toFixed(2)}
+                    </Typography>
+                  )}
+                  {metrics.change && (
+                    <Typography sx={{ width: 100, color }}>
+                      {quote.changePercent.toFixed(2)}%
+                    </Typography>
+                  )}
+                  {metrics.volume && (
+                    <Typography sx={{ width: 120 }}>
+                      {quote.volume ? quote.volume.toLocaleString() : "N/A"}
+                    </Typography>
+                  )}
+                  {metrics.trend && (
+                    <Sparkline data={quote.history} color={color} />
+                  )}
                 </Box>
               </Fade>
             )

--- a/src/components/__snapshots__/StockRow.test.tsx.snap
+++ b/src/components/__snapshots__/StockRow.test.tsx.snap
@@ -17,18 +17,23 @@ exports[`StockRow > renders quote data 1`] = `
           AAPL
         </p>
         <div
-          class="MuiBox-root css-j0ozid"
+          class="MuiBox-root css-128maw8"
           style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         >
           <p
-            class="MuiTypography-root MuiTypography-body1 css-tsexvv-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 css-16aoomd-MuiTypography-root"
           >
-            123.00 (1.00%)
+            123.00
           </p>
           <p
-            class="MuiTypography-root MuiTypography-body1 css-1019lio-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 css-16aoomd-MuiTypography-root"
           >
-            OPEN
+            1.00%
+          </p>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1vrcrf3-MuiTypography-root"
+          >
+            1,000
           </p>
           <svg
             class="MuiBox-root css-1bayzp8"

--- a/src/pages/Stocks.tsx
+++ b/src/pages/Stocks.tsx
@@ -1,11 +1,24 @@
 import { useState } from "react";
-import { Box, Button, TextField, List } from "@mui/material";
+import {
+  Box,
+  Button,
+  TextField,
+  List,
+  FormGroup,
+  FormControlLabel,
+  Checkbox,
+} from "@mui/material";
 import { useShallow } from "zustand/react/shallow";
 import StockRow from "../components/StockRow";
 import { useStocks } from "../store/stocks";
 
 export default function Stocks() {
   const [symbol, setSymbol] = useState("");
+  const defaultMetrics = { price: true, change: true, volume: true, trend: true };
+  const [metrics, setMetrics] = useState(() => {
+    const saved = localStorage.getItem("stockMetrics");
+    return saved ? { ...defaultMetrics, ...JSON.parse(saved) } : defaultMetrics;
+  });
   const { symbols, addStock } = useStocks(
     useShallow((state) => ({ symbols: state.symbols, addStock: state.addStock }))
   );
@@ -16,6 +29,14 @@ export default function Stocks() {
       addStock(sym);
       setSymbol("");
     }
+  };
+
+  const toggleMetric = (key: keyof typeof defaultMetrics) => {
+    setMetrics((prev) => {
+      const next = { ...prev, [key]: !prev[key] };
+      localStorage.setItem("stockMetrics", JSON.stringify(next));
+      return next;
+    });
   };
 
   return (
@@ -31,9 +52,27 @@ export default function Stocks() {
           Add
         </Button>
       </Box>
+      <FormGroup row sx={{ mb: 2 }}>
+        <FormControlLabel
+          control={<Checkbox checked={metrics.price} onChange={() => toggleMetric("price")} />}
+          label="Price"
+        />
+        <FormControlLabel
+          control={<Checkbox checked={metrics.change} onChange={() => toggleMetric("change")} />}
+          label="% Change"
+        />
+        <FormControlLabel
+          control={<Checkbox checked={metrics.volume} onChange={() => toggleMetric("volume")} />}
+          label="Volume"
+        />
+        <FormControlLabel
+          control={<Checkbox checked={metrics.trend} onChange={() => toggleMetric("trend")} />}
+          label="Trend"
+        />
+      </FormGroup>
       <List>
         {symbols.map((s) => (
-          <StockRow key={s} symbol={s} />
+          <StockRow key={s} symbol={s} metrics={metrics} />
         ))}
       </List>
     </Box>

--- a/src/store/stocks.test.ts
+++ b/src/store/stocks.test.ts
@@ -19,7 +19,7 @@ describe('useStocks store', () => {
 
   it('fetches quotes through the backend', async () => {
     (invoke as any).mockResolvedValue({
-      quotes: [{ price: 123, change_percent: 1, status: 'OPEN' }],
+      quotes: [{ price: 123, change_percent: 1, status: 'OPEN', volume: 1000 }],
       series: [{ points: [{ close: 1 }, { close: 2 }, { close: 3 }] }],
       market: { phase: 'OPEN' },
       stale: false,
@@ -31,7 +31,7 @@ describe('useStocks store', () => {
 
   it('captures quote errors from the backend', async () => {
     (invoke as any).mockResolvedValue({
-      quotes: [{ price: 0, change_percent: 0, status: 'CLOSED', error: 'fail' }],
+      quotes: [{ price: 0, change_percent: 0, status: 'CLOSED', volume: 0, error: 'fail' }],
       series: [{ points: [] }],
       market: { phase: 'CLOSED' },
       stale: false,
@@ -50,7 +50,7 @@ describe('useStocks store', () => {
   it('polls for updates when started', async () => {
     vi.useFakeTimers();
     (invoke as any).mockResolvedValue({
-      quotes: [{ price: 100, change_percent: 0, status: 'CLOSED' }],
+      quotes: [{ price: 100, change_percent: 0, status: 'CLOSED', volume: 0 }],
       series: [{ points: [{ close: 100 }] }],
       market: { phase: 'CLOSED' },
       stale: false,
@@ -65,7 +65,7 @@ describe('useStocks store', () => {
   it('ignores duplicate polling requests', async () => {
     vi.useFakeTimers();
     (invoke as any).mockResolvedValue({
-      quotes: [{ price: 100, change_percent: 0, status: 'CLOSED' }],
+      quotes: [{ price: 100, change_percent: 0, status: 'CLOSED', volume: 0 }],
       series: [{ points: [{ close: 100 }] }],
       market: { phase: 'CLOSED' },
       stale: false,

--- a/src/store/stocks.ts
+++ b/src/store/stocks.ts
@@ -11,6 +11,7 @@ interface Quote {
   changePercent: number;
   history: number[];
   marketStatus: string;
+  volume: number;
   lastFetched: number;
   // Optional error message from backend
   error?: string;
@@ -52,7 +53,7 @@ export const useStocks = create<StockState>((set, get) => ({
     const fetchSym = SYMBOL_MAP[sym] ?? sym;
     try {
       const bundle = await invoke<{
-        quotes: { price: number; change_percent: number; status: string; error?: string }[];
+        quotes: { price: number; change_percent: number; status: string; volume?: number; error?: string }[];
         series: { points: { ts: number; close: number }[] }[];
         market: { phase: string };
         stale: boolean;
@@ -67,6 +68,7 @@ export const useStocks = create<StockState>((set, get) => ({
           [sym]: {
             price: quote?.price ?? 0,
             changePercent: quote?.change_percent ?? 0,
+            volume: quote?.volume ?? 0,
             history,
             marketStatus: market_status,
             lastFetched: Date.now(),
@@ -82,6 +84,7 @@ export const useStocks = create<StockState>((set, get) => ({
           state.quotes[sym] ?? {
             price: NaN,
             changePercent: NaN,
+            volume: 0,
             history: [],
             marketStatus: '',
             lastFetched: Date.now(),


### PR DESCRIPTION
## Summary
- allow users to toggle which stock metrics are visible
- display volume alongside price, percentage change and trend sparkline
- include volume in backend and store quote data

## Testing
- `npm test -- -u`
- `cargo test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8130813708325b69f958ca5efdf4a