### PR TITLE
feat: show prompt preview in image generator

### DIFF
--- a/src/components/ImagePromptGenerator.test.tsx
+++ b/src/components/ImagePromptGenerator.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import ImagePromptGenerator from './ImagePromptGenerator';
 
 describe('ImagePromptGenerator', () => {
+  afterEach(cleanup);
   it('persists selections after generating and clears on reset', () => {
     const onGenerate = vi.fn();
     render(<ImagePromptGenerator onGenerate={onGenerate} />);
@@ -40,5 +41,25 @@ describe('ImagePromptGenerator', () => {
     expect(polaroid).not.toBeChecked();
     expect(macro).not.toBeChecked();
     expect(ghibli).not.toBeChecked();
+  });
+
+  it('updates preview as selections change', () => {
+    render(<ImagePromptGenerator onGenerate={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /image prompt/i }));
+
+    const textInput = screen.getByPlaceholderText(/describe the image/i);
+    fireEvent.change(textInput, { target: { value: 'mountain' } });
+    const preview = screen.getByLabelText(/preview/i);
+    expect(preview).toHaveValue('mountain');
+
+    fireEvent.click(screen.getByLabelText(/Shot on Polaroid/i));
+    expect(preview).toHaveValue(
+      'mountain Shot on Polaroid (vintage, instant photo look)'
+    );
+
+    fireEvent.click(screen.getByLabelText(/Macro lens photography/i));
+    expect(preview).toHaveValue(
+      'mountain Shot on Polaroid (vintage, instant photo look) Macro lens photography'
+    );
   });
 });

--- a/src/components/ImagePromptGenerator.tsx
+++ b/src/components/ImagePromptGenerator.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   Box,
   Button,
@@ -103,6 +103,17 @@ export default function ImagePromptGenerator({ onGenerate }: Props) {
   const [lofi, setLofi] = useState<string[]>([]);
   const [cosmic, setCosmic] = useState<string[]>([]);
 
+  const preview = useMemo(() => {
+    let prompt = text;
+    if (camera) prompt += ` ${camera}`;
+    if (lens) prompt += ` ${lens}`;
+    if (effects.length) prompt += ` ${effects.join(" ")}`;
+    if (cinematic.length) prompt += ` ${cinematic.join(" ")}`;
+    if (lofi.length) prompt += ` ${lofi.join(" ")}`;
+    if (cosmic.length) prompt += ` ${cosmic.join(" ")}`;
+    return prompt.trim();
+  }, [text, camera, lens, effects, cinematic, lofi, cosmic]);
+
   const toggleCamera = (opt: string) => {
     setCamera(opt);
   };
@@ -136,14 +147,7 @@ export default function ImagePromptGenerator({ onGenerate }: Props) {
   };
 
   const handleSend = () => {
-    let prompt = text;
-    if (camera) prompt += ` ${camera}`;
-    if (lens) prompt += ` ${lens}`;
-    if (effects.length) prompt += ` ${effects.join(" ")}`;
-    if (cinematic.length) prompt += ` ${cinematic.join(" ")}`;
-    if (lofi.length) prompt += ` ${lofi.join(" ")}`;
-    if (cosmic.length) prompt += ` ${cosmic.join(" ")}`;
-    onGenerate(prompt.trim());
+    onGenerate(preview);
   };
 
   const handleClear = () => {
@@ -254,19 +258,27 @@ export default function ImagePromptGenerator({ onGenerate }: Props) {
             Use for psychedelic, surreal, or space-themed visuals.
           </Typography>
           <FormGroup>
-            {cosmicOptions.map((opt) => (
-              <FormControlLabel
-                key={opt}
-                control={
-                  <Checkbox
-                    checked={cosmic.includes(opt)}
-                    onChange={() => toggleCosmic(opt)}
-                  />
-                }
-                label={opt}
-              />
-            ))}
-          </FormGroup>
+          {cosmicOptions.map((opt) => (
+            <FormControlLabel
+              key={opt}
+              control={
+                <Checkbox
+                  checked={cosmic.includes(opt)}
+                  onChange={() => toggleCosmic(opt)}
+                />
+              }
+              label={opt}
+            />
+          ))}
+        </FormGroup>
+          <TextField
+            label="Preview"
+            value={preview}
+            fullWidth
+            multiline
+            InputProps={{ readOnly: true }}
+            sx={{ mt: 2 }}
+          />
           <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
             <Button onClick={handleSend} disabled={!text.trim()}>
               Generate


### PR DESCRIPTION
## Summary
- derive a memoized prompt preview combining description and modifiers
- display read-only preview below options for review
- test preview updates as inputs change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a906f10de88325a36926d6b2325beb