### PR TITLE
Add DnD combat rules and engine

### DIFF
--- a/src/dnd/rules/CombatEngine.ts
+++ b/src/dnd/rules/CombatEngine.ts
@@ -1,0 +1,29 @@
+import { Character } from "../characters";
+import { attackRoll, calculateDamage } from "./core";
+
+export interface Weapon {
+  diceCount: number;
+  diceSides: number;
+  ability: string;
+  modifier?: number;
+}
+
+export class CombatEngine {
+  static resolveAttack(
+    attacker: Character,
+    defenderAC: number,
+    weapon: Weapon
+  ) {
+    const attack = attackRoll(attacker, weapon.ability, defenderAC);
+    if (attack.hit) {
+      const abilityMod = attacker.abilities[weapon.ability] ?? 0;
+      const damage = calculateDamage(
+        weapon.diceCount,
+        weapon.diceSides,
+        abilityMod + (weapon.modifier ?? 0)
+      );
+      return { ...attack, damage: damage.total };
+    }
+    return { ...attack, damage: 0 };
+  }
+}

--- a/src/dnd/rules/core.ts
+++ b/src/dnd/rules/core.ts
@@ -1,0 +1,45 @@
+import { Character } from "../characters";
+import { rollDice } from "./dice";
+
+export function abilityCheck(
+  character: Character,
+  ability: string,
+  dc: number
+) {
+  const roll = rollDice(20);
+  const modifier = character.abilities[ability] ?? 0;
+  const total = roll + modifier;
+  return { roll, total, success: total >= dc };
+}
+
+export function attackRoll(
+  attacker: Character,
+  ability: string,
+  targetAC: number
+) {
+  const roll = rollDice(20);
+  const modifier = attacker.abilities[ability] ?? 0;
+  const total = roll + modifier;
+  return { roll, total, hit: total >= targetAC };
+}
+
+export function calculateDamage(
+  diceCount: number,
+  diceSides: number,
+  modifier = 0
+) {
+  const rolls = Array.from({ length: diceCount }, () => rollDice(diceSides));
+  const total = rolls.reduce((a, b) => a + b, 0) + modifier;
+  return { rolls, total };
+}
+
+export function savingThrow(
+  character: Character,
+  ability: string,
+  dc: number
+) {
+  const roll = rollDice(20);
+  const modifier = character.abilities[ability] ?? 0;
+  const total = roll + modifier;
+  return { roll, total, success: total >= dc };
+}

--- a/src/dnd/rules/dice.ts
+++ b/src/dnd/rules/dice.ts
@@ -1,0 +1,3 @@
+export function rollDice(sides: number): number {
+  return Math.floor(Math.random() * sides) + 1;
+}

--- a/src/dnd/rules/index.ts
+++ b/src/dnd/rules/index.ts
@@ -1,0 +1,3 @@
+export { rollDice } from "./dice";
+export { abilityCheck, attackRoll, calculateDamage, savingThrow } from "./core";
+export { CombatEngine, type Weapon } from "./CombatEngine";

--- a/src/dnd/rules/rules.test.ts
+++ b/src/dnd/rules/rules.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  abilityCheck,
+  attackRoll,
+  calculateDamage,
+  savingThrow,
+  CombatEngine,
+} from "./index";
+import type { Character } from "../characters";
+import * as dice from "./dice";
+
+describe("dnd rules", () => {
+  const baseChar: Character = {
+    abilities: { strength: 3, dexterity: 2 },
+    class: "fighter",
+    level: 1,
+    hp: 10,
+    inventory: [],
+  };
+
+  it("passes ability checks when total meets DC", () => {
+    const spy = vi.spyOn(dice, "rollDice").mockReturnValue(15);
+    const result = abilityCheck(baseChar, "strength", 10);
+    expect(result).toEqual({ roll: 15, total: 18, success: true });
+    spy.mockRestore();
+  });
+
+  it("fails ability checks when total below DC", () => {
+    const spy = vi.spyOn(dice, "rollDice").mockReturnValue(2);
+    const result = abilityCheck(baseChar, "strength", 10);
+    expect(result).toEqual({ roll: 2, total: 5, success: false });
+    spy.mockRestore();
+  });
+
+  it("determines attack hits", () => {
+    const spy = vi.spyOn(dice, "rollDice").mockReturnValue(12);
+    const result = attackRoll(baseChar, "strength", 15);
+    expect(result).toEqual({ roll: 12, total: 15, hit: true });
+    spy.mockRestore();
+  });
+
+  it("calculates damage with modifiers", () => {
+    const spy = vi.spyOn(dice, "rollDice");
+    spy.mockReturnValueOnce(4).mockReturnValueOnce(5);
+    const result = calculateDamage(2, 6, 2);
+    expect(result).toEqual({ rolls: [4, 5], total: 11 });
+    spy.mockRestore();
+  });
+
+  it("resolves saving throws", () => {
+    const spy = vi.spyOn(dice, "rollDice").mockReturnValue(8);
+    const result = savingThrow(baseChar, "dexterity", 12);
+    expect(result).toEqual({ roll: 8, total: 10, success: false });
+    spy.mockRestore();
+  });
+
+  it("resolves combat attacks and damage", () => {
+    const spy = vi.spyOn(dice, "rollDice");
+    spy.mockReturnValueOnce(14).mockReturnValueOnce(6);
+    const result = CombatEngine.resolveAttack(baseChar, 15, {
+      diceCount: 1,
+      diceSides: 8,
+      ability: "strength",
+    });
+    expect(result).toEqual({ roll: 14, total: 17, hit: true, damage: 9 });
+    spy.mockRestore();
+  });
+
+  it("returns zero damage on missed attacks", () => {
+    const spy = vi.spyOn(dice, "rollDice").mockReturnValue(1);
+    const result = CombatEngine.resolveAttack(baseChar, 20, {
+      diceCount: 1,
+      diceSides: 8,
+      ability: "strength",
+    });
+    expect(result).toEqual({ roll: 1, total: 4, hit: false, damage: 0 });
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- implement rule book with ability checks, attack rolls, damage, and saving throws
- add CombatEngine for resolving attacks using character stats
- cover common scenarios with deterministic unit tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68a920eeb0948325bd86d939fcc97c2c