### PR TITLE
Add intent detection to GeneralChat

### DIFF
--- a/src/pages/GeneralChat.test.tsx
+++ b/src/pages/GeneralChat.test.tsx
@@ -36,6 +36,7 @@ describe('GeneralChat', () => {
   it('handles message flow', async () => {
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === 'start_ollama') return Promise.resolve();
+      if (cmd === 'detect_intent') return Promise.resolve('chat');
       if (cmd === 'general_chat') return Promise.resolve('Reply');
       return Promise.resolve();
     });
@@ -50,9 +51,12 @@ describe('GeneralChat', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
 
     await waitFor(() => {
-      const calls = (invoke as any).mock.calls.filter(([cmd]: [string]) => cmd === 'general_chat');
-      expect(calls).toHaveLength(1);
-      expect(calls[0][1]).toEqual({
+      const calls = (invoke as any).mock.calls;
+      const detect = calls.find(([cmd]: [string]) => cmd === 'detect_intent');
+      expect(detect).toBeTruthy();
+      expect(detect[1]).toEqual({ query: 'Hello' });
+      const chatCall = calls.find(([cmd]: [string]) => cmd === 'general_chat');
+      expect(chatCall[1]).toEqual({
         messages: [
           { role: 'system', content: systemPromptWithName },
           { role: 'user', content: 'Hello' },
@@ -66,6 +70,7 @@ describe('GeneralChat', () => {
   it('inserts system prompt only once', async () => {
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === 'start_ollama') return Promise.resolve();
+      if (cmd === 'detect_intent') return Promise.resolve('chat');
       if (cmd === 'general_chat') return Promise.resolve('Reply');
       return Promise.resolve();
     });
@@ -80,9 +85,9 @@ describe('GeneralChat', () => {
     fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'Hi' } });
     fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
     await waitFor(() => {
-      const calls = (invoke as any).mock.calls.filter(([cmd]: [string]) => cmd === 'general_chat');
-      expect(calls).toHaveLength(1);
-      expect(calls[0][1]).toEqual({
+      const calls = (invoke as any).mock.calls;
+      const chatCall = calls.find(([cmd]: [string]) => cmd === 'general_chat');
+      expect(chatCall[1]).toEqual({
         messages: [
           { role: 'system', content: systemPromptWithName },
           { role: 'user', content: 'Hi' },
@@ -95,9 +100,9 @@ describe('GeneralChat', () => {
     fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'How are you?' } });
     fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
     await waitFor(() => {
-      const calls = (invoke as any).mock.calls.filter(([cmd]: [string]) => cmd === 'general_chat');
-      expect(calls).toHaveLength(2);
-      expect(calls[1][1]).toEqual({
+      const calls = (invoke as any).mock.calls;
+      const secondChatCall = calls.filter(([cmd]: [string]) => cmd === 'general_chat')[1];
+      expect(secondChatCall[1]).toEqual({
         messages: [
           { role: 'system', content: systemPromptWithName },
           { role: 'user', content: 'Hi' },
@@ -111,6 +116,7 @@ describe('GeneralChat', () => {
   it('shows error when send fails', async () => {
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === 'start_ollama') return Promise.resolve();
+      if (cmd === 'detect_intent') return Promise.resolve('chat');
       if (cmd === 'general_chat') return Promise.reject('fail');
       return Promise.resolve();
     });
@@ -123,6 +129,63 @@ describe('GeneralChat', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
 
     await waitFor(() => expect(screen.getByText('fail')).toBeInTheDocument());
+  });
+
+  it('handles system info intent', async () => {
+    (invoke as any).mockImplementation((cmd: string) => {
+      if (cmd === 'start_ollama') return Promise.resolve();
+      if (cmd === 'detect_intent') return Promise.resolve('sys');
+      if (cmd === 'system_info')
+        return Promise.resolve({ cpu_usage: 1, mem_usage: 2, gpu_usage: 3 });
+      return Promise.resolve();
+    });
+    (listen as any).mockImplementation(() => Promise.resolve(() => {}));
+
+    render(<GeneralChat />);
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('start_ollama'));
+
+    fireEvent.change(screen.getAllByRole('textbox')[0], {
+      target: { value: 'stats' },
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
+
+    expect(await screen.findByText(/CPU: 1%/)).toBeInTheDocument();
+    const chatCalls = (invoke as any).mock.calls.filter(
+      ([cmd]: [string]) => cmd === 'general_chat'
+    );
+    expect(chatCalls).toHaveLength(0);
+  });
+
+  it('handles music intent', async () => {
+    (invoke as any).mockImplementation((cmd: string, args: any) => {
+      if (cmd === 'start_ollama') return Promise.resolve();
+      if (cmd === 'detect_intent') return Promise.resolve('music');
+      if (cmd === 'generate_album') return Promise.resolve();
+      return Promise.resolve();
+    });
+    (listen as any).mockImplementation(() => Promise.resolve(() => {}));
+
+    render(<GeneralChat />);
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('start_ollama'));
+
+    fireEvent.change(screen.getAllByRole('textbox')[0], {
+      target: { value: 'My Song template="Classic Lofi" tracks=2' },
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
+
+    await waitFor(() => {
+      const genCall = (invoke as any).mock.calls.find(
+        ([cmd]: [string]) => cmd === 'generate_album'
+      );
+      expect(genCall[1]).toEqual({
+        meta: { track_count: 2, title_base: 'My Song', template: 'Classic Lofi' },
+      });
+    });
+    expect(
+      await screen.findByText(
+        'Started music generation for "My Song" using "Classic Lofi" with 2 tracks.'
+      )
+    ).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- detect commands in GeneralChat via new `detect_intent` call
- route system requests to `system_info` and music prompts to `generate_album`
- expand tests for intent detection and music/system branches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a81b2ff78c83259eecd354a27d8205