### PR TITLE
Add simple prompt generation

### DIFF
--- a/src/components/PromptManager.tsx
+++ b/src/components/PromptManager.tsx
@@ -1,15 +1,16 @@
 import { useState } from "react";
+import { generatePrompt } from "../utils/promptGenerator";
 
 export default function PromptManager() {
   const [open, setOpen] = useState(false);
   const [prompt, setPrompt] = useState("");
 
   const handleVideo = () => {
-    console.log("Video Prompt:", prompt);
+    console.log("Video Prompt:", generatePrompt(prompt, "video"));
   };
 
   const handleImage = () => {
-    console.log("Image Prompt:", prompt);
+    console.log("Image Prompt:", generatePrompt(prompt, "image"));
   };
 
   return (

--- a/src/utils/promptGenerator.test.ts
+++ b/src/utils/promptGenerator.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { generatePrompt } from './promptGenerator';
+
+describe('generatePrompt', () => {
+  it('creates a video prompt', () => {
+    expect(generatePrompt('cats', 'video')).toBe('Generate a short video about cats.');
+  });
+
+  it('creates an image prompt', () => {
+    expect(generatePrompt('dogs', 'image')).toBe('Generate a detailed image of dogs.');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(generatePrompt('   ', 'video')).toBe('');
+  });
+});

--- a/src/utils/promptGenerator.ts
+++ b/src/utils/promptGenerator.ts
@@ -1,0 +1,9 @@
+export type PromptType = 'video' | 'image';
+
+export function generatePrompt(text: string, type: PromptType): string {
+  const cleaned = text.trim();
+  if (!cleaned) return '';
+  return type === 'video'
+    ? `Generate a short video about ${cleaned}.`
+    : `Generate a detailed image of ${cleaned}.`;
+}


### PR DESCRIPTION
## Summary
- generate video and image prompts from input text
- hook Prompt Manager UI to use generated prompts
- test prompt generation utility

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a819aaa15c8325851c346e2e1cf8af