### PR TITLE
feat: extend NPC schema for custom sections

### DIFF
--- a/dnd/schemas/npc.schema.json
+++ b/dnd/schemas/npc.schema.json
@@ -69,6 +69,13 @@
         "portrait": {
           "type": "string"
         },
+        "icon": {
+          "type": "string"
+        },
+        "sections": {
+          "type": "object",
+          "additionalProperties": {}
+        },
         "statblock": {
           "type": "object",
           "additionalProperties": {}

--- a/dnd/templates/npc.css
+++ b/dnd/templates/npc.css
@@ -24,6 +24,11 @@ body {
   height: auto;
 }
 
+.icon {
+  width: 50px;
+  height: 50px;
+}
+
 .quick-stats ul,
 .hooks ul,
 .secrets ul,
@@ -36,6 +41,10 @@ body {
 
 .statblock,
 .skills {
+  page-break-inside: avoid;
+}
+
+.custom-section {
   page-break-inside: avoid;
 }
 

--- a/dnd/templates/npc.hbs
+++ b/dnd/templates/npc.hbs
@@ -1,5 +1,8 @@
 <div class="npc">
   <div class="header">
+    {{#if icon}}
+    <img class="icon" src="{{icon}}" alt="{{name}} icon" />
+    {{/if}}
     {{#if portrait}}
     <img class="portrait" src="{{portrait}}" alt="{{name}} portrait" />
     {{/if}}
@@ -59,6 +62,15 @@
       {{/each}}
     </ul>
   </section>
+  {{/if}}
+
+  {{#if sections}}
+    {{#each sections}}
+    <section class="custom-section">
+      <h2>{{@key}}</h2>
+      <p>{{this}}</p>
+    </section>
+    {{/each}}
   {{/if}}
 </div>
 

--- a/src/dnd/schemas/npc.ts
+++ b/src/dnd/schemas/npc.ts
@@ -18,6 +18,8 @@ export const zNpc = z.object({
   quirks: z.array(z.string()).optional(),
   voice: zVoice,
   portrait: z.string().optional(),
+  icon: z.string().optional(),
+  sections: z.record(z.unknown()).optional(),
   statblock: z.record(z.unknown()),
   tags: z.array(z.string()).nonempty(),
 });

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -17,7 +17,9 @@ export default function NpcForm() {
   const [voiceProvider, setVoiceProvider] = useState("");
   const [voicePreset, setVoicePreset] = useState("");
   const [portrait, setPortrait] = useState("");
+  const [icon, setIcon] = useState("");
   const [statblock, setStatblock] = useState("{}");
+  const [sections, setSections] = useState("{}");
   const [tags, setTags] = useState("");
   const [errors, setErrors] = useState<Record<string, string | null>>({});
   const [result, setResult] = useState<NpcData | null>(null);
@@ -30,6 +32,15 @@ export default function NpcForm() {
       parsedStatblock = JSON.parse(statblock || "{}");
     } catch {
       setErrors({ statblock: "Invalid JSON" });
+      setResult(null);
+      return;
+    }
+
+    let parsedSections: Record<string, unknown> = {};
+    try {
+      parsedSections = JSON.parse(sections || "{}");
+    } catch {
+      setErrors({ sections: "Invalid JSON" });
       setResult(null);
       return;
     }
@@ -50,6 +61,8 @@ export default function NpcForm() {
         preset: voicePreset,
       },
       portrait: portrait || undefined,
+      icon: icon || undefined,
+      sections: Object.keys(parsedSections).length ? parsedSections : undefined,
       statblock: parsedStatblock,
       tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
     };
@@ -197,6 +210,13 @@ export default function NpcForm() {
         margin="normal"
       />
       <TextField
+        label="Icon URL"
+        value={icon}
+        onChange={(e) => setIcon(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <TextField
         label="Statblock JSON"
         value={statblock}
         onChange={(e) => {
@@ -208,6 +228,19 @@ export default function NpcForm() {
         multiline
         error={Boolean(errors.statblock)}
         helperText={errors.statblock}
+      />
+      <TextField
+        label="Custom Sections JSON"
+        value={sections}
+        onChange={(e) => {
+          setSections(e.target.value);
+          setErrors((prev) => ({ ...prev, sections: null }));
+        }}
+        fullWidth
+        margin="normal"
+        multiline
+        error={Boolean(errors.sections)}
+        helperText={errors.sections}
       />
       <TextField
         label="Tags (comma separated)"

--- a/src/features/dnd/tests/schemas.test.ts
+++ b/src/features/dnd/tests/schemas.test.ts
@@ -12,6 +12,8 @@ describe("dnd schemas", () => {
       alignment: "CE",
       hooks: ["steal"],
       voice: { style: "gravelly", provider: "acme", preset: "goblin" },
+      icon: "icon.png",
+      sections: { bio: "Lives in cave" },
       statblock: {},
       tags: ["monster"],
     };
@@ -72,6 +74,22 @@ describe("dnd schemas", () => {
       // hooks should be an array of strings
       hooks: "steal",
       voice: { style: "gravelly", provider: "acme", preset: "goblin" },
+      statblock: {},
+      tags: ["monster"],
+    };
+    expect(() => zNpc.parse(npc)).toThrowError();
+  });
+
+  it("rejects NPCs with invalid sections type", () => {
+    const npc = {
+      id: "1",
+      name: "Goblin Scout",
+      species: "Goblinoid",
+      role: "Scout",
+      alignment: "CE",
+      hooks: ["steal"],
+      voice: { style: "gravelly", provider: "acme", preset: "goblin" },
+      sections: "not-an-object" as any,
       statblock: {},
       tags: ["monster"],
     };

--- a/src/store/npcs.ts
+++ b/src/store/npcs.ts
@@ -15,11 +15,13 @@ export interface NPC {
   background: string;
   appearance: string;
   portrait?: string;
+  icon?: string;
   hooks?: string[];
   quirks?: string[];
   secrets?: string[];
   stats?: Record<string, string | number>;
   skills?: Record<string, string | number>;
+  sections?: Record<string, unknown>;
 }
 
 interface NPCState {


### PR DESCRIPTION
## Summary
- add `icon` field and `sections` map to NPC schema
- expose new fields in NPC form, template, and store
- support arbitrary custom sections when rendering NPCs

## Testing
- `npm run schemas:generate`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e797b49c832596e7e9b228e1334a