### PR TITLE
Replace ambience select with checkbox grid

### DIFF
--- a/src/components/VibeControls.tsx
+++ b/src/components/VibeControls.tsx
@@ -14,7 +14,7 @@ interface Props {
   leadInstrument: string;
   setLeadInstrument: (val: string) => void;
   ambience: string[];
-  setAmbience: (vals: string[]) => void;
+  setAmbience: (updater: (prev: string[]) => string[]) => void;
   ambienceLevel: number;
   setAmbienceLevel: (val: number) => void;
 }
@@ -102,25 +102,22 @@ export default function VibeControls({
       </div>
 
       <div className={styles.panel}>
-        <label className={styles.label} htmlFor="ambience-select">
+        <label className={styles.label}>
           Ambience
           <HelpIcon text="Background ambience sounds" />
         </label>
-        <select
-          id="ambience-select"
-          multiple
-          value={ambience}
-          onChange={(e) =>
-            setAmbience(Array.from(e.target.selectedOptions).map((o) => o.value))
-          }
-          className={styles.input}
-        >
+        <div className={styles.optionGrid}>
           {AMBI.map((a) => (
-            <option key={a} value={a}>
-              {a}
-            </option>
+            <label key={a} className={styles.optionCard}>
+              <span>{a}</span>
+              <input
+                type="checkbox"
+                checked={ambience.includes(a)}
+                onChange={() => setAmbience((prev) => toggle(prev, a))}
+              />
+            </label>
           ))}
-        </select>
+        </div>
         <input
           type="range"
           min={0}

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -1498,7 +1498,6 @@ exports[`SongForm > renders default form 1`] = `
             >
               <label
                 class="_label_62bdff"
-                for="ambience-select"
               >
                 Ambience
                 <svg
@@ -1519,62 +1518,111 @@ exports[`SongForm > renders default form 1`] = `
                   />
                 </svg>
               </label>
-              <select
-                class="_input_62bdff"
-                id="ambience-select"
-                multiple=""
+              <div
+                class="_optionGrid_62bdff"
               >
-                <option
-                  value="rain"
+                <label
+                  class="_optionCard_62bdff"
                 >
-                  rain
-                </option>
-                <option
-                  value="cafe"
+                  <span>
+                    rain
+                  </span>
+                  <input
+                    checked=""
+                    type="checkbox"
+                  />
+                </label>
+                <label
+                  class="_optionCard_62bdff"
                 >
-                  cafe
-                </option>
-                <option
-                  value="street"
+                  <span>
+                    cafe
+                  </span>
+                  <input
+                    type="checkbox"
+                  />
+                </label>
+                <label
+                  class="_optionCard_62bdff"
                 >
-                  street
-                </option>
-                <option
-                  value="birds"
+                  <span>
+                    street
+                  </span>
+                  <input
+                    type="checkbox"
+                  />
+                </label>
+                <label
+                  class="_optionCard_62bdff"
                 >
-                  birds
-                </option>
-                <option
-                  value="cicadas"
+                  <span>
+                    birds
+                  </span>
+                  <input
+                    type="checkbox"
+                  />
+                </label>
+                <label
+                  class="_optionCard_62bdff"
                 >
-                  cicadas
-                </option>
-                <option
-                  value="train"
+                  <span>
+                    cicadas
+                  </span>
+                  <input
+                    type="checkbox"
+                  />
+                </label>
+                <label
+                  class="_optionCard_62bdff"
                 >
-                  train
-                </option>
-                <option
-                  value="vinyl"
+                  <span>
+                    train
+                  </span>
+                  <input
+                    type="checkbox"
+                  />
+                </label>
+                <label
+                  class="_optionCard_62bdff"
                 >
-                  vinyl
-                </option>
-                <option
-                  value="forest"
+                  <span>
+                    vinyl
+                  </span>
+                  <input
+                    type="checkbox"
+                  />
+                </label>
+                <label
+                  class="_optionCard_62bdff"
                 >
-                  forest
-                </option>
-                <option
-                  value="fireplace"
+                  <span>
+                    forest
+                  </span>
+                  <input
+                    type="checkbox"
+                  />
+                </label>
+                <label
+                  class="_optionCard_62bdff"
                 >
-                  fireplace
-                </option>
-                <option
-                  value="ocean"
+                  <span>
+                    fireplace
+                  </span>
+                  <input
+                    type="checkbox"
+                  />
+                </label>
+                <label
+                  class="_optionCard_62bdff"
                 >
-                  ocean
-                </option>
-              </select>
+                  <span>
+                    ocean
+                  </span>
+                  <input
+                    type="checkbox"
+                  />
+                </label>
+              </div>
               <input
                 class="_slider_62bdff"
                 max="1"


### PR DESCRIPTION
## Summary
- Replace Ambience `<select>` with checkbox option grid in `VibeControls`
- Toggle ambience selections using checkbox state
- Update SongForm snapshot for new ambience controls

## Testing
- `npx vitest run -u`


------
https://chatgpt.com/codex/tasks/task_e_68a8ee39bc908325b5634e42dd315175