### PR TITLE
Add tooltips and ranges for audio controls

### DIFF
--- a/src/components/BatchActions.tsx
+++ b/src/components/BatchActions.tsx
@@ -74,7 +74,7 @@ export default function BatchActions({
 
         <div className={styles.panel}>
           <label className={styles.label}>
-            BPM Jitter (per song)
+            BPM Jitter (0-30%, per song)
             <HelpIcon text="Random tempo variation around base BPM" />
           </label>
           <input

--- a/src/components/RhythmControls.tsx
+++ b/src/components/RhythmControls.tsx
@@ -45,7 +45,7 @@ export default function RhythmControls({
 
       <div className={styles.panel}>
         <label className={styles.label}>
-          Variety
+          Variety (0-100%)
           <HelpIcon text="Amount of fills and swing" />
         </label>
         <input

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -19,6 +19,7 @@ import { usePaths } from "../features/paths/usePaths";
 import { useOutput } from "../features/output/useOutput";
 import { useAudioDefaults } from "../features/audioDefaults/useAudioDefaults";
 import { useTheme, type Theme } from "../features/theme/ThemeContext";
+import HelpIcon from "./HelpIcon";
 
 const KEY_OPTIONS = [
   "Auto",
@@ -168,11 +169,21 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
           </FormControl>
           <FormControlLabel
             control={<Switch checked={hqStereo} onChange={toggleHqStereo} />}
-            label="HQ Stereo"
+            label={
+              <span style={{ display: "inline-flex", alignItems: "center" }}>
+                HQ Stereo
+                <HelpIcon text="Enhanced stereo width for clearer separation" />
+              </span>
+            }
           />
           <FormControlLabel
             control={<Switch checked={hqReverb} onChange={toggleHqReverb} />}
-            label="HQ Reverb"
+            label={
+              <span style={{ display: "inline-flex", alignItems: "center" }}>
+                HQ Reverb
+                <HelpIcon text="High-quality reverb for a more natural space" />
+              </span>
+            }
           />
           <FormControlLabel
             control={<Switch checked={hqSidechain} onChange={toggleHqSidechain} />}

--- a/src/components/VibeControls.tsx
+++ b/src/components/VibeControls.tsx
@@ -83,7 +83,7 @@ export default function VibeControls({
       <div className={styles.panel}>
         <label className={styles.label}>
           Lead Instrument
-          <HelpIcon text="Main instrument for the melody" />
+          <HelpIcon text="Choose the instrument that carries the main melody" />
         </label>
         <div className={styles.optionGrid}>
           {LEAD_INSTR.map((l) => (

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -1367,7 +1367,7 @@ exports[`SongForm > renders default form 1`] = `
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <title>
-                    Main instrument for the melody
+                    Choose the instrument that carries the main melody
                   </title>
                   <path
                     d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
@@ -1676,7 +1676,7 @@ exports[`SongForm > renders default form 1`] = `
               <label
                 class="_label_62bdff"
               >
-                Variety
+                Variety (0-100%)
                 <svg
                   fill="currentColor"
                   height="1em"
@@ -1992,7 +1992,7 @@ exports[`SongForm > renders default form 1`] = `
           <label
             class="_label_62bdff"
           >
-            BPM Jitter (per song)
+            BPM Jitter (0-30%, per song)
             <svg
               fill="currentColor"
               height="1em"


### PR DESCRIPTION
## Summary
- clarify HQ Stereo and HQ Reverb with help tooltips
- explain lead instrument selection
- show numeric ranges for BPM jitter and rhythm variety

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a81903f2ac8325b6a56d861ea932af