### PR TITLE
feat: add custom rule creation

### DIFF
--- a/src/features/dnd/RuleForm.tsx
+++ b/src/features/dnd/RuleForm.tsx
@@ -1,13 +1,55 @@
 import { useState } from "react";
-import { Typography, TextField, Button } from "@mui/material";
+import {
+  Typography,
+  TextField,
+  Button,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+} from "@mui/material";
 import { zRule } from "./schemas";
 import type { RuleData } from "./types";
+import rulesIndex from "../../../dnd/rules/index.json";
+
+const ruleFiles = import.meta.glob("../../../dnd/rules/*.md", {
+  as: "raw",
+  eager: true,
+});
+
+const existingRules: RuleData[] = (rulesIndex as any).map((r: any) => ({
+  id: r.id,
+  name: r.name,
+  description: (ruleFiles[`../../../${r.path}`] as string) || "",
+  tags: r.tags,
+}));
 
 export default function RuleForm() {
+  const [selectedId, setSelectedId] = useState("new");
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [tags, setTags] = useState("");
   const [result, setResult] = useState<RuleData | null>(null);
+  const [originalRule, setOriginalRule] = useState<RuleData | null>(null);
+
+  const handleSelect = (e: any) => {
+    const id = e.target.value;
+    setSelectedId(id);
+    if (id === "new") {
+      setName("");
+      setDescription("");
+      setTags("");
+      setOriginalRule(null);
+    } else {
+      const rule = existingRules.find((r) => r.id === id);
+      if (rule) {
+        setName(rule.name);
+        setDescription(rule.description);
+        setTags(rule.tags.join(", "));
+        setOriginalRule(rule);
+      }
+    }
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -16,6 +58,7 @@ export default function RuleForm() {
       name,
       description,
       tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
+      ...(originalRule ? { sourceId: originalRule.id } : {}),
     };
     const parsed = zRule.parse(data);
     setResult(parsed);
@@ -24,6 +67,22 @@ export default function RuleForm() {
   return (
     <form onSubmit={handleSubmit}>
       <Typography variant="h6">Rulebook</Typography>
+      <FormControl fullWidth margin="normal">
+        <InputLabel id="rule-select-label">Base Rule</InputLabel>
+        <Select
+          labelId="rule-select-label"
+          value={selectedId}
+          label="Base Rule"
+          onChange={handleSelect}
+        >
+          <MenuItem value="new">Create New Rule</MenuItem>
+          {existingRules.map((r) => (
+            <MenuItem key={r.id} value={r.id}>
+              {r.name}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
       <TextField
         label="Name"
         value={name}
@@ -49,7 +108,13 @@ export default function RuleForm() {
       <Button type="submit" variant="contained" sx={{ mt: 2 }}>
         Submit
       </Button>
-      {result && <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>}
+      {result && (
+        <pre style={{ marginTop: "1rem" }}>
+          {originalRule &&
+            `Original:\n${JSON.stringify(originalRule, null, 2)}\n\n`}
+          {`Custom:\n${JSON.stringify(result, null, 2)}`}
+        </pre>
+      )}
     </form>
   );
 }

--- a/src/features/dnd/schemas.ts
+++ b/src/features/dnd/schemas.ts
@@ -52,6 +52,7 @@ export const zEncounter = zDndBase.extend({
 export const zRule = zDndBase.extend({
   description: z.string().min(1),
   tags: z.array(z.string()).nonempty(),
+  sourceId: z.string().min(1).optional(),
 });
 
 export const zSpell = zDndBase.extend({

--- a/src/features/dnd/tests/RuleForm.test.tsx
+++ b/src/features/dnd/tests/RuleForm.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import RuleForm from '../RuleForm';
+
+describe('RuleForm custom rules', () => {
+  it('copies existing rule and shows original and custom', async () => {
+    render(<RuleForm />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByLabelText(/Base Rule/i));
+    await user.click(await screen.findByRole('option', { name: 'Ability Checks' }));
+    const nameInput = screen.getByLabelText(/Name/i);
+    expect(nameInput).toHaveValue('Ability Checks');
+
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Ability Checks Custom');
+    const tagsInput = screen.getByLabelText(/Tags/i);
+    await user.clear(tagsInput);
+    await user.type(tagsInput, 'custom');
+    const descInput = screen.getByLabelText(/Description/i);
+    await user.clear(descInput);
+    await user.type(descInput, 'desc');
+
+    await user.click(screen.getByRole('button', { name: /submit/i }));
+    const output = await screen.findByText(/Custom:/);
+    expect(output).toHaveTextContent('Original');
+    expect(output).toHaveTextContent('Ability Checks');
+    expect(output).toHaveTextContent('Ability Checks Custom');
+  });
+});

--- a/src/features/dnd/types.ts
+++ b/src/features/dnd/types.ts
@@ -42,6 +42,7 @@ export interface EncounterData extends DndBase {
 export interface RuleData extends DndBase {
   description: string;
   tags: string[];
+  sourceId?: string;
 }
 
 export interface SpellData extends DndBase {


### PR DESCRIPTION
## Summary
- allow creating custom rules from scratch or by copying existing ones
- keep originals untouched and show both original and custom after submission
- cover rule copying with new tests

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a8150103a08325b1503215c01d1804