### PR TITLE
feat: add song form settings restore

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -275,6 +275,21 @@ export default function SongForm() {
     }
   }, [selectedTemplate]);
 
+  useEffect(() => {
+    const stored = localStorage.getItem("lastInstruments");
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as string[];
+        setInstruments(parsed);
+        setLeadInstrument(inferLeadInstrument(parsed));
+      } catch {}
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("lastInstruments", JSON.stringify(instruments));
+  }, [instruments]);
+
   // Album mode
   const [albumMode, setAlbumMode] = useState(false);
   const [trackCount, setTrackCount] = useState(6);
@@ -646,6 +661,34 @@ export default function SongForm() {
     return new Promise((r) => setJobs((prev) => (r(prev), prev)));
   }
 
+  function restoreLastSettings() {
+    const lastTpl = localStorage.getItem("lastSongTemplate");
+    if (lastTpl && templates[lastTpl]) {
+      setSelectedTemplate(lastTpl);
+      applyTemplate(templates[lastTpl]);
+    }
+    const lastInstr = localStorage.getItem("lastInstruments");
+    if (lastInstr) {
+      try {
+        const parsed = JSON.parse(lastInstr) as string[];
+        setInstruments(parsed);
+        setLeadInstrument(inferLeadInstrument(parsed));
+      } catch {}
+    }
+    const lastDir = localStorage.getItem("outDir");
+    if (lastDir) {
+      setOutDir(lastDir);
+    }
+  }
+
+  function restoreDefaults() {
+    setSelectedTemplate("");
+    applyTemplate(PRESET_TEMPLATES["Classic Lofi"]);
+    setTitleBase("Midnight Coffee");
+    setOutDir("");
+    setAutoKeyPerSong(false);
+  }
+
   return (
     <div className={styles.page}>
       <div className={styles.card}>
@@ -658,6 +701,15 @@ export default function SongForm() {
           setSelectedTemplate={setSelectedTemplate}
           applyTemplate={applyTemplate}
         />
+
+        <div className={styles.row}>
+          <button className={styles.btn} onClick={restoreLastSettings}>
+            Use last settings
+          </button>
+          <button className={styles.btn} onClick={restoreDefaults}>
+            Restore defaults
+          </button>
+        </div>
 
         {/* title + output folder */}
         <div className={styles.row}>
@@ -708,8 +760,11 @@ export default function SongForm() {
             </div>
             <div className={clsx(styles.toggle, "mt-2") }>
               <input type="checkbox" checked={autoKeyPerSong} onChange={(e) => setAutoKeyPerSong(e.target.checked)} disabled={key === "Auto"} />
-              <span className={styles.small}>Rotate key per song{key === "Auto" ? " (disabled: Auto)" : ""}</span>
+              <span className={styles.small}>Rotate key per song</span>
             </div>
+            {key === "Auto" && (
+              <div className={styles.small}>Disabled when key is set to Auto</div>
+            )}
           </div>
           <div className={styles.panel}>
             <label className={styles.label}>

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -172,6 +172,20 @@ exports[`SongForm > renders default form 1`] = `
       <div
         class="_row_62bdff"
       >
+        <button
+          class="_btn_62bdff"
+        >
+          Use last settings
+        </button>
+        <button
+          class="_btn_62bdff"
+        >
+          Restore defaults
+        </button>
+      </div>
+      <div
+        class="_row_62bdff"
+      >
         <input
           class="_input_62bdff"
           placeholder="Song title base"
@@ -386,8 +400,13 @@ exports[`SongForm > renders default form 1`] = `
               <span
                 class="_small_62bdff"
               >
-                Rotate key per song (disabled: Auto)
+                Rotate key per song
               </span>
+            </div>
+            <div
+              class="_small_62bdff"
+            >
+              Disabled when key is set to Auto
             </div>
           </div>
           <div


### PR DESCRIPTION
## Summary
- remember chosen instruments in local storage
- add buttons to restore defaults or last settings
- explain when rotating key option is disabled

## Testing
- `npm test -- -u`


------
https://chatgpt.com/codex/tasks/task_e_68a8215a0f448325a73d7ee989cf859b