### PR TITLE
feat: support album titles and tracks

### DIFF
--- a/src/components/BatchActions.tsx
+++ b/src/components/BatchActions.tsx
@@ -17,6 +17,7 @@ interface Props {
   titleBase: string;
   hasInvalidBars: boolean;
   albumMode: boolean;
+  albumReady: boolean;
   onRender: () => void;
   previewPlaying: boolean;
   onPreview: () => Promise<void> | void;
@@ -38,6 +39,7 @@ export default function BatchActions({
   titleBase,
   hasInvalidBars,
   albumMode,
+  albumReady,
   onRender,
   previewPlaying,
   onPreview,
@@ -47,30 +49,37 @@ export default function BatchActions({
   return (
     <>
       <div className={styles.grid2}>
-        <div className={styles.panel}>
-          <label className={styles.label}>
-            How many songs?
-            <HelpIcon text="Number of songs to render in this batch" />
-          </label>
-          <input
-            type="number"
-            min={1}
-            value={numSongs}
-            onChange={(e) => setNumSongs(Math.max(1, Number(e.target.value || 1)))}
-            className={styles.input}
-          />
-          <div className={clsx(styles.small, "mt-2")}>
-            Titles will be suffixed with{" "}
-            <select
-              value={titleSuffixMode}
-              onChange={(e) => setTitleSuffixMode(e.target.value)}
-              className={clsx(styles.input, "py-1 px-2 inline-block w-[160px] ml-1")}
-            >
-              <option value="number"># (1, 2, 3…)</option>
-              <option value="timestamp">timestamp</option>
-            </select>
+        {!albumMode && (
+          <div className={styles.panel}>
+            <label className={styles.label}>
+              How many songs?
+              <HelpIcon text="Number of songs to render in this batch" />
+            </label>
+            <input
+              type="number"
+              min={1}
+              value={numSongs}
+              onChange={(e) =>
+                setNumSongs(Math.max(1, Number(e.target.value || 1)))
+              }
+              className={styles.input}
+            />
+            <div className={clsx(styles.small, "mt-2")}>
+              Titles will be suffixed with{" "}
+              <select
+                value={titleSuffixMode}
+                onChange={(e) => setTitleSuffixMode(e.target.value)}
+                className={clsx(
+                  styles.input,
+                  "py-1 px-2 inline-block w-[160px] ml-1"
+                )}
+              >
+                <option value="number"># (1, 2, 3…)</option>
+                <option value="timestamp">timestamp</option>
+              </select>
+            </div>
           </div>
-        </div>
+        )}
 
         <div className={styles.panel}>
           <label className={styles.label}>
@@ -100,7 +109,13 @@ export default function BatchActions({
       <div className={styles.actions}>
         <button
           className={styles.btn}
-          disabled={busy || !outDir || !titleBase || hasInvalidBars}
+          disabled={
+            busy ||
+            !outDir ||
+            !titleBase ||
+            hasInvalidBars ||
+            (albumMode && !albumReady)
+          }
           onClick={onRender}
         >
           {albumMode

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -326,11 +326,28 @@ describe('SongForm', () => {
     );
 
     fireEvent.click(screen.getByLabelText(/album mode/i));
+    const tcInput = screen.getByDisplayValue('6') as HTMLInputElement;
+    fireEvent.change(tcInput, { target: { value: '3' } });
+    fireEvent.change(screen.getByPlaceholderText(/album name/i), {
+      target: { value: 'My Album' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Track 1 name'), {
+      target: { value: 'T1' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Track 2 name'), {
+      target: { value: 'T2' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Track 3 name'), {
+      target: { value: 'T3' },
+    });
     fireEvent.click(screen.getByText(/create album/i));
 
     await waitFor(() => {
-      const calls = (invoke as any).mock.calls.map(([c]: any) => c);
-      expect(calls).toContain('generate_album');
+      const call = (invoke as any).mock.calls.find(
+        ([c]: any) => c === 'generate_album'
+      );
+      expect(call[1].meta.album_name).toBe('My Album');
+      expect(call[1].meta.track_names).toEqual(['T1', 'T2', 'T3']);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add album name and per-track title inputs for album mode
- generate album and track titles with Ollama
- send album metadata to backend and tighten album creation checks

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68a93907405c8325b1e7048c84696b43