### PR TITLE
feat: add audio transcription

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ feedparser>=6.0.0
 requests>=2.31.0
 aiohttp>=3.9.0
 gTTS>=2.5.1
+vosk>=0.3.45

--- a/src-tauri/python/transcribe.py
+++ b/src-tauri/python/transcribe.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import json
+
+try:
+    import vosk  # type: ignore
+    import wave
+except Exception as e:
+    print(f"failed to import dependencies: {e}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: transcribe.py <audio_path>", file=sys.stderr)
+        return 1
+    audio_path = sys.argv[1]
+    if not os.path.exists(audio_path):
+        print("audio file not found", file=sys.stderr)
+        return 1
+    model_path = os.environ.get("VOSK_MODEL_PATH")
+    if not model_path or not os.path.isdir(model_path):
+        print("VOSK_MODEL_PATH not set", file=sys.stderr)
+        return 1
+    wf = wave.open(audio_path, "rb")
+    model = vosk.Model(model_path)
+    rec = vosk.KaldiRecognizer(model, wf.getframerate())
+    while True:
+        data = wf.readframes(4000)
+        if len(data) == 0:
+            break
+        rec.AcceptWaveform(data)
+    result = json.loads(rec.FinalResult())
+    print(result.get("text", ""))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -78,6 +78,9 @@ fn main() {
             commands::load_shorts,
             commands::save_shorts,
             commands::generate_short,
+            // Transcription:
+            commands::load_transcripts,
+            commands::transcribe_audio,
             commands::system_info,
             commands::enqueue_task,
             commands::task_status,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import Chores from "./pages/Chores";
 import User from "./pages/User";
 import SystemInfo from "./pages/SystemInfo";
 import Fusion from "./pages/Fusion";
+import Transcription from "./pages/Transcription";
 
 export default function App() {
   return (
@@ -45,6 +46,7 @@ export default function App() {
         <Route path="/shorts" element={<Shorts />} />
         <Route path="/chores" element={<Chores />} />
         <Route path="/system" element={<SystemInfo />} />
+        <Route path="/transcription" element={<Transcription />} />
         <Route path="/dnd" element={<DND />} />
         <Route path="/user" element={<User />} />
         <Route path="*" element={<NotFound />} />

--- a/src/features/transcription/Recorder.tsx
+++ b/src/features/transcription/Recorder.tsx
@@ -1,0 +1,13 @@
+import { useTranscription } from "./useTranscription";
+
+export default function Recorder() {
+  const { start, stop, recording, transcript } = useTranscription();
+  return (
+    <div>
+      <button type="button" onClick={recording ? stop : start}>
+        {recording ? "Stop" : "Record"}
+      </button>
+      {transcript && <p>{transcript}</p>}
+    </div>
+  );
+}

--- a/src/features/transcription/useTranscription.ts
+++ b/src/features/transcription/useTranscription.ts
@@ -1,0 +1,36 @@
+import { useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export function useTranscription() {
+  const [recording, setRecording] = useState(false);
+  const [transcript, setTranscript] = useState("");
+  const media = useRef<MediaRecorder | null>(null);
+  const chunks = useRef<Blob[]>([]);
+
+  async function start() {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    media.current = new MediaRecorder(stream);
+    chunks.current = [];
+    media.current.ondataavailable = (e) => chunks.current.push(e.data);
+    media.current.onstop = async () => {
+      const blob = new Blob(chunks.current, { type: "audio/wav" });
+      const buf = await blob.arrayBuffer();
+      const data = Array.from(new Uint8Array(buf));
+      try {
+        const text = await invoke<string>("transcribe_audio", { data });
+        setTranscript(text.trim());
+      } catch (err: any) {
+        setTranscript(`Error: ${err}`);
+      }
+    };
+    media.current.start();
+    setRecording(true);
+  }
+
+  function stop() {
+    media.current?.stop();
+    setRecording(false);
+  }
+
+  return { start, stop, recording, transcript };
+}

--- a/src/pages/Transcription.tsx
+++ b/src/pages/Transcription.tsx
@@ -1,0 +1,10 @@
+import Recorder from "../features/transcription/Recorder";
+
+export default function Transcription() {
+  return (
+    <div style={{ padding: 20 }}>
+      <h1>Transcription</h1>
+      <Recorder />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add frontend transcription recorder and hook
- add Tauri command and Python script to transcribe audio via Vosk
- store transcripts and expose route for playback

## Testing
- `npm test`
- `cargo check` *(fails: command not found)*
- `python -m py_compile src-tauri/python/transcribe.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8e6e56d948325aa3880b73a3275bb