### PR TITLE
feat: show task stats on chores page

### DIFF
--- a/src/pages/Chores.tsx
+++ b/src/pages/Chores.tsx
@@ -1,5 +1,61 @@
+import { useEffect } from "react";
 import Center from "./_Center";
+import { useCalendar } from "../features/calendar/useCalendar";
+import { useTasks } from "../store/tasks";
 
 export default function Chores() {
-  return <Center>Chores</Center>;
+  const { events } = useCalendar();
+  const { tasks, subscribe } = useTasks();
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    subscribe().then((u) => {
+      unlisten = u;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, [subscribe]);
+
+  const now = new Date();
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate()
+  );
+
+  const upcomingTasks = events.filter(
+    (e) =>
+      e.tags.includes("task") &&
+      e.status === "scheduled" &&
+      new Date(e.date) >= startOfToday
+  ).length;
+
+  const missedTasks = events.filter(
+    (e) =>
+      e.tags.includes("task") &&
+      e.status === "scheduled" &&
+      new Date(e.date) < startOfToday
+  ).length;
+
+  const currentTasks = Object.values(tasks).filter(
+    (t) => t.status === "queued"
+  ).length;
+
+  return (
+    <Center>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "1rem",
+          textAlign: "center",
+        }}
+      >
+        <div>Upcoming Tasks: {upcomingTasks}</div>
+        <div>Current Tasks: {currentTasks}</div>
+        <div>Missed Tasks: {missedTasks}</div>
+      </div>
+    </Center>
+  );
 }


### PR DESCRIPTION
## Summary
- show counts of upcoming, current queued, and missed tasks on Chores page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8e84a2d2083258926dfd24ea791e5