### PR TITLE
Add character sheets and player storage

### DIFF
--- a/dnd/schemas/npc.schema.json
+++ b/dnd/schemas/npc.schema.json
@@ -91,6 +91,26 @@
             "type": "string"
           },
           "minItems": 1
+        },
+        "abilities": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        },
+        "level": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "hp": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "inventory": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [

--- a/src/components/CharacterSheet.tsx
+++ b/src/components/CharacterSheet.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { Stack, TextField, Button, Typography } from '@mui/material';
+import { useCharacter } from '../store/character';
+import type { Character } from '../dnd/characters';
+
+export default function CharacterSheet() {
+  const stored = useCharacter((s) => s.character);
+  const setCharacter = useCharacter((s) => s.setCharacter);
+  const [character, setCharacterState] = useState<Character>(
+    stored ?? {
+      abilities: { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 },
+      class: '',
+      level: 1,
+      hp: 0,
+      inventory: [],
+    }
+  );
+
+  const updateAbility = (key: string, value: number) =>
+    setCharacterState((prev) => ({
+      ...prev,
+      abilities: { ...prev.abilities, [key]: value },
+    }));
+
+  const updateInventory = (value: string) =>
+    setCharacterState((prev) => ({
+      ...prev,
+      inventory: value
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    }));
+
+  const save = () => setCharacter(character);
+
+  return (
+    <Stack spacing={2} sx={{ maxWidth: 400 }}>
+      <Typography variant="h5">Character Sheet</Typography>
+      <TextField
+        label="Class"
+        value={character.class}
+        onChange={(e) =>
+          setCharacterState({ ...character, class: e.target.value })
+        }
+      />
+      <TextField
+        label="Level"
+        type="number"
+        value={character.level}
+        onChange={(e) =>
+          setCharacterState({
+            ...character,
+            level: parseInt(e.target.value, 10) || 0,
+          })
+        }
+      />
+      <TextField
+        label="HP"
+        type="number"
+        value={character.hp}
+        onChange={(e) =>
+          setCharacterState({
+            ...character,
+            hp: parseInt(e.target.value, 10) || 0,
+          })
+        }
+      />
+      <Typography variant="h6">Abilities</Typography>
+      <Stack direction="row" spacing={1}>
+        {['str', 'dex', 'con', 'int', 'wis', 'cha'].map((key) => (
+          <TextField
+            key={key}
+            label={key.toUpperCase()}
+            type="number"
+            value={character.abilities[key] || 0}
+            onChange={(e) =>
+              updateAbility(key, parseInt(e.target.value, 10) || 0)
+            }
+            sx={{ width: 60 }}
+          />
+        ))}
+      </Stack>
+      <TextField
+        label="Inventory"
+        value={character.inventory.join(', ')}
+        onChange={(e) => updateInventory(e.target.value)}
+      />
+      <Button variant="contained" onClick={save}>
+        Save
+      </Button>
+    </Stack>
+  );
+}
+

--- a/src/dnd/characters/index.ts
+++ b/src/dnd/characters/index.ts
@@ -1,0 +1,8 @@
+export interface Character {
+  abilities: Record<string, number>;
+  class: string;
+  level: number;
+  hp: number;
+  inventory: string[];
+}
+

--- a/src/dnd/schemas/npc.ts
+++ b/src/dnd/schemas/npc.ts
@@ -23,6 +23,10 @@ export const zNpc = z.object({
   sections: z.record(z.unknown()).optional(),
   statblock: z.record(z.unknown()),
   tags: z.array(z.string()).nonempty(),
+  abilities: z.record(z.number()).optional(),
+  level: z.number().int().min(1).optional(),
+  hp: z.number().int().min(0).optional(),
+  inventory: z.array(z.string()).optional(),
 });
 
 export type Npc = z.infer<typeof zNpc>;

--- a/src/store/character.ts
+++ b/src/store/character.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { Character } from '../dnd/characters';
+import { useNPCs } from './npcs';
+
+interface CharacterState {
+  character: Character | null;
+  setCharacter: (char: Character) => void;
+  clearCharacter: () => void;
+}
+
+export const useCharacter = create<CharacterState>()(
+  persist(
+    (set) => ({
+      character: null,
+      setCharacter: (char) => {
+        set({ character: char });
+        const addNPC = useNPCs.getState().addNPC;
+        addNPC({
+          name: 'Player Character',
+          race: 'Unknown',
+          class: char.class,
+          personality: '',
+          background: '',
+          appearance: '',
+          portrait: 'placeholder.png',
+          icon: 'placeholder-icon.png',
+          playerCharacter: true,
+          hooks: [],
+          stats: char.abilities,
+          sections: {},
+          tags: ['player'],
+          abilities: char.abilities,
+          level: char.level,
+          hp: char.hp,
+          inventory: char.inventory,
+        });
+      },
+      clearCharacter: () => set({ character: null }),
+    }),
+    { name: 'character-store' }
+  )
+);
+

--- a/src/store/npcs.ts
+++ b/src/store/npcs.ts
@@ -7,6 +7,10 @@ export interface NPC {
   name: string;
   race: string;
   class: string;
+  abilities?: Record<string, number>;
+  level?: number;
+  hp?: number;
+  inventory?: string[];
   role?: string;
   cr?: number;
   locale?: string;


### PR DESCRIPTION
## Summary
- add `Character` interface and zustand slice for persistence
- include `CharacterSheet` for editing ability scores, HP, level, inventory and class
- extend NPC schema/store to track player character data and flag them as player characters

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68a90f2ec02c8325976e2eb9e9b0a1e1