### PR TITLE
Start song title field empty

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -166,7 +166,7 @@ export default function SongForm() {
   } = useAudioDefaults();
 
   // THEME (applies to all songs)
-  const [titleBase, setTitleBase] = useState("Midnight Coffee");
+  const [titleBase, setTitleBase] = useState("");
   const [outDir, setOutDir] = useState(localStorage.getItem("outDir") ?? "");
   const [bpm, setBpm] = useState(defaultBpm);
   const [key, setKey] = useState<string>(defaultKey);
@@ -679,7 +679,7 @@ export default function SongForm() {
   function restoreDefaults() {
     setSelectedTemplate("");
     applyTemplate(PRESET_TEMPLATES["Classic Lofi"]);
-    setTitleBase("Midnight Coffee");
+    setTitleBase("");
     setOutDir("");
     setAutoKeyPerSong(false);
   }

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -189,7 +189,7 @@ exports[`SongForm > renders default form 1`] = `
         <input
           class="_input_62bdff"
           placeholder="Song title base"
-          value="Midnight Coffee"
+          value=""
         />
         <button
           class="_btn_62bdff"


### PR DESCRIPTION
## Summary
- initialize song title text field with an empty string
- reset the title to empty when restoring defaults

## Testing
- `npm test -- -u` *(fails: expected spy to be called at least once)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e9581388832598b6f65ed561cb7d