### PR TITLE
Add D&D item and spell schemas with inventory UI

### DIFF
--- a/src/components/CharacterSheet.tsx
+++ b/src/components/CharacterSheet.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { Stack, TextField, Button, Typography } from '@mui/material';
 import { useCharacter } from '../store/character';
 import type { Character } from '../dnd/characters';
+import InventoryPanel from './InventoryPanel';
+import SpellBook from './SpellBook';
 
 export default function CharacterSheet() {
   const stored = useCharacter((s) => s.character);
@@ -13,6 +15,8 @@ export default function CharacterSheet() {
       level: 1,
       hp: 0,
       inventory: [],
+      spells: [],
+      spellSlots: {},
     }
   );
 
@@ -20,15 +24,6 @@ export default function CharacterSheet() {
     setCharacterState((prev) => ({
       ...prev,
       abilities: { ...prev.abilities, [key]: value },
-    }));
-
-  const updateInventory = (value: string) =>
-    setCharacterState((prev) => ({
-      ...prev,
-      inventory: value
-        .split(',')
-        .map((s) => s.trim())
-        .filter(Boolean),
     }));
 
   const save = () => setCharacter(character);
@@ -80,10 +75,21 @@ export default function CharacterSheet() {
           />
         ))}
       </Stack>
-      <TextField
-        label="Inventory"
-        value={character.inventory.join(', ')}
-        onChange={(e) => updateInventory(e.target.value)}
+      <InventoryPanel
+        items={character.inventory}
+        onChange={(items) =>
+          setCharacterState((prev) => ({ ...prev, inventory: items }))
+        }
+      />
+      <SpellBook
+        spells={character.spells}
+        spellSlots={character.spellSlots}
+        onSpellsChange={(spells) =>
+          setCharacterState((prev) => ({ ...prev, spells }))
+        }
+        onSlotsChange={(slots) =>
+          setCharacterState((prev) => ({ ...prev, spellSlots: slots }))
+        }
       />
       <Button variant="contained" onClick={save}>
         Save

--- a/src/components/InventoryPanel.tsx
+++ b/src/components/InventoryPanel.tsx
@@ -1,0 +1,36 @@
+import { useState, useEffect } from 'react';
+import { TextField, Stack } from '@mui/material';
+import type { Item } from '../dnd/items';
+
+interface Props {
+  items: Item[];
+  onChange: (items: Item[]) => void;
+}
+
+export default function InventoryPanel({ items, onChange }: Props) {
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    setText(items.map((i) => i.name).join(', '));
+  }, [items]);
+
+  const handleChange = (value: string) => {
+    setText(value);
+    const list: Item[] = value
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((name) => ({ id: name.toLowerCase().replace(/\s+/g, '-'), name, quantity: 1 }));
+    onChange(list);
+  };
+
+  return (
+    <Stack>
+      <TextField
+        label="Inventory"
+        value={text}
+        onChange={(e) => handleChange(e.target.value)}
+      />
+    </Stack>
+  );
+}

--- a/src/components/SpellBook.tsx
+++ b/src/components/SpellBook.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { Stack, TextField, Typography } from '@mui/material';
+import type { Spell } from '../dnd/spells';
+
+interface Props {
+  spells: Spell[];
+  spellSlots: Record<number, number>;
+  onSpellsChange: (spells: Spell[]) => void;
+  onSlotsChange: (slots: Record<number, number>) => void;
+}
+
+export default function SpellBook({
+  spells,
+  spellSlots,
+  onSpellsChange,
+  onSlotsChange,
+}: Props) {
+  const [spellText, setSpellText] = useState('');
+  const [slotText, setSlotText] = useState('');
+
+  useEffect(() => {
+    setSpellText(spells.map((s) => s.name).join(', '));
+    setSlotText(
+      Object.entries(spellSlots)
+        .map(([lvl, cnt]) => `${lvl}:${cnt}`)
+        .join(', ')
+    );
+  }, [spells, spellSlots]);
+
+  const handleSpells = (value: string) => {
+    setSpellText(value);
+    const list: Spell[] = value
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((name) => ({
+        id: name.toLowerCase().replace(/\s+/g, '-'),
+        name,
+        level: 0,
+        school: 'unknown',
+      }));
+    onSpellsChange(list);
+  };
+
+  const handleSlots = (value: string) => {
+    setSlotText(value);
+    const entries = value
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((pair) => pair.split(':'))
+      .filter((arr) => arr.length === 2)
+      .map(([lvl, cnt]) => [parseInt(lvl, 10), parseInt(cnt, 10)] as const)
+      .filter(([lvl, cnt]) => !isNaN(lvl) && !isNaN(cnt));
+    const record: Record<number, number> = {};
+    for (const [lvl, cnt] of entries) {
+      record[lvl] = cnt;
+    }
+    onSlotsChange(record);
+  };
+
+  return (
+    <Stack spacing={1}>
+      <Typography variant="h6">Spells</Typography>
+      <TextField
+        label="Spells"
+        value={spellText}
+        onChange={(e) => handleSpells(e.target.value)}
+      />
+      <TextField
+        label="Spell Slots (level:count)"
+        value={slotText}
+        onChange={(e) => handleSlots(e.target.value)}
+      />
+    </Stack>
+  );
+}

--- a/src/dnd/characters/index.ts
+++ b/src/dnd/characters/index.ts
@@ -1,8 +1,12 @@
+import type { Item } from "../items";
+import type { Spell } from "../spells";
+
 export interface Character {
   abilities: Record<string, number>;
   class: string;
   level: number;
   hp: number;
-  inventory: string[];
+  inventory: Item[];
+  spells: Spell[];
+  spellSlots: Record<number, number>;
 }
-

--- a/src/dnd/items/index.ts
+++ b/src/dnd/items/index.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const zItem = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  quantity: z.number().int().min(1).default(1),
+  description: z.string().optional(),
+});
+
+export type Item = z.infer<typeof zItem>;

--- a/src/dnd/rules/rules.test.ts
+++ b/src/dnd/rules/rules.test.ts
@@ -16,6 +16,8 @@ describe("dnd rules", () => {
     level: 1,
     hp: 10,
     inventory: [],
+    spells: [],
+    spellSlots: {},
   };
 
   it("passes ability checks when total meets DC", () => {

--- a/src/dnd/spells/index.ts
+++ b/src/dnd/spells/index.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const zSpell = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  level: z.number().int().min(0).max(9),
+  school: z.string().min(1),
+  description: z.string().optional(),
+});
+
+export type Spell = z.infer<typeof zSpell>;

--- a/src/store/character.ts
+++ b/src/store/character.ts
@@ -33,7 +33,7 @@ export const useCharacter = create<CharacterState>()(
           abilities: char.abilities,
           level: char.level,
           hp: char.hp,
-          inventory: char.inventory,
+          inventory: char.inventory.map((i) => i.name),
         });
       },
       clearCharacter: () => set({ character: null }),


### PR DESCRIPTION
## Summary
- define Item and Spell zod schemas
- extend Character with inventory, spell list and slot tracking
- add InventoryPanel and SpellBook components and integrate into CharacterSheet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a930531f508325858b5511aad1e0e7