### PR TITLE
Rename duplicate tilt-shift option

### DIFF
--- a/src/components/ImagePromptGenerator.tsx
+++ b/src/components/ImagePromptGenerator.tsx
@@ -72,7 +72,7 @@ const lofiOptions = [
   "sunset golden hour",
   "bokeh background",
   "ambient haze",
-  "tilt-shift lens effect",
+  "Tilt-shift miniature effect",
   "whimsical color grading",
   "cozy cottagecore",
   "16:9 ratio, soft vignette",


### PR DESCRIPTION
## Summary
- Distinguish lofi tilt-shift entry as "Tilt-shift miniature effect" to avoid duplication with lens options

## Testing
- `npm test src/components/ImagePromptGenerator.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a8f0faaf748325a42227e44315977f