### PR TITLE
feat: generate album art prompt

### DIFF
--- a/src/components/SongForm.module.css
+++ b/src/components/SongForm.module.css
@@ -175,3 +175,20 @@
   flex-wrap: wrap;
   align-items: center;
 }
+
+.albumArt {
+  margin-top: 20px;
+  text-align: center;
+}
+
+.promptBox {
+  margin-top: 4px;
+  font-size: 12px;
+  opacity: 0.85;
+}
+
+.artPreview {
+  margin-top: 8px;
+  max-width: 100%;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- generate album art prompt via LLM when album metadata is confirmed
- show album art prompt and preview image in SongForm
- cache album metadata with image prompt in local storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a95252dca883258068763ee8c77e08