### PR TITLE
feat: add tabletop map with grid

### DIFF
--- a/src/features/dnd/TabletopMap.tsx
+++ b/src/features/dnd/TabletopMap.tsx
@@ -1,0 +1,81 @@
+import { Box, Button, Checkbox, FormControlLabel, TextField } from "@mui/material";
+import { useState } from "react";
+import { useTabletopStore } from "../../store/tabletop";
+
+export default function TabletopMap() {
+  const {
+    gridSize,
+    gridColor,
+    showGrid,
+    setGridSize,
+    setGridColor,
+    setShowGrid,
+  } = useTabletopStore();
+  const [image, setImage] = useState<string | undefined>();
+
+  const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setImage(reader.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Button variant="contained" component="label" sx={{ maxWidth: 200 }}>
+        Upload Image
+        <input type="file" hidden accept="image/*" onChange={handleUpload} />
+      </Button>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={showGrid}
+            onChange={(e) => setShowGrid(e.target.checked)}
+          />
+        }
+        label="Show Grid"
+      />
+      <TextField
+        label="Grid Size"
+        type="number"
+        value={gridSize}
+        onChange={(e) => setGridSize(Number(e.target.value))}
+        sx={{ maxWidth: 200 }}
+      />
+      <TextField
+        label="Grid Color"
+        type="color"
+        value={gridColor}
+        onChange={(e) => setGridColor(e.target.value)}
+        sx={{ maxWidth: 200 }}
+        InputLabelProps={{ shrink: true }}
+      />
+      <Box
+        sx={{
+          position: "relative",
+          mt: 2,
+          border: "1px solid #ccc",
+          height: 500,
+          width: "100%",
+          backgroundImage: image ? `url(${image})` : "none",
+          backgroundSize: "contain",
+          backgroundRepeat: "no-repeat",
+          backgroundPosition: "center",
+        }}
+      >
+        {showGrid && (
+          <Box
+            sx={{
+              position: "absolute",
+              inset: 0,
+              backgroundImage: `linear-gradient(to right, ${gridColor} 1px, transparent 1px), linear-gradient(to bottom, ${gridColor} 1px, transparent 1px)`,
+              backgroundSize: `${gridSize}px ${gridSize}px`,
+              pointerEvents: "none",
+            }}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -7,6 +7,7 @@ import EncounterForm from "../features/dnd/EncounterForm";
 import RuleForm from "../features/dnd/RuleForm";
 import SpellForm from "../features/dnd/SpellForm";
 import DiceRoller from "../features/dnd/DiceRoller";
+import TabletopMap from "../features/dnd/TabletopMap";
 
 export default function DND() {
   const [tab, setTab] = useState(0);
@@ -21,6 +22,7 @@ export default function DND() {
         <Tab label="Rulebook" />
         <Tab label="Spellbook" />
         <Tab label="Dice" />
+        <Tab label="Tabletop" />
       </Tabs>
       {tab === 0 && <NpcForm />}
       {tab === 1 && <LoreForm />}
@@ -29,6 +31,7 @@ export default function DND() {
       {tab === 4 && <RuleForm />}
       {tab === 5 && <SpellForm />}
       {tab === 6 && <DiceRoller />}
+      {tab === 7 && <TabletopMap />}
     </Box>
   );
 }

--- a/src/store/tabletop.ts
+++ b/src/store/tabletop.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface TabletopState {
+  gridSize: number;
+  gridColor: string;
+  showGrid: boolean;
+  setGridSize: (size: number) => void;
+  setGridColor: (color: string) => void;
+  setShowGrid: (show: boolean) => void;
+}
+
+export const useTabletopStore = create<TabletopState>()(
+  persist(
+    (set) => ({
+      gridSize: 50,
+      gridColor: '#000000',
+      showGrid: true,
+      setGridSize: (gridSize) => set({ gridSize }),
+      setGridColor: (gridColor) => set({ gridColor }),
+      setShowGrid: (showGrid) => set({ showGrid }),
+    }),
+    { name: 'tabletop-store' }
+  )
+);


### PR DESCRIPTION
## Summary
- add TabletopMap component with image upload and grid controls
- persist grid settings via Zustand store
- show Tabletop tab on DND page

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a8d9d244ac832591c2e874842bc03a