### PR TITLE
feat: add ComfyUI setup tutorial

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -19,6 +19,7 @@ import { usePaths } from "../features/paths/usePaths";
 import { useOutput } from "../features/output/useOutput";
 import { useAudioDefaults } from "../features/audioDefaults/useAudioDefaults";
 import { useTheme, type Theme } from "../features/theme/ThemeContext";
+import { useComfyTutorial } from "../features/comfyTutorial/useComfyTutorial";
 import HelpIcon from "./HelpIcon";
 
 const KEY_OPTIONS = [
@@ -156,6 +157,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
     toggleHqChorus,
   } = useAudioDefaults();
   const { theme, setTheme, mode, setMode } = useTheme();
+  const { showTutorial, setShowTutorial } = useComfyTutorial();
   const [audioSaved, setAudioSaved] = useState(false);
   const [pathsSaved, setPathsSaved] = useState(false);
   const [appearanceSaved, setAppearanceSaved] = useState(false);
@@ -200,6 +202,14 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
           >
             Save Paths
           </Button>
+        </Box>
+
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="subtitle1">Guides</Typography>
+          <FormControlLabel
+            control={<Switch checked={showTutorial} onChange={(e) => setShowTutorial(e.target.checked)} />}
+            label="Show ComfyUI Tutorial"
+          />
         </Box>
 
         <Box sx={{ mb: 3 }}>

--- a/src/features/comfyTutorial/useComfyTutorial.ts
+++ b/src/features/comfyTutorial/useComfyTutorial.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface ComfyTutorialState {
+  showTutorial: boolean;
+  setShowTutorial: (show: boolean) => void;
+}
+
+export const useComfyTutorial = create<ComfyTutorialState>()(
+  persist(
+    (set) => ({
+      showTutorial: true,
+      setShowTutorial: (show: boolean) => set({ showTutorial: show }),
+    }),
+    { name: "comfy-tutorial" }
+  )
+);
+
+export type { ComfyTutorialState };

--- a/src/pages/Comfy.tsx
+++ b/src/pages/Comfy.tsx
@@ -4,12 +4,14 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { usePaths } from "../features/paths/usePaths";
 import PromptManager from "../components/PromptManager";
+import { useComfyTutorial } from "../features/comfyTutorial/useComfyTutorial";
 
 export default function Comfy() {
   const [running, setRunning] = useState(false);
   const [log, setLog] = useState<string[]>([]);
   const [pingOk, setPingOk] = useState(false);
   const { comfyPath } = usePaths();
+  const { showTutorial, setShowTutorial } = useComfyTutorial();
 
   useEffect(() => {
     let unlisten: (() => void) | undefined;
@@ -65,6 +67,17 @@ export default function Comfy() {
 
   return (
     <div style={styles.wrap}>
+      {showTutorial && (
+        <div style={styles.tut}>
+          <h3 style={{ marginTop: 0 }}>Connect Blossom to ComfyUI</h3>
+          <ol style={{ marginTop: 4 }}>
+            <li>Install ComfyUI; the folder should contain <code>main.py</code>.</li>
+            <li>Open Settings → Paths and set "ComfyUI Folder" to that directory.</li>
+            <li>Return here and click Start to launch ComfyUI.</li>
+          </ol>
+          <button onClick={() => setShowTutorial(false)} style={styles.tutBtn}>Got it</button>
+        </div>
+      )}
       <div style={styles.header}>
         <div>
           <h2 style={{ margin: 0 }}>ComfyUI</h2>
@@ -129,5 +142,20 @@ const styles: Record<string, React.CSSProperties> = {
   right: { background: "#121214", borderRadius: 10, display: "flex", flexDirection: "column" },
   placeholder: { height: "100%", display: "grid", placeItems: "center", opacity: 0.7 },
   logHead: { padding: "8px 12px", borderBottom: "1px solid #333", fontSize: 12, opacity: 0.8 },
-  logBox: { padding: 12, overflow: "auto", fontFamily: "ui-monospace, monospace", fontSize: 12, flex: 1 }
+  logBox: { padding: 12, overflow: "auto", fontFamily: "ui-monospace, monospace", fontSize: 12, flex: 1 },
+  tut: {
+    background: "#222",
+    padding: 16,
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+  tutBtn: {
+    marginTop: 8,
+    padding: "6px 10px",
+    border: "none",
+    borderRadius: 6,
+    background: "#3a82f6",
+    color: "#fff",
+    cursor: "pointer",
+  }
 };


### PR DESCRIPTION
## Summary
- guide users through connecting Blossom to ComfyUI
- remember whether the ComfyUI tutorial has been dismissed
- allow re-enabling the tutorial from Settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a82f3f2fec832593205031d66eeaf7