### PR TITLE
Switch camera and lens selectors to radio buttons

### DIFF
--- a/src/components/ImagePromptGenerator.test.tsx
+++ b/src/components/ImagePromptGenerator.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import ImagePromptGenerator from './ImagePromptGenerator';
 
 describe('ImagePromptGenerator', () => {
-  it('disables conflicting options and generates prompt', () => {
+  it('selects camera and lens using radio buttons and generates prompt', () => {
     const onGenerate = vi.fn();
     render(<ImagePromptGenerator onGenerate={onGenerate} />);
     fireEvent.click(screen.getByRole('button', { name: /image prompt/i }));
@@ -13,13 +13,22 @@ describe('ImagePromptGenerator', () => {
 
     const kodak = screen.getByLabelText(/Kodak Portra 400/i);
     fireEvent.click(kodak);
-    const polaroid = screen.getByLabelText(/Shot on Polaroid/i);
-    expect(polaroid).toBeDisabled();
+    expect(kodak).toBeChecked();
 
-    const wide = screen.getByLabelText(/Wide-angle lens/i);
+    const polaroid = screen.getByLabelText(/Shot on Polaroid/i);
+    expect(polaroid).not.toBeDisabled();
+    fireEvent.click(polaroid);
+    expect(polaroid).toBeChecked();
+    expect(kodak).not.toBeChecked();
+
+    const wide = screen.getByLabelText(/Wide-angle lens, 24mm/i);
     fireEvent.click(wide);
-    const tilt = screen.getAllByLabelText(/Tilt-shift lens effect/i)[0];
-    expect(tilt).toBeDisabled();
+    expect(wide).toBeChecked();
+
+    const macro = screen.getByLabelText(/Macro lens photography/i);
+    fireEvent.click(macro);
+    expect(macro).toBeChecked();
+    expect(wide).not.toBeChecked();
 
     const ghibli = screen.getByLabelText(/Studio Ghibli/i);
     fireEvent.click(ghibli);
@@ -29,8 +38,7 @@ describe('ImagePromptGenerator', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /generate/i }));
     expect(onGenerate).toHaveBeenCalledWith(
-      'sunset Shot on Kodak Portra 400 (warm, soft film aesthetic) Wide-angle lens, 24mm cinematography by Roger Deakins Studio Ghibli–inspired framing'
+      'sunset Shot on Polaroid (vintage, instant photo look) Macro lens photography cinematography by Roger Deakins Studio Ghibli–inspired framing'
     );
   });
 });
-

--- a/src/components/ImagePromptGenerator.tsx
+++ b/src/components/ImagePromptGenerator.tsx
@@ -8,6 +8,8 @@ import {
   FormControlLabel,
   Checkbox,
   Typography,
+  RadioGroup,
+  Radio,
 } from "@mui/material";
 
 interface Props {
@@ -102,11 +104,11 @@ export default function ImagePromptGenerator({ onGenerate }: Props) {
   const [cosmic, setCosmic] = useState<string[]>([]);
 
   const toggleCamera = (opt: string) => {
-    setCamera((prev) => (prev === opt ? null : opt));
+    setCamera(opt);
   };
 
   const toggleLens = (opt: string) => {
-    setLens((prev) => (prev === opt ? null : opt));
+    setLens(opt);
   };
 
   const toggleEffect = (opt: string) => {
@@ -169,37 +171,30 @@ export default function ImagePromptGenerator({ onGenerate }: Props) {
           <Typography sx={{ mt: 2, mb: 1 }}>
             📸 Camera Style / Photographic Aesthetic
           </Typography>
-          <FormGroup>
+          <RadioGroup
+            value={camera ?? ""}
+            onChange={(_, value) => toggleCamera(value)}
+          >
             {cameraOptions.map((opt) => (
               <FormControlLabel
                 key={opt}
-                control={
-                  <Checkbox
-                    checked={camera === opt}
-                    onChange={() => toggleCamera(opt)}
-                    disabled={!!camera && camera !== opt}
-                  />
-                }
+                value={opt}
+                control={<Radio />}
                 label={opt}
               />
             ))}
-          </FormGroup>
+          </RadioGroup>
           <Typography sx={{ mt: 2, mb: 1 }}>Lens Options</Typography>
-          <FormGroup>
+          <RadioGroup value={lens ?? ""} onChange={(_, value) => toggleLens(value)}>
             {lensOptions.map((opt) => (
               <FormControlLabel
                 key={opt}
-                control={
-                  <Checkbox
-                    checked={lens === opt}
-                    onChange={() => toggleLens(opt)}
-                    disabled={!!lens && lens !== opt}
-                  />
-                }
+                value={opt}
+                control={<Radio />}
                 label={opt}
               />
             ))}
-          </FormGroup>
+          </RadioGroup>
           <Typography sx={{ mt: 2, mb: 1 }}>Effects</Typography>
           <FormGroup>
             {effectOptions.map((opt) => (


### PR DESCRIPTION
## Summary
- Replace camera and lens checkboxes with MUI RadioGroup/Radio components
- Simplify toggle handlers to set selected camera or lens directly
- Adjust ImagePromptGenerator tests for radio-button selection behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8ee8321148325b40d077a4e2d320e