### PR TITLE
Add rule PDF upload support

### DIFF
--- a/src-tauri/python/pdf_tools.py
+++ b/src-tauri/python/pdf_tools.py
@@ -215,6 +215,22 @@ def extract_spells(path: str):
     return {"spells": spells}
 
 
+def extract_rules(path: str):
+    """Extract simple rule entries from a PDF file."""
+    pdf_path = Path(path)
+    rules = []
+    with pdfplumber.open(pdf_path) as pdf:
+        text = "\n".join(page.extract_text() or "" for page in pdf.pages)
+    for block in text.split("\n\n"):
+        lines = [ln.strip() for ln in block.splitlines() if ln.strip()]
+        if not lines:
+            continue
+        name = lines[0]
+        desc = " ".join(lines[1:])
+        rules.append({"name": name, "description": desc})
+    return {"rules": rules}
+
+
 def search(query: str, k: int = 3):
     ensure_dirs()
     conn = get_db()
@@ -389,6 +405,8 @@ def main():
     sub.add_parser("list")
     p = sub.add_parser("spells")
     p.add_argument("path")
+    p = sub.add_parser("rules")
+    p.add_argument("path")
     args = parser.parse_args()
 
     if args.cmd == "add":
@@ -408,6 +426,8 @@ def main():
         out = list_docs()
     elif args.cmd == "spells":
         out = extract_spells(args.path)
+    elif args.cmd == "rules":
+        out = extract_rules(args.path)
     else:
         out = {}
     json.dump(out, fp=os.fdopen(1, "w"))

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -358,6 +358,12 @@ pub struct SpellRecord {
     pub description: String,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RuleRecord {
+    pub name: String,
+    pub description: String,
+}
+
 #[tauri::command]
 pub async fn pdf_add<R: Runtime>(app: AppHandle<R>, path: String) -> Result<Value, String> {
     let out = run_pdf_tool(&app, &["add", &path])?;
@@ -424,6 +430,16 @@ pub async fn parse_spell_pdf<R: Runtime>(
     let out = run_pdf_tool(&app, &["spells", &path])?;
     let v: Value = serde_json::from_str(&out).map_err(|e| e.to_string())?;
     serde_json::from_value(v["spells"].clone()).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn parse_rule_pdf<R: Runtime>(
+    app: AppHandle<R>,
+    path: String,
+) -> Result<Vec<RuleRecord>, String> {
+    let out = run_pdf_tool(&app, &["rules", &path])?;
+    let v: Value = serde_json::from_str(&out).map_err(|e| e.to_string())?;
+    serde_json::from_value(v["rules"].clone()).map_err(|e| e.to_string())
 }
 
 /* ==============================

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -62,6 +62,7 @@ fn main() {
             commands::pdf_search,
             commands::pdf_ingest,
             commands::parse_spell_pdf,
+            commands::parse_rule_pdf,
             // Blender:
             commands::blender_run_script,
             commands::save_npc,

--- a/src-tauri/src/stocks.rs
+++ b/src-tauri/src/stocks.rs
@@ -142,9 +142,7 @@ impl Provider for YahooProvider {
             .and_then(|v| v.as_str())
             .unwrap_or("UNKNOWN")
             .to_string();
-        let volume = result
-            .get("regularMarketVolume")
-            .and_then(|v| v.as_u64());
+        let volume = result.get("regularMarketVolume").and_then(|v| v.as_u64());
         log::info!(
             "quote {} fetched in {} ms ({} bytes)",
             ticker,

--- a/src/features/dnd/RuleForm.tsx
+++ b/src/features/dnd/RuleForm.tsx
@@ -11,6 +11,7 @@ import {
 import { zRule } from "./schemas";
 import type { RuleData } from "./types";
 import rulesIndex from "../../../dnd/rules/index.json";
+import RulePdfUpload from "./RulePdfUpload";
 
 const ruleFiles = import.meta.glob("../../../dnd/rules/*.md", {
   as: "raw",
@@ -67,6 +68,7 @@ export default function RuleForm() {
   return (
     <form onSubmit={handleSubmit}>
       <Typography variant="h6">Rulebook</Typography>
+      <RulePdfUpload />
       <FormControl fullWidth margin="normal">
         <InputLabel id="rule-select-label">Base Rule</InputLabel>
         <Select

--- a/src/features/dnd/RulePdfUpload.tsx
+++ b/src/features/dnd/RulePdfUpload.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { invoke } from "@tauri-apps/api/core";
+
+interface RuleRecord {
+  name: string;
+  description: string;
+}
+
+interface ParsedRule extends RuleRecord {
+  origin: "official" | "custom";
+}
+
+const OFFICIAL_RULES = new Set([
+  "Ability Checks",
+  "Advantage and Disadvantage",
+  "Critical Hits",
+  "Saving Throws",
+]);
+
+export default function RulePdfUpload() {
+  const [rules, setRules] = useState<ParsedRule[]>([]);
+
+  async function handleUpload() {
+    const selected = await open({ filters: [{ name: "PDF", extensions: ["pdf"] }] });
+    if (typeof selected === "string") {
+      const extracted = await invoke<RuleRecord[]>("parse_rule_pdf", { path: selected });
+      const classified = extracted.map((r) => ({
+        ...r,
+        origin: OFFICIAL_RULES.has(r.name) ? "official" : "custom",
+      }));
+      setRules(classified);
+    }
+  }
+
+  return (
+    <div>
+      <button type="button" onClick={handleUpload}>
+        Upload Rule PDF
+      </button>
+      {rules.length > 0 && (
+        <ul>
+          {rules.map((r) => (
+            <li key={r.name}>
+              {r.name} – {r.origin}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/src/features/dnd/tests/RulePdfUpload.test.tsx
+++ b/src/features/dnd/tests/RulePdfUpload.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import RulePdfUpload from "../RulePdfUpload";
+import { open } from "@tauri-apps/plugin-dialog";
+import { invoke } from "@tauri-apps/api/core";
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+describe("RulePdfUpload", () => {
+  afterEach(() => {
+    cleanup();
+    vi.resetAllMocks();
+  });
+
+  it("uploads and classifies rules", async () => {
+    (open as any).mockResolvedValue("/tmp/rules.pdf");
+    (invoke as any).mockResolvedValue([{ name: "Ability Checks", description: "roll" }]);
+
+    render(<RulePdfUpload />);
+    fireEvent.click(screen.getByText(/upload rule pdf/i));
+
+    await waitFor(() => expect(open).toHaveBeenCalled());
+    await waitFor(() => expect(invoke).toHaveBeenCalled());
+    await screen.findByText(/Ability Checks/i);
+  });
+});


### PR DESCRIPTION
## Summary
- allow uploading and parsing of rule PDFs
- extend PDF tools and Tauri commands for rule extraction
- cover rule PDF upload with tests

## Testing
- `npm test -- --run`
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8259f6db48325a70d3822e107a81d