### PR TITLE
feat: add random concept fusion

### DIFF
--- a/src/pages/Fusion.test.tsx
+++ b/src/pages/Fusion.test.tsx
@@ -15,22 +15,31 @@ describe('Fusion', () => {
     cleanup();
   });
 
-  it('fuses provided words into prompt and stores archive', () => {
+  it('fuses provided concepts into prompt and stores archive', () => {
     render(<Fusion />);
-    fireEvent.change(screen.getByLabelText('Word 1'), { target: { value: 'cat' } });
-    fireEvent.change(screen.getByLabelText('Word 2'), { target: { value: 'robot' } });
+    fireEvent.change(screen.getByLabelText('Concept 1'), {
+      target: { value: 'ancient library' },
+    });
+    fireEvent.change(screen.getByLabelText('Concept 2'), {
+      target: { value: 'floating city' },
+    });
     fireEvent.click(screen.getByRole('button', { name: /^Fuse$/i }));
-    const expected = 'Generate a detailed image of cat robot.';
+    const expected =
+      'Generate a detailed image combining ancient library and floating city.';
     expect(screen.getByLabelText('Image Prompt')).toHaveValue(expected);
     const archive = getArchive();
-    expect(archive[0]).toEqual({ word1: 'cat', word2: 'robot', prompt: expected });
+    expect(archive[0]).toEqual({
+      concept1: 'ancient library',
+      concept2: 'floating city',
+      prompt: expected,
+    });
   });
 
   it('random button fills words and archives', () => {
     render(<Fusion />);
     fireEvent.click(screen.getAllByRole('button', { name: /random/i })[2]);
-    expect(screen.getByLabelText('Word 1')).not.toHaveValue('');
-    expect(screen.getByLabelText('Word 2')).not.toHaveValue('');
+    expect(screen.getByLabelText('Concept 1')).not.toHaveValue('');
+    expect(screen.getByLabelText('Concept 2')).not.toHaveValue('');
     expect(screen.getByLabelText('Image Prompt')).not.toHaveValue('');
     const archive = getArchive();
     expect(archive.length).toBe(1);
@@ -38,18 +47,22 @@ describe('Fusion', () => {
 
   it('keeps only 200 most recent prompts', () => {
     const entries = Array.from({ length: 200 }, (_, i) => ({
-      word1: `w${i}`,
-      word2: `x${i}`,
+      concept1: `w${i}`,
+      concept2: `x${i}`,
       prompt: `p${i}`,
     }));
     localStorage.setItem('fusionArchive', JSON.stringify(entries));
     render(<Fusion />);
-    fireEvent.change(screen.getByLabelText('Word 1'), { target: { value: 'new' } });
-    fireEvent.change(screen.getByLabelText('Word 2'), { target: { value: 'entry' } });
+    fireEvent.change(screen.getByLabelText('Concept 1'), {
+      target: { value: 'new' },
+    });
+    fireEvent.change(screen.getByLabelText('Concept 2'), {
+      target: { value: 'entry' },
+    });
     fireEvent.click(screen.getByRole('button', { name: /^Fuse$/i }));
     const archive = getArchive();
     expect(archive.length).toBe(200);
-    expect(archive[0].word1).toBe('new');
-    expect(archive[199].word1).toBe('w198');
+    expect(archive[0].concept1).toBe('new');
+    expect(archive[199].concept1).toBe('w198');
   });
 });

--- a/src/pages/Fusion.tsx
+++ b/src/pages/Fusion.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
 import { Box, Stack, TextField, Button, Typography } from "@mui/material";
 import { generatePrompt } from "../utils/promptGenerator";
-import { getRandomWord } from "../utils/randomWord";
+import { getRandomConcept } from "../utils/randomConcept";
 
 export default function Fusion() {
-  const [word1, setWord1] = useState("");
-  const [word2, setWord2] = useState("");
+  const [concept1, setConcept1] = useState("");
+  const [concept2, setConcept2] = useState("");
   const [prompt, setPrompt] = useState("");
   const [archive, setArchive] = useState<
-    { word1: string; word2: string; prompt: string }[]
+    { concept1: string; concept2: string; prompt: string }[]
   >(() => {
     const stored = localStorage.getItem("fusionArchive");
     return stored ? JSON.parse(stored) : [];
@@ -16,13 +16,12 @@ export default function Fusion() {
 
   const handleChange = (setter: (v: string) => void) =>
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value.replace(/\s+/g, "");
-      setter(value);
+      setter(e.target.value);
     };
 
   const saveArchive = (entry: {
-    word1: string;
-    word2: string;
+    concept1: string;
+    concept2: string;
     prompt: string;
   }) => {
     setArchive((prev) => {
@@ -32,24 +31,24 @@ export default function Fusion() {
     });
   };
 
-  const fuse = (w1 = word1, w2 = word2) => {
-    if (!w1 && !w2) return;
-    const fusion = [w1, w2].filter(Boolean).join(" ");
+  const fuse = (c1 = concept1, c2 = concept2) => {
+    if (!c1 && !c2) return;
+    const fusion = [c1, c2].filter(Boolean).join(" and ");
     const result = generatePrompt(fusion, "image");
     setPrompt(result);
-    saveArchive({ word1: w1, word2: w2, prompt: result });
+    saveArchive({ concept1: c1, concept2: c2, prompt: result });
   };
 
   const randomize = (setter: (v: string) => void) => {
-    setter(getRandomWord());
+    setter(getRandomConcept());
   };
 
   const randomFuse = () => {
-    const w1 = getRandomWord();
-    const w2 = getRandomWord();
-    setWord1(w1);
-    setWord2(w2);
-    fuse(w1, w2);
+    const c1 = getRandomConcept();
+    const c2 = getRandomConcept();
+    setConcept1(c1);
+    setConcept2(c2);
+    fuse(c1, c2);
   };
 
   return (
@@ -58,21 +57,21 @@ export default function Fusion() {
         <Stack direction="row" spacing={2}>
           <Stack direction="row" spacing={1}>
             <TextField
-              label="Word 1"
-              value={word1}
-              onChange={handleChange(setWord1)}
+              label="Concept 1"
+              value={concept1}
+              onChange={handleChange(setConcept1)}
             />
-            <Button variant="outlined" onClick={() => randomize(setWord1)}>
+            <Button variant="outlined" onClick={() => randomize(setConcept1)}>
               Random
             </Button>
           </Stack>
           <Stack direction="row" spacing={1}>
             <TextField
-              label="Word 2"
-              value={word2}
-              onChange={handleChange(setWord2)}
+              label="Concept 2"
+              value={concept2}
+              onChange={handleChange(setConcept2)}
             />
-            <Button variant="outlined" onClick={() => randomize(setWord2)}>
+            <Button variant="outlined" onClick={() => randomize(setConcept2)}>
               Random
             </Button>
           </Stack>
@@ -99,7 +98,7 @@ export default function Fusion() {
             </Typography>
             <Stack spacing={1} maxHeight={200} sx={{ overflowY: "auto" }}>
               {archive.map((a, i) => (
-                <Box key={i}>{`${a.word1} + ${a.word2}: ${a.prompt}`}</Box>
+                <Box key={i}>{`${a.concept1} + ${a.concept2}: ${a.prompt}`}</Box>
               ))}
             </Stack>
           </Box>

--- a/src/utils/promptGenerator.test.ts
+++ b/src/utils/promptGenerator.test.ts
@@ -7,7 +7,9 @@ describe('generatePrompt', () => {
   });
 
   it('creates an image prompt', () => {
-    expect(generatePrompt('dogs', 'image')).toBe('Generate a detailed image of dogs.');
+    expect(generatePrompt('dogs', 'image')).toBe(
+      'Generate a detailed image combining dogs.'
+    );
   });
 
   it('creates a music prompt', () => {

--- a/src/utils/promptGenerator.ts
+++ b/src/utils/promptGenerator.ts
@@ -8,7 +8,7 @@ export function generatePrompt(text: string, type: PromptType): string {
     case 'video':
       return `Generate a short video about ${cleaned}.`;
     case 'image':
-      return `Generate a detailed image of ${cleaned}.`;
+      return `Generate a detailed image combining ${cleaned}.`;
     case 'music':
       return `Compose a short piece of music about ${cleaned}.`;
     case 'dnd':

--- a/src/utils/randomConcept.ts
+++ b/src/utils/randomConcept.ts
@@ -1,0 +1,28 @@
+const CONCEPTS = [
+  "Forgotten Cathedrals Beneath Ocean",
+  "Solar Nomads Crossing Crystal Dunes",
+  "Mechanical Forests of Neon Rain",
+  "Clockwork Cities in the Clouds",
+  "Subterranean Libraries of Whispering Stones",
+  "Glacial Deserts Lit by Bioluminescent Fungi",
+  "Astral Marketplaces on Floating Islands",
+  "Quantum Gardens of Fractal Flowers",
+  "Haunted Observatories on the Moon",
+  "Chromatic Rivers Flowing Upward",
+  "Desolate Highways Through Electric Storms",
+  "Mirrored Jungles of Infinite Reflections",
+  "Volcanic Archives of Living Scrolls",
+  "Ruined Starships Buried in Sand",
+  "Crystal Caverns Echoing with Time",
+  "Eternal Carnivals in Orbit",
+  "Ancient Robots Tending Solar Fields",
+  "Frozen Thunderstorms Above Black Seas",
+  "Starlit Temples Carved into Comets",
+  "Singing Mountains of Hollow Glass"
+];
+
+export function getRandomConcept(): string {
+  return CONCEPTS[Math.floor(Math.random() * CONCEPTS.length)];
+}
+
+export default getRandomConcept;


### PR DESCRIPTION
## Summary
- add curated random concept list
- fuse random concepts into image prompts
- update prompt generator wording and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a82b9f21d883258a1de86aa98a21af