### PR TITLE
Improve accessibility for navigation and stock list

### DIFF
--- a/src/components/FeatureNav.tsx
+++ b/src/components/FeatureNav.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Box, IconButton } from "@mui/material";
+import { getContrastColor } from "../utils/color";
 import {
   FaMusic,
   FaCubes,
@@ -57,39 +58,45 @@ export default function FeatureNav({
   const enabled = useMemo(() => ITEMS.filter((it) => modules[it.key]), [modules]);
 
   if (variant === "grid") {
-    return (
-      <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        gap={48}
-        sx={{ height: "100vh", position: "relative", zIndex: 1, flexWrap: "wrap" }}
-      >
-        {enabled.map((it, i) => (
-          <div key={i} style={{ textAlign: "center" }}>
-            <IconButton
-              sx={{
-                fontSize: "3rem",
-                color: "white",
-                transition: "all .2s",
-                "&:hover": {
-                  color: it.color.replace("0.55", "1"),
-                  transform: "scale(1.08)",
-                  filter: "drop-shadow(0 8px 18px rgba(0,0,0,.18))",
-                },
-              }}
-              onMouseEnter={() => onHoverColor(it.color)}
-              onMouseLeave={() => onHoverColor("rgba(255,255,255,0.22)")}
-              onClick={() => nav(it.path)}
-              aria-label={it.label}
-            >
-              {it.icon}
-            </IconButton>
-            <div style={{ color: "#222", marginTop: 8, fontSize: 14 }}>{it.label}</div>
-          </div>
-        ))}
-      </Box>
-    );
+      return (
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          gap={48}
+          sx={{ height: "100vh", position: "relative", zIndex: 1, flexWrap: "wrap" }}
+        >
+          {enabled.map((it, i) => {
+            const fullColor = it.color.replace("0.55", "1");
+            const textColor = getContrastColor(fullColor);
+            return (
+              <div key={i} style={{ textAlign: "center" }}>
+                <IconButton
+                  sx={{
+                    fontSize: "3rem",
+                    color: textColor,
+                    transition: "all .2s",
+                    "&:hover": {
+                      color: fullColor,
+                      transform: "scale(1.08)",
+                      filter: "drop-shadow(0 8px 18px rgba(0,0,0,.18))",
+                    },
+                  }}
+                  onMouseEnter={() => onHoverColor(it.color)}
+                  onMouseLeave={() => onHoverColor("rgba(255,255,255,0.22)")}
+                  onClick={() => nav(it.path)}
+                  aria-label={it.label}
+                >
+                  {it.icon}
+                </IconButton>
+                <div style={{ color: textColor, marginTop: 8, fontSize: 14 }}>
+                  {it.label}
+                </div>
+              </div>
+            );
+          })}
+        </Box>
+      );
   }
 
   // carousel variant

--- a/src/components/StockRow.tsx
+++ b/src/components/StockRow.tsx
@@ -58,7 +58,11 @@ function StockRow({ symbol, metrics }: { symbol: string; metrics: MetricConfig }
     <ListItem
       key={symbol}
       secondaryAction={
-        <IconButton edge="end" onClick={() => removeStock(symbol)}>
+        <IconButton
+          edge="end"
+          onClick={() => removeStock(symbol)}
+          aria-label={`Remove ${symbol}`}
+        >
           <DeleteIcon />
         </IconButton>
       }

--- a/src/components/__snapshots__/StockRow.test.tsx.snap
+++ b/src/components/__snapshots__/StockRow.test.tsx.snap
@@ -52,6 +52,7 @@ exports[`StockRow > renders quote data 1`] = `
       class="MuiListItemSecondaryAction-root css-zezwi5-MuiListItemSecondaryAction-root"
     >
       <button
+        aria-label="Remove AAPL"
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1ysp02-MuiButtonBase-root-MuiIconButton-root"
         tabindex="0"
         type="button"

--- a/src/components/sx.ts
+++ b/src/components/sx.ts
@@ -1,4 +1,5 @@
 import type { SxProps } from "@mui/material";
+import { getContrastColor } from "../utils/color";
 
 export const fixedIconButtonSx: SxProps = {
   position: "fixed",
@@ -56,7 +57,7 @@ export const carouselIconButtonSx = (center: boolean, accent: string): SxProps =
 });
 
 export const carouselLabelSx = (center: boolean, accent: string): SxProps => ({
-  color: center ? accent : "white",
+  color: center ? getContrastColor(accent) : "white",
   mt: 1.5,
   fontSize: 14,
 });

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,23 @@
+export function getContrastColor(color: string): string {
+  let r: number, g: number, b: number;
+  if (color.startsWith('#')) {
+    let hex = color.slice(1);
+    if (hex.length === 3) {
+      hex = hex.split('').map((c) => c + c).join('');
+    }
+    const num = parseInt(hex, 16);
+    r = (num >> 16) & 255;
+    g = (num >> 8) & 255;
+    b = num & 255;
+  } else {
+    const m = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+    if (!m) {
+      return '#000';
+    }
+    r = parseInt(m[1], 10);
+    g = parseInt(m[2], 10);
+    b = parseInt(m[3], 10);
+  }
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.6 ? '#000' : '#fff';
+}


### PR DESCRIPTION
## Summary
- ensure stock removal buttons have accessible labels
- adjust feature navigation to use contrast-aware colors for icons and labels
- add utility for computing high-contrast text colors

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a81e478b60832593b558cf5eaaedfb