### PR TITLE
feat: extend prompt manager

### DIFF
--- a/src/components/PromptManager.tsx
+++ b/src/components/PromptManager.tsx
@@ -1,20 +1,17 @@
 import { useState } from "react";
-import { generatePrompt } from "../utils/promptGenerator";
+import { generatePrompt, type PromptType } from "../utils/promptGenerator";
 
 export default function PromptManager() {
   const [open, setOpen] = useState(false);
   const [prompt, setPrompt] = useState("");
 
-  const handleVideo = () => {
-    console.log("Video Prompt:", generatePrompt(prompt, "video"));
-  };
-
-  const handleImage = () => {
-    console.log("Image Prompt:", generatePrompt(prompt, "image"));
+  const handlePrompt = (type: PromptType) => {
+    const label = type.charAt(0).toUpperCase() + type.slice(1);
+    console.log(`${label} Prompt:`, generatePrompt(prompt, type));
   };
 
   return (
-    <div style={{ position: "relative" }}>
+    <div>
       <button onClick={() => setOpen((o) => !o)} style={styles.btn}>
         Prompt Manager
       </button>
@@ -27,11 +24,29 @@ export default function PromptManager() {
             placeholder="Enter prompt"
           />
           <div style={styles.actions}>
-            <button onClick={handleVideo} style={styles.actionBtn}>
-              Video Prompt
+            <button
+              onClick={() => handlePrompt("image")}
+              style={styles.actionBtn}
+            >
+              Image
             </button>
-            <button onClick={handleImage} style={styles.actionBtn}>
-              Image Prompt
+            <button
+              onClick={() => handlePrompt("video")}
+              style={styles.actionBtn}
+            >
+              Video
+            </button>
+            <button
+              onClick={() => handlePrompt("music")}
+              style={styles.actionBtn}
+            >
+              Music
+            </button>
+            <button
+              onClick={() => handlePrompt("dnd")}
+              style={styles.actionBtn}
+            >
+              DND
             </button>
           </div>
         </div>
@@ -50,15 +65,15 @@ const styles: Record<string, React.CSSProperties> = {
     cursor: "pointer",
   },
   panel: {
-    position: "absolute",
-    top: "100%",
-    right: 0,
-    marginTop: 8,
+    position: "fixed",
+    top: 10,
+    left: "50%",
+    transform: "translateX(-50%)",
     padding: 12,
     background: "#121214",
     border: "1px solid #333",
     borderRadius: 10,
-    width: 300,
+    width: 400,
     zIndex: 10,
   },
   textarea: {
@@ -75,7 +90,7 @@ const styles: Record<string, React.CSSProperties> = {
   actions: {
     display: "flex",
     gap: 8,
-    justifyContent: "flex-end",
+    justifyContent: "center",
   },
   actionBtn: {
     padding: "6px 10px",

--- a/src/utils/promptGenerator.test.ts
+++ b/src/utils/promptGenerator.test.ts
@@ -10,6 +10,18 @@ describe('generatePrompt', () => {
     expect(generatePrompt('dogs', 'image')).toBe('Generate a detailed image of dogs.');
   });
 
+  it('creates a music prompt', () => {
+    expect(generatePrompt('jazz', 'music')).toBe(
+      'Compose a short piece of music about jazz.'
+    );
+  });
+
+  it('creates a DND prompt', () => {
+    expect(generatePrompt('dragons', 'dnd')).toBe(
+      'Create a DND campaign idea involving dragons.'
+    );
+  });
+
   it('returns empty string for empty input', () => {
     expect(generatePrompt('   ', 'video')).toBe('');
   });

--- a/src/utils/promptGenerator.ts
+++ b/src/utils/promptGenerator.ts
@@ -1,9 +1,19 @@
-export type PromptType = 'video' | 'image';
+export type PromptType = 'video' | 'image' | 'music' | 'dnd';
 
 export function generatePrompt(text: string, type: PromptType): string {
   const cleaned = text.trim();
   if (!cleaned) return '';
-  return type === 'video'
-    ? `Generate a short video about ${cleaned}.`
-    : `Generate a detailed image of ${cleaned}.`;
+
+  switch (type) {
+    case 'video':
+      return `Generate a short video about ${cleaned}.`;
+    case 'image':
+      return `Generate a detailed image of ${cleaned}.`;
+    case 'music':
+      return `Compose a short piece of music about ${cleaned}.`;
+    case 'dnd':
+      return `Create a DND campaign idea involving ${cleaned}.`;
+    default:
+      return '';
+  }
 }


### PR DESCRIPTION
## Summary
- extend prompt generator to handle music and DND prompts
- surface prompt manager panel at top with buttons for Image, Video, Music, and DND
- cover new prompt types in tests

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a81effa2f083258244d2a9acfac7af