### PR TITLE
Collapse default SongForm sections

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -30,6 +30,10 @@ function openSection(id: string) {
   fireEvent.click(summary);
 }
 
+function openDetails(title: string) {
+  fireEvent.click(screen.getByText(title));
+}
+
 describe('SongForm', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -73,6 +77,11 @@ describe('SongForm', () => {
     render(<SongForm />);
     fireEvent.click(screen.getByText(/choose folder/i));
     await screen.findByText('/tmp/out');
+
+    fireEvent.change(
+      screen.getByPlaceholderText(/song title base/i),
+      { target: { value: 'Test Song' } }
+    );
 
     const autoPlay = screen.getByText(/Auto‑play last successful render/).previousSibling as HTMLInputElement;
     fireEvent.click(autoPlay);
@@ -129,11 +138,13 @@ describe('SongForm', () => {
 
   it('remembers last used template', () => {
     render(<SongForm />);
+    openDetails('Structure');
     const select = screen.getByLabelText(/song templates/i) as HTMLSelectElement;
     fireEvent.change(select, { target: { value: 'Study Session' } });
     expect(select.value).toBe('Study Session');
     cleanup();
     render(<SongForm />);
+    openDetails('Structure');
     expect(
       (screen.getByLabelText(/song templates/i) as HTMLSelectElement).value
     ).toBe('Study Session');
@@ -171,37 +182,44 @@ describe('SongForm', () => {
 
   it('shows Arcane Clash template option', () => {
     render(<SongForm />);
+    openDetails('Structure');
     expect(screen.getAllByText('Arcane Clash')[0]).toBeInTheDocument();
   });
 
   it('shows Bossa Nova template option', () => {
     render(<SongForm />);
+    openDetails('Structure');
     expect(screen.getAllByText('Bossa Nova')[0]).toBeInTheDocument();
   });
 
   it("shows King's Last Stand template option", () => {
     render(<SongForm />);
+    openDetails('Structure');
     expect(screen.getAllByText("King's Last Stand")[0]).toBeInTheDocument();
   });
 
   it('shows Ocean Breeze template option', () => {
     render(<SongForm />);
+    openDetails('Structure');
     expect(screen.getAllByText('Ocean Breeze')[0]).toBeInTheDocument();
   });
 
   it('shows City Lights template option', () => {
     render(<SongForm />);
+    openDetails('Structure');
     expect(screen.getAllByText('City Lights')[0]).toBeInTheDocument();
   });
 
   it('applies Bossa Nova template', () => {
     render(<SongForm />);
+    openDetails('Structure');
     const select = screen.getByLabelText(/song templates/i) as HTMLSelectElement;
     fireEvent.change(select, { target: { value: 'Bossa Nova' } });
     openSection('rhythm-section');
     const label = screen.getByText('Drum Pattern');
     const drumSelect = label.parentElement!.querySelector('select') as HTMLSelectElement;
     expect(drumSelect.value).toBe('bossa_nova');
+    openDetails('Core');
     const bpmSlider = screen.getAllByRole('slider')[0] as HTMLInputElement;
     expect(bpmSlider.value).toBe('120');
   });
@@ -220,6 +238,7 @@ describe('SongForm', () => {
       JSON.stringify({ Foo: PRESET_TEMPLATES['Classic Lofi'] })
     );
     render(<SongForm />);
+    openDetails('Structure');
     const select = screen.getByLabelText(/song templates/i) as HTMLSelectElement;
     const options = Array.from(select.options).map((o) => o.value);
     expect(options).toContain('Bossa Nova');
@@ -234,6 +253,11 @@ describe('SongForm', () => {
 
     fireEvent.click(screen.getByText(/choose folder/i));
     await screen.findByText('/tmp/out');
+
+    fireEvent.change(
+      screen.getByPlaceholderText(/song title base/i),
+      { target: { value: 'Test Song' } }
+    );
 
     ['rhodes', 'nylon guitar', 'upright bass'].forEach((name) =>
       fireEvent.click(screen.getByText(name))
@@ -258,6 +282,11 @@ describe('SongForm', () => {
 
     fireEvent.click(screen.getByText(/choose folder/i));
     await screen.findByText('/tmp/out');
+
+    fireEvent.change(
+      screen.getByPlaceholderText(/song title base/i),
+      { target: { value: 'Test Song' } }
+    );
 
     fireEvent.click(screen.getByRole('radio', { name: 'flute' }));
 
@@ -290,6 +319,11 @@ describe('SongForm', () => {
 
     fireEvent.click(screen.getByText(/choose folder/i));
     await screen.findByText('/tmp/out');
+
+    fireEvent.change(
+      screen.getByPlaceholderText(/song title base/i),
+      { target: { value: 'Test Song' } }
+    );
 
     fireEvent.click(screen.getByLabelText(/album mode/i));
     fireEvent.click(screen.getByText(/create album/i));

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -724,7 +724,7 @@ export default function SongForm() {
         <div className={styles.small}>{outDir || "No output folder selected"}</div>
 
         {/* core knobs */}
-        <details className="mt-3" open>
+        <details className="mt-3">
           <summary className="cursor-pointer text-xs opacity-80">Core</summary>
           <div className={styles.grid3}>
           <div className={styles.panel}>
@@ -785,7 +785,7 @@ export default function SongForm() {
         </details>
 
         {/* structure editor */}
-        <details className={clsx(styles.panel, "mt-3")} open>
+        <details className={clsx(styles.panel, "mt-3")}>
           <summary className="cursor-pointer text-xs opacity-80">Structure</summary>
           <div className="mt-2">
           <div className={clsx(styles.row, "mb-2")}>

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -209,7 +209,6 @@ exports[`SongForm > renders default form 1`] = `
       </div>
       <details
         class="mt-3"
-        open=""
       >
         <summary
           class="cursor-pointer text-xs opacity-80"
@@ -467,7 +466,6 @@ exports[`SongForm > renders default form 1`] = `
       </details>
       <details
         class="_panel_62bdff mt-3"
-        open=""
       >
         <summary
           class="cursor-pointer text-xs opacity-80"


### PR DESCRIPTION
## Summary
- Remove default `open` state from Core and Structure details in SongForm
- Adjust tests to open sections explicitly and provide a song title before rendering

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a8eb6cb96c83259a428c20cc5a59d5