### PR TITLE
feat: add encounter tracker

### DIFF
--- a/src/components/EncounterTracker/index.tsx
+++ b/src/components/EncounterTracker/index.tsx
@@ -1,0 +1,44 @@
+import { Button, Stack, Typography } from '@mui/material';
+import { useEncounterStore } from '../../store/encounter';
+
+export default function EncounterTracker() {
+  const encounter = useEncounterStore((s) => s.encounter);
+  const startEncounter = useEncounterStore((s) => s.startEncounter);
+  const nextTurn = useEncounterStore((s) => s.nextTurn);
+  const endEncounter = useEncounterStore((s) => s.endEncounter);
+
+  const start = () =>
+    startEncounter([
+      { name: 'Hero', initiative: 15 },
+      { name: 'Goblin', initiative: 12 },
+    ]);
+
+  const current = encounter?.participants[encounter.current]?.name;
+
+  return (
+    <Stack spacing={2} sx={{ maxWidth: 300 }}>
+      <Typography variant="h6">Encounter Tracker</Typography>
+      {encounter && <Typography>Current: {current}</Typography>}
+      <Stack direction="row" spacing={1}>
+        <Button variant="contained" onClick={start} disabled={!!encounter}>
+          Start Encounter
+        </Button>
+        <Button
+          variant="outlined"
+          onClick={nextTurn}
+          disabled={!encounter}
+        >
+          Next Turn
+        </Button>
+        <Button
+          variant="outlined"
+          color="error"
+          onClick={endEncounter}
+          disabled={!encounter}
+        >
+          End Combat
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/src/dnd/encounters/Encounter.ts
+++ b/src/dnd/encounters/Encounter.ts
@@ -1,0 +1,24 @@
+export interface Participant {
+  name: string;
+  initiative: number;
+}
+
+export class Encounter {
+  participants: Participant[];
+  current: number;
+
+  constructor(participants: Participant[] = [], current = 0, sorted = false) {
+    this.participants = sorted
+      ? [...participants]
+      : [...participants].sort((a, b) => b.initiative - a.initiative);
+    this.current = current;
+  }
+
+  advance(): Encounter {
+    if (this.participants.length === 0) {
+      return new Encounter([]);
+    }
+    const next = (this.current + 1) % this.participants.length;
+    return new Encounter(this.participants, next, true);
+  }
+}

--- a/src/dnd/encounters/index.ts
+++ b/src/dnd/encounters/index.ts
@@ -1,0 +1,1 @@
+export { Encounter, type Participant } from './Encounter';

--- a/src/store/encounter.ts
+++ b/src/store/encounter.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { Encounter, Participant } from '../dnd/encounters';
+
+interface EncounterState {
+  encounter: Encounter | null;
+  startEncounter: (participants: Participant[]) => void;
+  nextTurn: () => void;
+  endEncounter: () => void;
+}
+
+export const useEncounterStore = create<EncounterState>()(
+  persist(
+    (set) => ({
+      encounter: null,
+      startEncounter: (participants) =>
+        set({ encounter: new Encounter(participants) }),
+      nextTurn: () =>
+        set((state) =>
+          state.encounter ? { encounter: state.encounter.advance() } : state
+        ),
+      endEncounter: () => set({ encounter: null }),
+    }),
+    { name: 'encounter-store' }
+  )
+);
+
+export type { EncounterState };


### PR DESCRIPTION
## Summary
- add Encounter class for participants and initiative order
- add EncounterTracker component with controls for combat flow
- create Zustand store to manage encounter state and turns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a927dca0c48325bb79fc440e687997