### PR TITLE
Add inputs to Fusion page

### DIFF
--- a/src/pages/Fusion.tsx
+++ b/src/pages/Fusion.tsx
@@ -1,9 +1,41 @@
-import { Box } from "@mui/material";
+import { useState } from "react";
+import { Box, Stack, TextField } from "@mui/material";
 
 export default function Fusion() {
+  const [word1, setWord1] = useState("");
+  const [word2, setWord2] = useState("");
+
+  const handleChange = (setter: (v: string) => void) =>
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value.replace(/\s+/g, "");
+      setter(value);
+    };
+
+  const fusion = [word1, word2].filter(Boolean).join(" ");
+
   return (
     <Box sx={{ p: 2, color: "#fff" }}>
-      Fusion
+      <Stack spacing={2}>
+        <Stack direction="row" spacing={2}>
+          <TextField
+            label="Word 1"
+            value={word1}
+            onChange={handleChange(setWord1)}
+          />
+          <TextField
+            label="Word 2"
+            value={word2}
+            onChange={handleChange(setWord2)}
+          />
+        </Stack>
+        <TextField
+          label="Fusion"
+          multiline
+          minRows={6}
+          value={fusion}
+          InputProps={{ readOnly: true }}
+        />
+      </Stack>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add two editable text fields and a read-only fusion area on the Fusion page

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a813ecfd2c8325967a680b9791586f