### PR TITLE
feat: add DND war table with markers

### DIFF
--- a/src/features/dnd/WarTable.tsx
+++ b/src/features/dnd/WarTable.tsx
@@ -1,0 +1,116 @@
+import { Box, Button } from "@mui/material";
+import { useState } from "react";
+import { useWarTableStore } from "../../store/warTable";
+
+export default function WarTable() {
+  const {
+    mapImage,
+    partyPosition,
+    markers,
+    setMapImage,
+    setPartyPosition,
+    addMarker,
+  } = useWarTableStore();
+  const [mode, setMode] = useState<"party" | "area" | null>(null);
+
+  const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setMapImage(reader.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  const handleMapClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!mode) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = (e.clientX - rect.left) / rect.width;
+    const y = (e.clientY - rect.top) / rect.height;
+    if (mode === "party") {
+      setPartyPosition({ x, y });
+    } else if (mode === "area") {
+      const note = window.prompt("Area note?");
+      if (note) addMarker({ x, y, note });
+    }
+    setMode(null);
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+      <Button variant="contained" component="label" sx={{ maxWidth: 200 }}>
+        Upload Map
+        <input type="file" hidden accept="image/*" onChange={handleUpload} />
+      </Button>
+      <Box sx={{ display: "flex", gap: 2 }}>
+        <Button variant="outlined" onClick={() => setMode("party")}>
+          Set Party Position
+        </Button>
+        <Button variant="outlined" onClick={() => setMode("area")}>
+          Add Area
+        </Button>
+      </Box>
+      <Box
+        sx={{
+          position: "relative",
+          mt: 2,
+          border: "1px solid #ccc",
+          height: 500,
+          width: "100%",
+          backgroundImage: mapImage ? `url(${mapImage})` : "none",
+          backgroundSize: "contain",
+          backgroundRepeat: "no-repeat",
+          backgroundPosition: "center",
+          overflow: "hidden",
+        }}
+        onClick={handleMapClick}
+      >
+        {mapImage && (
+          <Box
+            sx={{
+              position: "absolute",
+              inset: 0,
+              backgroundColor: "rgba(245, 222, 179, 0.4)",
+              mixBlendMode: "multiply",
+              pointerEvents: "none",
+            }}
+          />
+        )}
+        {partyPosition && (
+          <Box
+            sx={{
+              position: "absolute",
+              width: 16,
+              height: 16,
+              borderRadius: "50%",
+              backgroundColor: "red",
+              top: `${partyPosition.y * 100}%`,
+              left: `${partyPosition.x * 100}%`,
+              transform: "translate(-50%, -50%)",
+            }}
+          />
+        )}
+        {markers.map((m) => (
+          <Box
+            key={m.id}
+            onClick={(ev) => {
+              ev.stopPropagation();
+              window.alert(m.note);
+            }}
+            sx={{
+              position: "absolute",
+              width: 12,
+              height: 12,
+              borderRadius: "50%",
+              backgroundColor: "blue",
+              top: `${m.y * 100}%`,
+              left: `${m.x * 100}%`,
+              transform: "translate(-50%, -50%)",
+              cursor: "pointer",
+            }}
+            title={m.note}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -8,6 +8,7 @@ import RuleForm from "../features/dnd/RuleForm";
 import SpellForm from "../features/dnd/SpellForm";
 import DiceRoller from "../features/dnd/DiceRoller";
 import TabletopMap from "../features/dnd/TabletopMap";
+import WarTable from "../features/dnd/WarTable";
 
 export default function DND() {
   const [tab, setTab] = useState(0);
@@ -23,6 +24,7 @@ export default function DND() {
         <Tab label="Spellbook" />
         <Tab label="Dice" />
         <Tab label="Tabletop" />
+        <Tab label="War Table" />
       </Tabs>
       {tab === 0 && <NpcForm />}
       {tab === 1 && <LoreForm />}
@@ -32,6 +34,7 @@ export default function DND() {
       {tab === 5 && <SpellForm />}
       {tab === 6 && <DiceRoller />}
       {tab === 7 && <TabletopMap />}
+      {tab === 8 && <WarTable />}
     </Box>
   );
 }

--- a/src/store/warTable.ts
+++ b/src/store/warTable.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface Marker {
+  id: string;
+  x: number;
+  y: number;
+  note: string;
+}
+
+interface WarTableState {
+  mapImage: string | null;
+  partyPosition: { x: number; y: number } | null;
+  markers: Marker[];
+  setMapImage: (img: string | null) => void;
+  setPartyPosition: (pos: { x: number; y: number } | null) => void;
+  addMarker: (marker: Omit<Marker, 'id'>) => void;
+  removeMarker: (id: string) => void;
+}
+
+export const useWarTableStore = create<WarTableState>()(
+  persist(
+    (set) => ({
+      mapImage: null,
+      partyPosition: null,
+      markers: [],
+      setMapImage: (mapImage) => set({ mapImage }),
+      setPartyPosition: (partyPosition) => set({ partyPosition }),
+      addMarker: (marker) =>
+        set((state) => ({
+          markers: [...state.markers, { id: crypto.randomUUID(), ...marker }],
+        })),
+      removeMarker: (id) =>
+        set((state) => ({
+          markers: state.markers.filter((m) => m.id !== id),
+        })),
+    }),
+    { name: 'war-table-store' }
+  )
+);


### PR DESCRIPTION
## Summary
- add War Table tab and component for DND maps
- enable uploading map images, set party position, and mark areas of interest with notes
- persist war table state using new zustand store

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e712206c8325986ed118cf2dcc81