### PR TITLE
Add preview snippet and post-render actions

### DIFF
--- a/src/components/BatchActions.tsx
+++ b/src/components/BatchActions.tsx
@@ -112,9 +112,12 @@ export default function BatchActions({
             : "Render Songs"}
         </button>
 
-        <button className={styles.playBtn} onClick={onPreview}>
-          {previewPlaying ? "Stop preview" : "Preview in browser"}
-        </button>
+        <div className={styles.row}>
+          <button className={styles.playBtn} onClick={onPreview}>
+            {previewPlaying ? "Stop preview" : "Preview snippet"}
+          </button>
+          <HelpIcon text="Play a quick 5-second preview" />
+        </div>
 
         <button className={styles.playBtn} onClick={onPlayLastTrack}>
           {isPlaying ? "Pause" : "Play last track"}

--- a/src/components/SongForm.module.css
+++ b/src/components/SongForm.module.css
@@ -167,3 +167,11 @@
   width: 0%;
   transition: width 0.3s;
 }
+
+.nextSteps {
+  margin-top: 16px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: center;
+}

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -2,11 +2,13 @@ import { fireEvent, render, screen, waitFor, cleanup } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import SongForm from './SongForm';
 import { PRESET_TEMPLATES } from "./songTemplates";
-import { open } from '@tauri-apps/plugin-dialog';
+import { open as openDialog } from '@tauri-apps/plugin-dialog';
+import { open as openOpener } from '@tauri-apps/plugin-opener';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 
 vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
+vi.mock('@tauri-apps/plugin-opener', () => ({ open: vi.fn() }));
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
   convertFileSrc: (p: string) => p,
@@ -52,7 +54,7 @@ describe('SongForm', () => {
   });
 
   it('adds a job and shows progress', async () => {
-    (open as any).mockResolvedValue('/tmp/out');
+    (openDialog as any).mockResolvedValue('/tmp/out');
     let resolveRun: (p: string) => void;
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === 'run_lofi_song') {
@@ -224,7 +226,7 @@ describe('SongForm', () => {
   });
 
   it('passes selected instruments in spec', async () => {
-    (open as any).mockResolvedValue('/tmp/out');
+    (openDialog as any).mockResolvedValue('/tmp/out');
     (invoke as any).mockResolvedValue('');
     (listen as any).mockResolvedValue(() => {});
 
@@ -248,7 +250,7 @@ describe('SongForm', () => {
   });
 
   it('passes lead instrument in spec', async () => {
-    (open as any).mockResolvedValue('/tmp/out');
+    (openDialog as any).mockResolvedValue('/tmp/out');
     (invoke as any).mockResolvedValue('');
     (listen as any).mockResolvedValue(() => {});
 
@@ -280,7 +282,7 @@ describe('SongForm', () => {
   });
 
   it('calls generate_album when album mode enabled', async () => {
-    (open as any).mockResolvedValue('/tmp/out');
+    (openDialog as any).mockResolvedValue('/tmp/out');
     (invoke as any).mockResolvedValue({});
     (listen as any).mockResolvedValue(() => {});
 

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -2066,11 +2066,32 @@ exports[`SongForm > renders default form 1`] = `
         >
           Render Songs
         </button>
-        <button
-          class="_playBtn_62bdff"
+        <div
+          class="_row_62bdff"
         >
-          Preview in browser
-        </button>
+          <button
+            class="_playBtn_62bdff"
+          >
+            Preview snippet
+          </button>
+          <svg
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            style="margin-left: 4px; cursor: help; opacity: 0.6;"
+            viewBox="0 0 512 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>
+              Play a quick 5-second preview
+            </title>
+            <path
+              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+            />
+          </svg>
+        </div>
         <button
           class="_playBtn_62bdff"
         >


### PR DESCRIPTION
## Summary
- Allow quick 5s preview snippets with a help tooltip
- Offer intuitive next-step actions after rendering songs
- Provide styling for new next-step actions

## Testing
- `npm test -- run src/components/SongForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a822d863c083259b406355eb7a7a2c