### PR TITLE
Add real-time stock streaming and price flash animation

### DIFF
--- a/src/components/StockRow.test.tsx
+++ b/src/components/StockRow.test.tsx
@@ -16,6 +16,7 @@ describe('StockRow', () => {
   beforeEach(() => {
     useStocks.setState({
       quotes: {},
+      ws: {},
       removeStock: vi.fn(),
       forecast: vi.fn().mockResolvedValue({ shortTerm: 'st', longTerm: 'lt' }),
       fetchNews: vi.fn().mockResolvedValue([]),
@@ -23,7 +24,7 @@ describe('StockRow', () => {
   });
 
   afterEach(() => {
-    useStocks.setState({ quotes: {}, forecast: undefined, fetchNews: undefined } as any);
+    useStocks.setState({ quotes: {}, ws: {}, forecast: undefined, fetchNews: undefined } as any);
     cleanup();
   });
 

--- a/src/components/__snapshots__/StockRow.test.tsx.snap
+++ b/src/components/__snapshots__/StockRow.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`StockRow > renders quote data 1`] = `
           style="opacity: 1; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
         >
           <p
-            class="MuiTypography-root MuiTypography-body1 css-16aoomd-MuiTypography-root"
+            class="MuiTypography-root MuiTypography-body1 css-vjag8l-MuiTypography-root"
           >
             123.00
           </p>


### PR DESCRIPTION
## Summary
- stream live prices through Binance websockets
- highlight price changes with subtle color flash animations
- cover realtime logic with unit tests and update snapshots

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a815a75aa48325a86a607b69b84e97