### PR TITLE
Add quest system with quest log and map triggers

### DIFF
--- a/src/components/QuestLog.test.tsx
+++ b/src/components/QuestLog.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import QuestLog from './QuestLog';
+import { Quest } from '../dnd/quests';
+
+describe('QuestLog', () => {
+  it('displays active and completed quests', () => {
+    const activeQuest = new Quest(
+      'Find the Sword',
+      [
+        { description: 'Reach the cave', completed: true },
+        { description: 'Retrieve the sword', completed: false },
+      ],
+      { experience: 100 }
+    );
+
+    const completedQuest = new Quest(
+      'Visit the King',
+      [{ description: 'Travel to the castle', completed: true }],
+      { items: ['Crown'] },
+      'completed'
+    );
+
+    render(<QuestLog quests={[activeQuest, completedQuest]} />);
+
+    expect(screen.getByText('Active Quests')).toBeInTheDocument();
+    expect(screen.getByText('Completed Quests')).toBeInTheDocument();
+    expect(screen.getByText('Find the Sword')).toBeInTheDocument();
+    expect(screen.getByText('Visit the King')).toBeInTheDocument();
+  });
+});

--- a/src/components/QuestLog.tsx
+++ b/src/components/QuestLog.tsx
@@ -1,0 +1,38 @@
+import { List, ListItem, Stack, Typography } from '@mui/material';
+import type { Quest } from '../dnd/quests';
+
+interface Props {
+  quests: Quest[];
+}
+
+export default function QuestLog({ quests }: Props) {
+  const active = quests.filter((q) => q.status === 'active');
+  const completed = quests.filter((q) => q.status === 'completed');
+
+  const renderQuest = (quest: Quest) => (
+    <ListItem key={quest.title} alignItems="flex-start">
+      <Stack>
+        <Typography variant="subtitle1">{quest.title}</Typography>
+        <List sx={{ pl: 2 }}>
+          {quest.objectives.map((obj, idx) => (
+            <ListItem key={idx} sx={{ display: 'list-item' }}>
+              <Typography variant="body2">
+                {obj.completed ? '✓ ' : ''}
+                {obj.description}
+              </Typography>
+            </ListItem>
+          ))}
+        </List>
+      </Stack>
+    </ListItem>
+  );
+
+  return (
+    <Stack spacing={2}>
+      <Typography variant="h6">Active Quests</Typography>
+      <List>{active.map(renderQuest)}</List>
+      <Typography variant="h6">Completed Quests</Typography>
+      <List>{completed.map(renderQuest)}</List>
+    </Stack>
+  );
+}

--- a/src/dnd/locations/MapTrigger.ts
+++ b/src/dnd/locations/MapTrigger.ts
@@ -1,0 +1,15 @@
+import type { Quest } from '../quests';
+
+export class MapTrigger {
+  id: string;
+  objectiveIndex: number;
+
+  constructor(id: string, objectiveIndex: number) {
+    this.id = id;
+    this.objectiveIndex = objectiveIndex;
+  }
+
+  interact(quest: Quest) {
+    quest.completeObjective(this.objectiveIndex);
+  }
+}

--- a/src/dnd/locations/index.ts
+++ b/src/dnd/locations/index.ts
@@ -1,0 +1,1 @@
+export { MapTrigger } from './MapTrigger';

--- a/src/dnd/quests/Quest.ts
+++ b/src/dnd/quests/Quest.ts
@@ -1,0 +1,38 @@
+export interface QuestObjective {
+  description: string;
+  completed: boolean;
+}
+
+export interface QuestReward {
+  experience?: number;
+  items?: string[];
+}
+
+export type QuestStatus = 'active' | 'completed';
+
+export class Quest {
+  title: string;
+  objectives: QuestObjective[];
+  reward: QuestReward;
+  status: QuestStatus;
+
+  constructor(
+    title: string,
+    objectives: QuestObjective[],
+    reward: QuestReward,
+    status: QuestStatus = 'active'
+  ) {
+    this.title = title;
+    this.objectives = objectives;
+    this.reward = reward;
+    this.status = status;
+  }
+
+  completeObjective(index: number) {
+    if (index < 0 || index >= this.objectives.length) return;
+    this.objectives[index].completed = true;
+    if (this.objectives.every((o) => o.completed)) {
+      this.status = 'completed';
+    }
+  }
+}

--- a/src/dnd/quests/index.ts
+++ b/src/dnd/quests/index.ts
@@ -1,0 +1,1 @@
+export { Quest, type QuestObjective, type QuestReward, type QuestStatus } from './Quest';


### PR DESCRIPTION
## Summary
- add Quest model for tracking objectives, rewards, and status
- add MapTrigger to update quest objectives when interacting with locations
- introduce QuestLog component to display active and completed quests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9397d7d64832597bebd463c2430eb