### PR TITLE
feat: add intent detector

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -54,6 +54,7 @@ fn main() {
             commands::start_ollama,
             commands::stop_ollama,
             commands::general_chat,
+            commands::detect_intent,
             // PDF tools:
             commands::pdf_add,
             commands::pdf_remove,


### PR DESCRIPTION
## Summary
- add `detect_intent` tauri command to classify messages using Ollama
- expose `detect_intent` through Tauri invoke handler

## Testing
- `npm test`
- `cargo test` *(fails: type annotations needed in src/stocks.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68a8175c07e08325bd5e782e9acde217