### PR TITLE
Keep ImagePromptGenerator state until reset

### DIFF
--- a/src/components/ImagePromptGenerator.test.tsx
+++ b/src/components/ImagePromptGenerator.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import ImagePromptGenerator from './ImagePromptGenerator';
 
 describe('ImagePromptGenerator', () => {
-  it('selects camera and lens using radio buttons and generates prompt', () => {
+  it('persists selections after generating and clears on reset', () => {
     const onGenerate = vi.fn();
     render(<ImagePromptGenerator onGenerate={onGenerate} />);
     fireEvent.click(screen.getByRole('button', { name: /image prompt/i }));
@@ -11,24 +11,11 @@ describe('ImagePromptGenerator', () => {
     const textInput = screen.getByPlaceholderText(/describe the image/i);
     fireEvent.change(textInput, { target: { value: 'sunset' } });
 
-    const kodak = screen.getByLabelText(/Kodak Portra 400/i);
-    fireEvent.click(kodak);
-    expect(kodak).toBeChecked();
-
     const polaroid = screen.getByLabelText(/Shot on Polaroid/i);
-    expect(polaroid).not.toBeDisabled();
     fireEvent.click(polaroid);
-    expect(polaroid).toBeChecked();
-    expect(kodak).not.toBeChecked();
-
-    const wide = screen.getByLabelText(/Wide-angle lens, 24mm/i);
-    fireEvent.click(wide);
-    expect(wide).toBeChecked();
 
     const macro = screen.getByLabelText(/Macro lens photography/i);
     fireEvent.click(macro);
-    expect(macro).toBeChecked();
-    expect(wide).not.toBeChecked();
 
     const ghibli = screen.getByLabelText(/Studio Ghibli/i);
     fireEvent.click(ghibli);
@@ -40,5 +27,18 @@ describe('ImagePromptGenerator', () => {
     expect(onGenerate).toHaveBeenCalledWith(
       'sunset Shot on Polaroid (vintage, instant photo look) Macro lens photography cinematography by Roger Deakins Studio Ghibli–inspired framing'
     );
+
+    // State should persist after generating
+    expect(textInput).toHaveValue('sunset');
+    expect(polaroid).toBeChecked();
+    expect(macro).toBeChecked();
+    expect(ghibli).toBeChecked();
+
+    // Reset clears all selections
+    fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+    expect(textInput).toHaveValue('');
+    expect(polaroid).not.toBeChecked();
+    expect(macro).not.toBeChecked();
+    expect(ghibli).not.toBeChecked();
   });
 });

--- a/src/components/ImagePromptGenerator.tsx
+++ b/src/components/ImagePromptGenerator.tsx
@@ -144,7 +144,9 @@ export default function ImagePromptGenerator({ onGenerate }: Props) {
     if (lofi.length) prompt += ` ${lofi.join(" ")}`;
     if (cosmic.length) prompt += ` ${cosmic.join(" ")}`;
     onGenerate(prompt.trim());
-    setOpen(false);
+  };
+
+  const handleClear = () => {
     setText("");
     setCamera(null);
     setLens(null);
@@ -268,6 +270,9 @@ export default function ImagePromptGenerator({ onGenerate }: Props) {
           <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
             <Button onClick={handleSend} disabled={!text.trim()}>
               Generate
+            </Button>
+            <Button variant="outlined" onClick={handleClear}>
+              Reset
             </Button>
           </Stack>
         </Box>


### PR DESCRIPTION
## Summary
- Keep ImagePromptGenerator form open and stateful after generating prompts
- Add a reset button to clear all selections on demand
- Update tests for persistent state and reset behavior

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a9027c49f88325aba25ed6b3b77315