### PR TITLE
feat: expand image prompt aesthetics

### DIFF
--- a/src/components/ImagePromptGenerator.test.tsx
+++ b/src/components/ImagePromptGenerator.test.tsx
@@ -13,7 +13,7 @@ describe('ImagePromptGenerator', () => {
 
     const kodak = screen.getByLabelText(/Kodak Portra 400/i);
     fireEvent.click(kodak);
-    const polaroid = screen.getByLabelText(/Polaroid/i);
+    const polaroid = screen.getByLabelText(/Shot on Polaroid/i);
     expect(polaroid).toBeDisabled();
 
     const wide = screen.getByLabelText(/Wide-angle lens/i);

--- a/src/components/ImagePromptGenerator.tsx
+++ b/src/components/ImagePromptGenerator.tsx
@@ -22,6 +22,17 @@ const cameraOptions = [
   "Captured with DSLR, shallow depth of field",
   "Medium format photography",
   "Shot on CineStill 800T (moody, film-like with strong blues and halogens)",
+  // 💅 Editorial / Styled / Trendy - Use for stylized, design-focused, or aesthetic-heavy compositions.
+  "Vogue cover portrait",
+  "Shot for Architectural Digest",
+  "Instagram aesthetic",
+  "Apple product ad lighting",
+  "Clean studio backdrop",
+  "Polaroid border style",
+  "CineStill 800T color grading",
+  "Euphoria lighting",
+  "Wes Anderson symmetry and palette",
+  "Pinterest decor angle",
 ];
 
 const lensOptions = [


### PR DESCRIPTION
## Summary
- add editorial/styled/trendy camera presets to ImagePromptGenerator
- update test to target specific Polaroid option

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a8b0c34bec8325823f6031273ee4fb