### PR TITLE
feat: improve settings usability

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -46,6 +46,40 @@ const KEY_OPTIONS = [
 ];
 const displayKey = (k: string) => k.replace("#", "♯").replace("b", "♭");
 
+const THEME_PREVIEWS: Record<Theme, string> = {
+  default: "#3d0a0a",
+  ocean: "#0a3d5e",
+  forest: "#0a3d1a",
+  sunset: "#5e2a0a",
+  sakura: "#5e0a3d",
+  studio: "#000",
+  galaxy: "#000",
+  retro: "#000",
+  noir: "#1a1a1a",
+  aurora: "linear-gradient(270deg,#00ffa3,#0085ff)",
+  rainy: "#0a1e3d",
+  pastel: "#ffe4e1",
+  mono: "#000",
+  eclipse: "#000",
+};
+
+const THEME_OPTIONS: { value: Theme; label: string }[] = [
+  { value: "default", label: "Default" },
+  { value: "ocean", label: "Ocean" },
+  { value: "forest", label: "Forest" },
+  { value: "sunset", label: "Sunset" },
+  { value: "sakura", label: "Sakura" },
+  { value: "studio", label: "Studio" },
+  { value: "galaxy", label: "Galaxy" },
+  { value: "retro", label: "Retro" },
+  { value: "noir", label: "Noir" },
+  { value: "aurora", label: "Aurora" },
+  { value: "rainy", label: "Rainy" },
+  { value: "pastel", label: "Pastel" },
+  { value: "mono", label: "Mono" },
+  { value: "eclipse", label: "Eclipse" },
+];
+
 interface SettingsDrawerProps {
   open: boolean;
   onClose: () => void;
@@ -54,12 +88,12 @@ interface SettingsDrawerProps {
 function PathField({
   label,
   value,
-  onPick,
+  onChange,
   directory,
 }: {
   label: string;
   value: string;
-  onPick: (p: string) => void;
+  onChange: (p: string) => void;
   directory?: boolean;
 }) {
   const [invalid, setInvalid] = useState(false);
@@ -85,8 +119,8 @@ function PathField({
       <TextField
         label={label}
         value={value}
+        onChange={(e) => onChange(e.target.value)}
         fullWidth
-        InputProps={{ readOnly: true }}
         error={invalid}
         helperText={invalid ? "Path does not exist" : undefined}
       />
@@ -95,7 +129,7 @@ function PathField({
         sx={{ mt: 1 }}
         onClick={async () => {
           const res = await open(directory ? { directory: true } : {});
-          if (typeof res === "string") onPick(res);
+          if (typeof res === "string") onChange(res);
         }}
       >
         Browse
@@ -123,6 +157,21 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   } = useAudioDefaults();
   const { theme, setTheme, mode, setMode } = useTheme();
   const [audioSaved, setAudioSaved] = useState(false);
+  const [pathsSaved, setPathsSaved] = useState(false);
+  const [appearanceSaved, setAppearanceSaved] = useState(false);
+  const [outputSaved, setOutputSaved] = useState(false);
+
+  const [pythonDraft, setPythonDraft] = useState(pythonPath);
+  const [comfyDraft, setComfyDraft] = useState(comfyPath);
+  const [folderDraft, setFolderDraft] = useState(folder);
+  const [themeDraft, setThemeDraft] = useState<Theme>(theme);
+  const [modeDraft, setModeDraft] = useState(mode);
+
+  useEffect(() => setPythonDraft(pythonPath), [pythonPath]);
+  useEffect(() => setComfyDraft(comfyPath), [comfyPath]);
+  useEffect(() => setFolderDraft(folder), [folder]);
+  useEffect(() => setThemeDraft(theme), [theme]);
+  useEffect(() => setModeDraft(mode), [mode]);
 
   return (
     <Drawer anchor="right" open={open} onClose={onClose}>
@@ -133,13 +182,24 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
 
         <Box sx={{ mb: 3 }}>
           <Typography variant="subtitle1">Paths</Typography>
-          <PathField label="Python Path" value={pythonPath} onPick={setPythonPath} />
+          <PathField label="Python Path" value={pythonDraft} onChange={setPythonDraft} />
           <PathField
             label="ComfyUI Folder"
-            value={comfyPath}
-            onPick={setComfyPath}
+            value={comfyDraft}
+            onChange={setComfyDraft}
             directory
           />
+          <Button
+            variant="contained"
+            sx={{ mt: 2 }}
+            onClick={() => {
+              setPythonPath(pythonDraft);
+              setComfyPath(comfyDraft);
+              setPathsSaved(true);
+            }}
+          >
+            Save Paths
+          </Button>
         </Box>
 
         <Box sx={{ mb: 3 }}>
@@ -187,11 +247,21 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
           />
           <FormControlLabel
             control={<Switch checked={hqSidechain} onChange={toggleHqSidechain} />}
-            label="HQ Sidechain"
+            label={
+              <span style={{ display: "inline-flex", alignItems: "center" }}>
+                HQ Sidechain
+                <HelpIcon text="Sidechain ducking for punchier kick" />
+              </span>
+            }
           />
           <FormControlLabel
             control={<Switch checked={hqChorus} onChange={toggleHqChorus} />}
-            label="HQ Chorus"
+            label={
+              <span style={{ display: "inline-flex", alignItems: "center" }}>
+                HQ Chorus
+                <HelpIcon text="Subtle chorus on melodic parts" />
+              </span>
+            }
           />
           <Button variant="contained" sx={{ mt: 2 }} onClick={() => setAudioSaved(true)}>
             Save Audio Defaults
@@ -204,51 +274,90 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
             <Select
               labelId="theme-label"
               label="Theme"
-              value={theme}
-              onChange={(e) => setTheme(e.target.value as Theme)}
+              value={themeDraft}
+              onChange={(e) => setThemeDraft(e.target.value as Theme)}
             >
-              <MenuItem value="default">Default</MenuItem>
-              <MenuItem value="ocean">Ocean</MenuItem>
-              <MenuItem value="forest">Forest</MenuItem>
-              <MenuItem value="sunset">Sunset</MenuItem>
-              <MenuItem value="sakura">Sakura</MenuItem>
-              <MenuItem value="studio">Studio</MenuItem>
-              <MenuItem value="galaxy">Galaxy</MenuItem>
-              <MenuItem value="retro">Retro</MenuItem>
-              <MenuItem value="noir">Noir</MenuItem>
-              <MenuItem value="aurora">Aurora</MenuItem>
-              <MenuItem value="rainy">Rainy</MenuItem>
-              <MenuItem value="pastel">Pastel</MenuItem>
-              <MenuItem value="mono">Mono</MenuItem>
-              <MenuItem value="eclipse">Eclipse</MenuItem>
+              {THEME_OPTIONS.map((opt) => (
+                <MenuItem key={opt.value} value={opt.value}>
+                  <Box
+                    sx={{
+                      width: 16,
+                      height: 16,
+                      background: THEME_PREVIEWS[opt.value],
+                      border: "1px solid #ccc",
+                      mr: 1,
+                    }}
+                  />
+                  {opt.label}
+                </MenuItem>
+              ))}
             </Select>
           </FormControl>
           <FormControlLabel
             sx={{ mt: 1 }}
             control={
               <Switch
-                checked={mode === "dark"}
-                onChange={(e) => setMode(e.target.checked ? "dark" : "light")}
+                checked={modeDraft === "dark"}
+                onChange={(e) => setModeDraft(e.target.checked ? "dark" : "light")}
               />
             }
             label="Dark Mode"
           />
+          <Button
+            variant="contained"
+            sx={{ mt: 2 }}
+            onClick={() => {
+              setTheme(themeDraft);
+              setMode(modeDraft);
+              setAppearanceSaved(true);
+            }}
+          >
+            Save Appearance
+          </Button>
         </Box>
 
         <Box>
           <Typography variant="subtitle1">Output</Typography>
           <PathField
             label="Default Save Folder"
-            value={folder}
-            onPick={setFolder}
+            value={folderDraft}
+            onChange={setFolderDraft}
             directory
           />
+          <Button
+            variant="contained"
+            sx={{ mt: 2 }}
+            onClick={() => {
+              setFolder(folderDraft);
+              setOutputSaved(true);
+            }}
+          >
+            Save Output
+          </Button>
         </Box>
         <Snackbar
           open={audioSaved}
           autoHideDuration={3000}
           onClose={() => setAudioSaved(false)}
           message="Audio defaults saved"
+        />
+        <Snackbar
+          open={pathsSaved}
+          autoHideDuration={3000}
+          onClose={() => setPathsSaved(false)}
+          message="Paths saved"
+        />
+        <Snackbar
+          open={appearanceSaved}
+          autoHideDuration={3000}
+          onClose={() => setAppearanceSaved(false)}
+          message="Appearance saved"
+        />
+        <Snackbar
+          open={outputSaved}
+          autoHideDuration={3000}
+          onClose={() => setOutputSaved(false)}
+          message="Output path saved"
         />
       </Box>
     </Drawer>


### PR DESCRIPTION
## Summary
- allow manual path editing and explicit save actions across Settings sections
- add helpful tooltips to HQ sidechain and chorus toggles
- preview available themes for easier selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a822872944832582dcc8b4bc983ac8