### PR TITLE
feat: add tabletop map with configurable grid

### DIFF
--- a/src/features/dnd/TabletopMap.tsx
+++ b/src/features/dnd/TabletopMap.tsx
@@ -1,0 +1,89 @@
+import { Box, Button, FormControlLabel, Slider, Switch } from "@mui/material";
+import { ChangeEvent, useEffect, useRef, useState } from "react";
+import { useTabletopMap } from "../../store/tabletopMap";
+
+export default function TabletopMap() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [image, setImage] = useState<string | null>(null);
+  const showGrid = useTabletopMap((s) => s.showGrid);
+  const gridSize = useTabletopMap((s) => s.gridSize);
+  const toggleGrid = useTabletopMap((s) => s.toggleGrid);
+  const setGridSize = useTabletopMap((s) => s.setGridSize);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const { width, height } = canvas;
+    ctx.clearRect(0, 0, width, height);
+    if (!showGrid) return;
+    ctx.strokeStyle = "rgba(0,0,0,0.3)";
+    for (let x = 0; x <= width; x += gridSize) {
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, height);
+      ctx.stroke();
+    }
+    for (let y = 0; y <= height; y += gridSize) {
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(width, y);
+      ctx.stroke();
+    }
+  }, [showGrid, gridSize]);
+
+  const handleImageUpload = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setImage(reader.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <Box>
+      <Box sx={{ mb: 2, display: "flex", gap: 2, alignItems: "center" }}>
+        <FormControlLabel
+          control={<Switch checked={showGrid} onChange={toggleGrid} />}
+          label="Show Grid"
+        />
+        <Slider
+          value={gridSize}
+          onChange={(_, v) => setGridSize(v as number)}
+          min={20}
+          max={100}
+          valueLabelDisplay="auto"
+          sx={{ width: 200 }}
+        />
+        <Button variant="contained" component="label">
+          Upload Map
+          <input type="file" accept="image/*" hidden onChange={handleImageUpload} />
+        </Button>
+      </Box>
+      <Box sx={{ position: "relative", width: 600, height: 600 }}>
+        {image && (
+          <Box
+            component="img"
+            src={image}
+            alt="tabletop"
+            sx={{ width: "100%", height: "100%", objectFit: "contain" }}
+          />
+        )}
+        <canvas
+          ref={canvasRef}
+          width={600}
+          height={600}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            pointerEvents: "none",
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -6,6 +6,7 @@ import QuestForm from "../features/dnd/QuestForm";
 import EncounterForm from "../features/dnd/EncounterForm";
 import RuleForm from "../features/dnd/RuleForm";
 import SpellForm from "../features/dnd/SpellForm";
+import TabletopMap from "../features/dnd/TabletopMap";
 
 export default function DND() {
   const [tab, setTab] = useState(0);
@@ -19,6 +20,7 @@ export default function DND() {
         <Tab label="Encounter" />
         <Tab label="Rulebook" />
         <Tab label="Spellbook" />
+        <Tab label="Tabletop" />
       </Tabs>
       {tab === 0 && <NpcForm />}
       {tab === 1 && <LoreForm />}
@@ -26,6 +28,7 @@ export default function DND() {
       {tab === 3 && <EncounterForm />}
       {tab === 4 && <RuleForm />}
       {tab === 5 && <SpellForm />}
+      {tab === 6 && <TabletopMap />}
     </Box>
   );
 }

--- a/src/store/tabletopMap.ts
+++ b/src/store/tabletopMap.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface TabletopMapState {
+  showGrid: boolean;
+  gridSize: number;
+  toggleGrid: () => void;
+  setGridSize: (size: number) => void;
+}
+
+export const useTabletopMap = create<TabletopMapState>()(
+  persist(
+    (set) => ({
+      showGrid: true,
+      gridSize: 50,
+      toggleGrid: () => set((s) => ({ showGrid: !s.showGrid })),
+      setGridSize: (size) => set({ gridSize: size }),
+    }),
+    { name: 'tabletop-map' }
+  )
+);


### PR DESCRIPTION
## Summary
- add TabletopMap component with image upload and configurable grid
- persist grid settings with zustand store
- show new Tabletop tab on DND page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8d2002fcc83258381d1ee5b763eb4