### PR TITLE
feat: add album rendering support

### DIFF
--- a/src-tauri/python/lofi/renderer.py
+++ b/src-tauri/python/lofi/renderer.py
@@ -1533,6 +1533,7 @@ def main():
         INSTRUMENTS_DATA = _load_instruments(args.instruments_file)
 
     spec = json.loads(args.song_json)
+    album = spec.get("album")
 
     logger.info({"stage": "generate", "message": "building sections"})
     song, _ = render_from_spec(spec)
@@ -1541,12 +1542,24 @@ def main():
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
     tmp_path = out_path.replace(".wav", ".tmp.wav")
 
-    song.export(tmp_path, format="wav", parameters=["-acodec", "pcm_s16le"])
+    tags = {"title": spec.get("title")}
+    if album:
+        tags["album"] = album
+
+    song.export(
+        tmp_path,
+        format="wav",
+        parameters=["-acodec", "pcm_s16le"],
+        tags=tags,
+    )
     if os.path.exists(out_path):
         os.remove(out_path)
     os.replace(tmp_path, out_path)
 
-    logger.info({"stage": "done", "message": "saved", "path": out_path})
+    info = {"stage": "done", "message": "saved", "path": out_path}
+    if album:
+        info["album"] = album
+    logger.info(info)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- expand album generation command to render each track in a dedicated album folder
- return per-track metadata with output paths
- allow Python renderer to tag songs with album info

## Testing
- `cargo test` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*
- `npm test`
- `cd src-tauri/python && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9480cd638832584de4fa10887d153