### PR TITLE
Add NPC PDF import workflow

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -63,6 +63,8 @@ fn main() {
             commands::pdf_ingest,
             commands::parse_spell_pdf,
             commands::parse_rule_pdf,
+            commands::parse_npc_pdf,
+            commands::enqueue_parse_npc_pdf,
             // Blender:
             commands::blender_run_script,
             commands::save_npc,

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -1,8 +1,17 @@
 import { useState } from "react";
-import { Typography, TextField, Button, FormControlLabel, Checkbox } from "@mui/material";
+import {
+  Typography,
+  TextField,
+  Button,
+  FormControlLabel,
+  Checkbox,
+  MenuItem,
+} from "@mui/material";
 import { z } from "zod";
 import { zNpc } from "../../dnd/schemas/npc";
 import { NpcData } from "./types";
+import { useWorlds } from "../../store/worlds";
+import NpcPdfUpload from "./NpcPdfUpload";
 
 export default function NpcForm() {
   const [name, setName] = useState("");
@@ -24,6 +33,8 @@ export default function NpcForm() {
   const [tags, setTags] = useState("");
   const [errors, setErrors] = useState<Record<string, string | null>>({});
   const [result, setResult] = useState<NpcData | null>(null);
+  const worlds = useWorlds((s) => s.worlds);
+  const [world, setWorld] = useState("");
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -87,6 +98,21 @@ export default function NpcForm() {
   return (
     <form onSubmit={handleSubmit}>
       <Typography variant="h6">NPC Form</Typography>
+      <TextField
+        select
+        label="World"
+        value={world}
+        onChange={(e) => setWorld(e.target.value)}
+        fullWidth
+        margin="normal"
+      >
+        {worlds.map((w) => (
+          <MenuItem key={w} value={w}>
+            {w}
+          </MenuItem>
+        ))}
+      </TextField>
+      {world && <NpcPdfUpload world={world} />}
       <TextField
         label="Name"
         value={name}

--- a/src/features/dnd/NpcPdfUpload.tsx
+++ b/src/features/dnd/NpcPdfUpload.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { invoke } from "@tauri-apps/api/core";
+import { useTasks } from "../../store/tasks";
+import type { NpcData } from "./types";
+
+interface Props {
+  world: string;
+}
+
+export default function NpcPdfUpload({ world }: Props) {
+  const enqueueTask = useTasks((s) => s.enqueueTask);
+  const tasks = useTasks((s) => s.tasks);
+  const [taskId, setTaskId] = useState<number | null>(null);
+
+  async function handleUpload() {
+    const selected = await open({ filters: [{ name: "PDF", extensions: ["pdf"] }] });
+    if (typeof selected === "string") {
+      const id = await enqueueTask("Import NPC PDF", {
+        ParseNpcPdf: { path: selected, world },
+      });
+      setTaskId(id);
+    }
+  }
+
+  useEffect(() => {
+    if (!taskId) return;
+    const task = tasks[taskId];
+    if (task && task.status === "completed" && Array.isArray(task.result)) {
+      const parsed = task.result as NpcData[];
+      (async () => {
+        const existing = await invoke<NpcData[]>("list_npcs", { world });
+        for (const npc of parsed) {
+          const dup = existing.find(
+            (e) => e.id === npc.id || e.name === npc.name
+          );
+          let overwrite = true;
+          if (dup) {
+            overwrite = window.confirm(`NPC ${npc.name} exists. Overwrite?`);
+          }
+          if (overwrite) {
+            await invoke("save_npc", { world, npc, overwrite });
+          }
+        }
+      })();
+    }
+  }, [taskId, tasks, world]);
+
+  return (
+    <div>
+      <button type="button" onClick={handleUpload} disabled={!world}>
+        Upload NPC PDF
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow selecting worlds and upload NPC PDFs from NpcForm
- queue and run `ParseNpcPdf` tasks that extract NPCs via Python
- store NPCs per world with zod validation and overwrite prompts

## Testing
- `npm test`
- `cargo test` *(fails: missing type annotations in stocks.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68a9312202488325a560bf7081cf5125