### PR TITLE
Add basic monster AI for encounter automation

### DIFF
--- a/src/dnd/npcs/MonsterAI.test.ts
+++ b/src/dnd/npcs/MonsterAI.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { Encounter } from "../encounters";
+import { attack, selectTarget, MonsterAI, type Npc } from "./index";
+import * as rules from "../rules";
+
+describe("Monster AI", () => {
+  const baseGoblin: Npc = {
+    name: "goblin",
+    hp: 7,
+    ac: 13,
+    attackBonus: 4,
+    damage: 5,
+    isMonster: true,
+  };
+
+  const baseHero: Npc = {
+    name: "hero",
+    hp: 10,
+    ac: 12,
+    attackBonus: 5,
+    damage: 6,
+    isMonster: false,
+  };
+
+  it("selects first valid target", () => {
+    const goblin = { ...baseGoblin };
+    const hero = { ...baseHero };
+    const target = selectTarget(goblin, [goblin, hero]);
+    expect(target).toBe(hero);
+  });
+
+  it("applies damage on hit", () => {
+    const goblin = { ...baseGoblin };
+    const hero = { ...baseHero };
+    const spy = vi.spyOn(rules, "rollDice").mockReturnValue(15);
+    attack(goblin, hero);
+    expect(hero.hp).toBe(5);
+    spy.mockRestore();
+  });
+
+  it("plays monster turn in encounter", () => {
+    const goblin = { ...baseGoblin };
+    const hero = { ...baseHero };
+    const encounter = new Encounter([
+      { name: goblin.name, initiative: 15 },
+      { name: hero.name, initiative: 10 },
+    ]);
+    const ai = new MonsterAI([goblin, hero]);
+    const spy = vi.spyOn(rules, "rollDice").mockReturnValue(15);
+    const next = ai.takeTurn(encounter);
+    expect(ai.combatants[hero.name].hp).toBe(5);
+    expect(next.current).toBe(1);
+    spy.mockRestore();
+  });
+});

--- a/src/dnd/npcs/MonsterAI.ts
+++ b/src/dnd/npcs/MonsterAI.ts
@@ -1,0 +1,34 @@
+import { Encounter } from "../encounters";
+import type { Npc } from "./types";
+import { selectTarget, attack } from "./ai";
+
+export class MonsterAI {
+  combatants: Record<string, Npc>;
+
+  constructor(combatants: Npc[]) {
+    this.combatants = Object.fromEntries(
+      combatants.map((c) => [c.name, { ...c }])
+    );
+  }
+
+  takeTurn(encounter: Encounter, roll?: number): Encounter {
+    if (encounter.participants.length === 0) {
+      return encounter;
+    }
+    const current = encounter.participants[encounter.current];
+    const actor = this.combatants[current.name];
+    if (!actor || !actor.isMonster || actor.hp <= 0) {
+      return encounter.advance();
+    }
+    const candidates = encounter.participants
+      .map((p) => this.combatants[p.name])
+      .filter(
+        (c): c is Npc => !!c && c.name !== actor.name && c.hp > 0
+      );
+    const target = selectTarget(actor, candidates);
+    if (target) {
+      attack(actor, target, roll);
+    }
+    return encounter.advance();
+  }
+}

--- a/src/dnd/npcs/ai.ts
+++ b/src/dnd/npcs/ai.ts
@@ -1,0 +1,18 @@
+import type { Npc } from "./types";
+import { rollDice } from "../rules";
+
+export function selectTarget(self: Npc, combatants: Npc[]): Npc | undefined {
+  return combatants.find((c) => c.name !== self.name && c.hp > 0);
+}
+
+export function attack(
+  attacker: Npc,
+  target: Npc,
+  roll: number = rollDice(20)
+): boolean {
+  const hit = roll + attacker.attackBonus >= target.ac;
+  if (hit) {
+    target.hp = Math.max(0, target.hp - attacker.damage);
+  }
+  return hit;
+}

--- a/src/dnd/npcs/index.ts
+++ b/src/dnd/npcs/index.ts
@@ -1,0 +1,3 @@
+export type { Npc } from "./types";
+export { selectTarget, attack } from "./ai";
+export { MonsterAI } from "./MonsterAI";

--- a/src/dnd/npcs/types.ts
+++ b/src/dnd/npcs/types.ts
@@ -1,0 +1,8 @@
+export interface Npc {
+  name: string;
+  hp: number;
+  ac: number;
+  attackBonus: number;
+  damage: number;
+  isMonster: boolean;
+}


### PR DESCRIPTION
## Summary
- add NPC combat model and helper AI routines
- implement MonsterAI to control turns in encounters
- test monster target selection, damage, and encounter integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a931be9c588325a4bf5e51916428a6