### PR TITLE
Switch from gTTS to TTS library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ Pillow>=9.0.0
 feedparser>=6.0.0
 requests>=2.31.0
 aiohttp>=3.9.0
-gTTS>=2.5.1
+TTS>=0.15
+torch>=2.0
 vosk>=0.3.45


### PR DESCRIPTION
## Summary
- replace gTTS dependency with TTS and torch

## Testing
- `python - <<'PY'
import torch
import TTS
print('torch', torch.__version__)
print('TTS', TTS.__version__)
PY`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9310c157c832593be469e3bed09ee