### PR TITLE
Add base prompt and modifier combo for image prompts

### DIFF
--- a/src/components/ImagePromptGenerator.test.tsx
+++ b/src/components/ImagePromptGenerator.test.tsx
@@ -9,8 +9,8 @@ describe('ImagePromptGenerator', () => {
     render(<ImagePromptGenerator onGenerate={onGenerate} />);
     fireEvent.click(screen.getByRole('button', { name: /image prompt/i }));
 
-    const textInput = screen.getByPlaceholderText(/describe the image/i);
-    fireEvent.change(textInput, { target: { value: 'sunset' } });
+    const baseInput = screen.getByPlaceholderText(/base prompt/i);
+    fireEvent.change(baseInput, { target: { value: 'sunset' } });
 
     const polaroid = screen.getByLabelText(/Shot on Polaroid/i);
     fireEvent.click(polaroid);
@@ -30,14 +30,14 @@ describe('ImagePromptGenerator', () => {
     );
 
     // State should persist after generating
-    expect(textInput).toHaveValue('sunset');
+    expect(baseInput).toHaveValue('sunset');
     expect(polaroid).toBeChecked();
     expect(macro).toBeChecked();
     expect(ghibli).toBeChecked();
 
     // Reset clears all selections
     fireEvent.click(screen.getByRole('button', { name: /reset/i }));
-    expect(textInput).toHaveValue('');
+    expect(baseInput).toHaveValue('');
     expect(polaroid).not.toBeChecked();
     expect(macro).not.toBeChecked();
     expect(ghibli).not.toBeChecked();
@@ -47,8 +47,8 @@ describe('ImagePromptGenerator', () => {
     render(<ImagePromptGenerator onGenerate={vi.fn()} />);
     fireEvent.click(screen.getByRole('button', { name: /image prompt/i }));
 
-    const textInput = screen.getByPlaceholderText(/describe the image/i);
-    fireEvent.change(textInput, { target: { value: 'mountain' } });
+    const baseInput = screen.getByPlaceholderText(/base prompt/i);
+    fireEvent.change(baseInput, { target: { value: 'mountain' } });
     const preview = screen.getByLabelText(/preview/i);
     expect(preview).toHaveValue('mountain');
 
@@ -60,6 +60,24 @@ describe('ImagePromptGenerator', () => {
     fireEvent.click(screen.getByLabelText(/Macro lens photography/i));
     expect(preview).toHaveValue(
       'mountain Shot on Polaroid (vintage, instant photo look) Macro lens photography'
+    );
+  });
+
+  it('combines base prompt with modifiers on generate', () => {
+    const onGenerate = vi.fn();
+    render(<ImagePromptGenerator onGenerate={onGenerate} />);
+    fireEvent.click(screen.getByRole('button', { name: /image prompt/i }));
+
+    const baseInput = screen.getByPlaceholderText(/base prompt/i);
+    fireEvent.change(baseInput, { target: { value: 'forest' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /generate/i }));
+    expect(onGenerate).toHaveBeenCalledWith('forest');
+
+    fireEvent.click(screen.getByLabelText(/Shot on Polaroid/i));
+    fireEvent.click(screen.getByRole('button', { name: /generate/i }));
+    expect(onGenerate).toHaveBeenLastCalledWith(
+      'forest Shot on Polaroid (vintage, instant photo look)'
     );
   });
 });

--- a/src/components/ImagePromptGenerator.tsx
+++ b/src/components/ImagePromptGenerator.tsx
@@ -95,7 +95,7 @@ const cosmicOptions = [
 
 export default function ImagePromptGenerator({ onGenerate }: Props) {
   const [open, setOpen] = useState(false);
-  const [text, setText] = useState("");
+  const [basePrompt, setBasePrompt] = useState("");
   const [camera, setCamera] = useState<string | null>(null);
   const [lens, setLens] = useState<string | null>(null);
   const [effects, setEffects] = useState<string[]>([]);
@@ -104,7 +104,7 @@ export default function ImagePromptGenerator({ onGenerate }: Props) {
   const [cosmic, setCosmic] = useState<string[]>([]);
 
   const preview = useMemo(() => {
-    let prompt = text;
+    let prompt = basePrompt;
     if (camera) prompt += ` ${camera}`;
     if (lens) prompt += ` ${lens}`;
     if (effects.length) prompt += ` ${effects.join(" ")}`;
@@ -112,7 +112,7 @@ export default function ImagePromptGenerator({ onGenerate }: Props) {
     if (lofi.length) prompt += ` ${lofi.join(" ")}`;
     if (cosmic.length) prompt += ` ${cosmic.join(" ")}`;
     return prompt.trim();
-  }, [text, camera, lens, effects, cinematic, lofi, cosmic]);
+  }, [basePrompt, camera, lens, effects, cinematic, lofi, cosmic]);
 
   const toggleCamera = (opt: string) => {
     setCamera(opt);
@@ -147,11 +147,18 @@ export default function ImagePromptGenerator({ onGenerate }: Props) {
   };
 
   const handleSend = () => {
-    onGenerate(preview);
+    let prompt = basePrompt;
+    if (camera) prompt += ` ${camera}`;
+    if (lens) prompt += ` ${lens}`;
+    if (effects.length) prompt += ` ${effects.join(" ")}`;
+    if (cinematic.length) prompt += ` ${cinematic.join(" ")}`;
+    if (lofi.length) prompt += ` ${lofi.join(" ")}`;
+    if (cosmic.length) prompt += ` ${cosmic.join(" ")}`;
+    onGenerate(prompt.trim());
   };
 
   const handleClear = () => {
-    setText("");
+    setBasePrompt("");
     setCamera(null);
     setLens(null);
     setEffects([]);
@@ -170,9 +177,9 @@ export default function ImagePromptGenerator({ onGenerate }: Props) {
           <TextField
             fullWidth
             multiline
-            placeholder="Describe the image"
-            value={text}
-            onChange={(e) => setText(e.target.value)}
+            placeholder="Base prompt"
+            value={basePrompt}
+            onChange={(e) => setBasePrompt(e.target.value)}
           />
           <Typography sx={{ mt: 2, mb: 1 }}>
             📸 Camera Style / Photographic Aesthetic
@@ -280,7 +287,7 @@ export default function ImagePromptGenerator({ onGenerate }: Props) {
             sx={{ mt: 2 }}
           />
           <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
-            <Button onClick={handleSend} disabled={!text.trim()}>
+            <Button onClick={handleSend} disabled={!basePrompt.trim()}>
               Generate
             </Button>
             <Button variant="outlined" onClick={handleClear}>


### PR DESCRIPTION
## Summary
- add base prompt field to image prompt generator
- combine base prompt with camera and style modifiers when generating
- test base prompt behavior and modifier effects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a92151fd048325adbfec3dad663c4d