### PR TITLE
feat: add construction hub

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import User from "./pages/User";
 import SystemInfo from "./pages/SystemInfo";
 import Fusion from "./pages/Fusion";
 import Transcription from "./pages/Transcription";
+import Construction from "./pages/Construction";
 
 export default function App() {
   return (
@@ -41,6 +42,7 @@ export default function App() {
         <Route path="/dnd/npcs-library" element={<NPCList />} />
         <Route path="/laser" element={<Laser />} />
         <Route path="/fusion" element={<Fusion />} />
+        <Route path="/construction" element={<Construction />} />
         <Route path="/lofi" element={<Lofi />} />
         <Route path="/stocks" element={<Stocks />} />
         <Route path="/shorts" element={<Shorts />} />

--- a/src/components/FeatureNav.tsx
+++ b/src/components/FeatureNav.tsx
@@ -14,6 +14,7 @@ import {
   FaChartLine,
   FaFilm,
   FaBroom,
+  FaTools,
 } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import { useSettings } from "../features/settings/useSettings";
@@ -46,6 +47,13 @@ const ITEMS: Item[] = [
   { key: "stocks", icon: <FaChartLine />, label: "Stocks", path: "/stocks", color: "rgba(200,255,200,0.55)" },
   { key: "shorts", icon: <FaFilm />, label: "Shorts", path: "/shorts", color: "rgba(200,200,200,0.55)" },
   { key: "chores", icon: <FaBroom />, label: "Chores", path: "/chores", color: "rgba(200,200,255,0.55)" },
+  {
+    key: "construction",
+    icon: <FaTools />,
+    label: "Under Construction",
+    path: "/construction",
+    color: "rgba(180,180,180,0.55)",
+  },
 ];
 
 export default function FeatureNav({

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -14,7 +14,8 @@ type ModuleKey =
   | 'dnd'
   | 'stocks'
   | 'shorts'
-  | 'chores';
+  | 'chores'
+  | 'construction';
 
 type ModulesState = Record<ModuleKey, boolean>;
 
@@ -30,6 +31,7 @@ const defaultModules: ModulesState = {
   stocks: true,
   shorts: true,
   chores: true,
+  construction: true,
 };
 
   interface User {

--- a/src/pages/Construction.tsx
+++ b/src/pages/Construction.tsx
@@ -1,0 +1,18 @@
+import { Button, Stack } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+import Center from "./_Center";
+
+export default function Construction() {
+  const navigate = useNavigate();
+  return (
+    <Center>
+      <Stack spacing={2} sx={{ width: "100%", maxWidth: 400 }}>
+        <Button variant="contained" onClick={() => navigate("/laser")}>Laser Lab</Button>
+        <Button variant="contained" onClick={() => navigate("/assistant")}>Agents</Button>
+        <Button variant="contained" onClick={() => {}}>
+          Create new
+        </Button>
+      </Stack>
+    </Center>
+  );
+}


### PR DESCRIPTION
## Summary
- add under construction icon to feature wheel
- create construction page with quick links
- include new route and module setting

## Testing
- `npm test` *(fails: 1 file failed | 24 passed; 4 tests failed | 115 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8eb215bcc8325a1b159fe55c593ae