### PR TITLE
chore: bump version to 0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blossom",
-  "version": "0.1.5",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blossom",
-      "version": "0.1.5",
+      "version": "0.1.8",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blossom",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='blossom-audio',
-    version='0.1.5',
+    version='0.1.8',
     install_requires=[
         'scipy>=1.9.0',
         'pyloudnorm>=0.1.0',

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "blossom"
-version = "0.1.5"
+version = "0.1.8"
 dependencies = [
  "async-trait",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blossom"
-version = "0.1.5"
+version = "0.1.8"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "blossom",
-  "version": "0.1.5",
+  "version": "0.1.8",
   "identifier": "com.owner.blossom",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- bump project version to 0.1.8 across manifests

## Testing
- `CI=true npm test -- --run` *(fails: process hangs; partial output available)*
- `cargo test` *(fails: system library `gobject-2.0` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a939617e14832597c2da736dbc4236