### PR TITLE
feat: add encounter tracker

### DIFF
--- a/src/components/EncounterTracker/index.tsx
+++ b/src/components/EncounterTracker/index.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { useEncounterStore } from '../../store/encounter';
+import type { EncounterParticipant } from '../../dnd/encounters/Encounter';
+
+export default function EncounterTracker() {
+  const { encounter, startEncounter, nextTurn, endEncounter } =
+    useEncounterStore();
+  const [name, setName] = useState('');
+  const [initiative, setInitiative] = useState<number>(0);
+  const [pending, setPending] = useState<EncounterParticipant[]>([]);
+
+  const addParticipant = () => {
+    if (!name) return;
+    setPending([
+      ...pending,
+      { id: crypto.randomUUID(), name, initiative },
+    ]);
+    setName('');
+    setInitiative(0);
+  };
+
+  if (!encounter) {
+    return (
+      <div>
+        <h3>Prepare Encounter</h3>
+        <ul>
+          {pending.map((p) => (
+            <li key={p.id}>
+              {p.name} ({p.initiative})
+            </li>
+          ))}
+        </ul>
+        <input
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          type="number"
+          value={initiative}
+          onChange={(e) => setInitiative(Number(e.target.value))}
+        />
+        <button onClick={addParticipant}>Add</button>
+        <button onClick={() => startEncounter(pending)}>Start Encounter</button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h3>Encounter</h3>
+      <ul>
+        {encounter.participants.map((p, idx) => (
+          <li
+            key={p.id}
+            style={{ fontWeight: idx === encounter.turnIndex ? 'bold' : 'normal' }}
+          >
+            {p.name} ({p.initiative})
+          </li>
+        ))}
+      </ul>
+      <button onClick={nextTurn}>Next Turn</button>
+      <button onClick={endEncounter}>End Encounter</button>
+    </div>
+  );
+}

--- a/src/dnd/encounters/Encounter.ts
+++ b/src/dnd/encounters/Encounter.ts
@@ -1,0 +1,29 @@
+export interface EncounterParticipant {
+  id: string;
+  name: string;
+  initiative: number;
+}
+
+export class Encounter {
+  participants: EncounterParticipant[];
+  turnIndex: number;
+
+  constructor(participants: EncounterParticipant[] = []) {
+    this.participants = [...participants].sort(
+      (a, b) => b.initiative - a.initiative
+    );
+    this.turnIndex = 0;
+  }
+
+  next() {
+    if (this.participants.length === 0) return;
+    this.turnIndex = (this.turnIndex + 1) % this.participants.length;
+  }
+
+  current(): EncounterParticipant | null {
+    if (this.participants.length === 0) return null;
+    return this.participants[this.turnIndex];
+  }
+}
+
+export default Encounter;

--- a/src/store/encounter.ts
+++ b/src/store/encounter.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import Encounter, { EncounterParticipant } from '../dnd/encounters/Encounter';
+
+interface EncounterState {
+  encounter: Encounter | null;
+  startEncounter: (participants: EncounterParticipant[]) => void;
+  nextTurn: () => void;
+  endEncounter: () => void;
+}
+
+export const useEncounterStore = create<EncounterState>()(
+  persist(
+    (set) => ({
+      encounter: null,
+      startEncounter: (participants) =>
+        set({ encounter: new Encounter(participants) }),
+      nextTurn: () =>
+        set((state) => {
+          state.encounter?.next();
+          return { encounter: state.encounter };
+        }),
+      endEncounter: () => set({ encounter: null }),
+    }),
+    { name: 'encounter-store' }
+  )
+);


### PR DESCRIPTION
## Summary
- add Encounter class and zustand store
- build EncounterTracker component with basic controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a92425ccf8832589b57cd6f57a79f6