### PR TITLE
feat: add campaign persistence helpers and UI

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,0 +1,16 @@
+import { Button, Stack } from "@mui/material";
+import { saveCampaign, loadCampaign } from "../store";
+
+export default function Menu() {
+  return (
+    <Stack spacing={2} direction="row">
+      <Button variant="contained" onClick={() => saveCampaign()}>
+        Save Campaign
+      </Button>
+      <Button variant="outlined" onClick={() => loadCampaign()}>
+        Load Campaign
+      </Button>
+    </Stack>
+  );
+}
+

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,59 @@
+import { saveState, loadState } from "../utils/persist";
+import { useNPCs } from "./npcs";
+import { useWorlds } from "./worlds";
+import { useCharacter } from "./character";
+import { useEncounterStore } from "./encounter";
+import { useWarTableStore } from "./warTable";
+import { useTabletopStore } from "./tabletop";
+
+// Export individual stores for existing imports elsewhere
+export {
+  useNPCs,
+  useWorlds,
+  useCharacter,
+  useEncounterStore,
+  useWarTableStore,
+  useTabletopStore,
+};
+
+const slices = {
+  npcs: useNPCs,
+  worlds: useWorlds,
+  character: useCharacter,
+  encounter: useEncounterStore,
+  warTable: useWarTableStore,
+  tabletop: useTabletopStore,
+};
+
+type StoreState<T> = {
+  [K in keyof T]: T[K] extends { getState: () => infer S }
+    ? { [P in keyof S as S[P] extends Function ? never : P]: S[P] }
+    : never;
+};
+
+export type CampaignState = StoreState<typeof slices>;
+
+export async function saveCampaign(
+  key = "campaign",
+  backendUrl?: string
+) {
+  const data: Record<string, unknown> = {};
+  for (const [name, store] of Object.entries(slices)) {
+    const state = store.getState();
+    data[name] = JSON.parse(JSON.stringify(state));
+  }
+  await saveState(key, data, backendUrl);
+}
+
+export async function loadCampaign(
+  key = "campaign",
+  backendUrl?: string
+) {
+  const data = await loadState<CampaignState>(key, backendUrl);
+  if (!data) return;
+  for (const [name, store] of Object.entries(slices)) {
+    const slice = (data as any)[name];
+    if (slice) store.setState(slice, true);
+  }
+}
+

--- a/src/utils/persist.ts
+++ b/src/utils/persist.ts
@@ -1,0 +1,47 @@
+// Utility functions to persist application state either to
+// localStorage or a backend endpoint.
+// When a backend URL is provided the state is sent via fetch.
+// Otherwise it falls back to localStorage.
+
+export async function saveState<T>(
+  key: string,
+  state: T,
+  backendUrl?: string
+): Promise<void> {
+  const serialized = JSON.stringify(state);
+  if (backendUrl) {
+    await fetch(backendUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key, state }),
+    });
+  } else {
+    try {
+      window.localStorage.setItem(key, serialized);
+    } catch {
+      // ignore write errors
+    }
+  }
+}
+
+export async function loadState<T>(
+  key: string,
+  backendUrl?: string
+): Promise<T | null> {
+  if (backendUrl) {
+    try {
+      const res = await fetch(`${backendUrl}?key=${encodeURIComponent(key)}`);
+      if (!res.ok) return null;
+      return (await res.json()) as T;
+    } catch {
+      return null;
+    }
+  }
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add generic persist helpers for local storage or backend
- wire campaign save/load utilities into root store
- expose save/load campaign buttons in new Menu component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a947c8cd8c832586ea849cdd8e19d6