### PR TITLE
feat: allow configuring voice model for DJ mix

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -46,6 +46,7 @@ fn main() {
             commands::run_lofi_song,
             commands::generate_album,
             commands::cancel_album,
+            commands::dj_mix,
             // ComfyUI:
             commands::comfy_status,
             commands::comfy_start,

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -140,7 +140,20 @@ function PathField({
 }
 
 export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
-  const { pythonPath, setPythonPath, comfyPath, setComfyPath } = usePaths();
+  const {
+    pythonPath,
+    setPythonPath,
+    comfyPath,
+    setComfyPath,
+    ttsModelPath,
+    setTtsModelPath,
+    ttsConfigPath,
+    setTtsConfigPath,
+    ttsSpeaker,
+    setTtsSpeaker,
+    ttsLanguage,
+    setTtsLanguage,
+  } = usePaths();
   const { folder, setFolder } = useOutput();
   const {
     bpm,
@@ -165,12 +178,20 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
 
   const [pythonDraft, setPythonDraft] = useState(pythonPath);
   const [comfyDraft, setComfyDraft] = useState(comfyPath);
+  const [ttsModelDraft, setTtsModelDraft] = useState(ttsModelPath);
+  const [ttsConfigDraft, setTtsConfigDraft] = useState(ttsConfigPath);
+  const [ttsSpeakerDraft, setTtsSpeakerDraft] = useState(ttsSpeaker);
+  const [ttsLanguageDraft, setTtsLanguageDraft] = useState(ttsLanguage);
   const [folderDraft, setFolderDraft] = useState(folder);
   const [themeDraft, setThemeDraft] = useState<Theme>(theme);
   const [modeDraft, setModeDraft] = useState(mode);
 
   useEffect(() => setPythonDraft(pythonPath), [pythonPath]);
   useEffect(() => setComfyDraft(comfyPath), [comfyPath]);
+  useEffect(() => setTtsModelDraft(ttsModelPath), [ttsModelPath]);
+  useEffect(() => setTtsConfigDraft(ttsConfigPath), [ttsConfigPath]);
+  useEffect(() => setTtsSpeakerDraft(ttsSpeaker), [ttsSpeaker]);
+  useEffect(() => setTtsLanguageDraft(ttsLanguage), [ttsLanguage]);
   useEffect(() => setFolderDraft(folder), [folder]);
   useEffect(() => setThemeDraft(theme), [theme]);
   useEffect(() => setModeDraft(mode), [mode]);
@@ -191,12 +212,40 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
             onChange={setComfyDraft}
             directory
           />
+          <PathField
+            label="TTS Model Path"
+            value={ttsModelDraft}
+            onChange={setTtsModelDraft}
+          />
+          <PathField
+            label="TTS Config Path"
+            value={ttsConfigDraft}
+            onChange={setTtsConfigDraft}
+          />
+          <TextField
+            label="TTS Speaker"
+            value={ttsSpeakerDraft}
+            onChange={(e) => setTtsSpeakerDraft(e.target.value)}
+            fullWidth
+            sx={{ mt: 1 }}
+          />
+          <TextField
+            label="TTS Language"
+            value={ttsLanguageDraft}
+            onChange={(e) => setTtsLanguageDraft(e.target.value)}
+            fullWidth
+            sx={{ mt: 1 }}
+          />
           <Button
             variant="contained"
             sx={{ mt: 2 }}
             onClick={() => {
               setPythonPath(pythonDraft);
               setComfyPath(comfyDraft);
+              setTtsModelPath(ttsModelDraft);
+              setTtsConfigPath(ttsConfigDraft);
+              setTtsSpeaker(ttsSpeakerDraft);
+              setTtsLanguage(ttsLanguageDraft);
               setPathsSaved(true);
             }}
           >

--- a/src/features/djMix/useDjMix.ts
+++ b/src/features/djMix/useDjMix.ts
@@ -1,0 +1,17 @@
+import { invoke } from "@tauri-apps/api/core";
+import { usePaths } from "../paths/usePaths";
+
+export function useDjMix() {
+  const { ttsModelPath, ttsConfigPath, ttsSpeaker, ttsLanguage } = usePaths();
+  return async (specs: string[], out: string, host = false) => {
+    await invoke("dj_mix", {
+      specs,
+      out,
+      host,
+      tts_model_path: ttsModelPath,
+      tts_config: ttsConfigPath,
+      tts_speaker: ttsSpeaker,
+      tts_language: ttsLanguage,
+    });
+  };
+}

--- a/src/features/paths/usePaths.ts
+++ b/src/features/paths/usePaths.ts
@@ -5,31 +5,112 @@ import { useEffect } from "react";
 interface PathsState {
   pythonPath: string;
   comfyPath: string;
+  ttsModelPath: string;
+  ttsConfigPath: string;
+  ttsSpeaker: string;
+  ttsLanguage: string;
   loaded: boolean;
   setPythonPath: (p: string) => void;
   setComfyPath: (p: string) => void;
+  setTtsModelPath: (p: string) => void;
+  setTtsConfigPath: (p: string) => void;
+  setTtsSpeaker: (s: string) => void;
+  setTtsLanguage: (l: string) => void;
   load: () => Promise<void>;
 }
 
 const usePathsStore = create<PathsState>((set, get) => ({
   pythonPath: "",
   comfyPath: "",
+  ttsModelPath: "",
+  ttsConfigPath: "",
+  ttsSpeaker: "",
+  ttsLanguage: "",
   loaded: false,
   setPythonPath: (pythonPath: string) => {
     set({ pythonPath });
-    invoke("save_paths", { python_path: pythonPath, comfy_path: get().comfyPath }).catch(() => {});
+    invoke("save_paths", {
+      python_path: pythonPath,
+      comfy_path: get().comfyPath,
+      tts_model_path: get().ttsModelPath,
+      tts_config_path: get().ttsConfigPath,
+      tts_speaker: get().ttsSpeaker,
+      tts_language: get().ttsLanguage,
+    }).catch(() => {});
   },
   setComfyPath: (comfyPath: string) => {
     set({ comfyPath });
-    invoke("save_paths", { python_path: get().pythonPath, comfy_path: comfyPath }).catch(() => {});
+    invoke("save_paths", {
+      python_path: get().pythonPath,
+      comfy_path: comfyPath,
+      tts_model_path: get().ttsModelPath,
+      tts_config_path: get().ttsConfigPath,
+      tts_speaker: get().ttsSpeaker,
+      tts_language: get().ttsLanguage,
+    }).catch(() => {});
+  },
+  setTtsModelPath: (ttsModelPath: string) => {
+    set({ ttsModelPath });
+    invoke("save_paths", {
+      python_path: get().pythonPath,
+      comfy_path: get().comfyPath,
+      tts_model_path: ttsModelPath,
+      tts_config_path: get().ttsConfigPath,
+      tts_speaker: get().ttsSpeaker,
+      tts_language: get().ttsLanguage,
+    }).catch(() => {});
+  },
+  setTtsConfigPath: (ttsConfigPath: string) => {
+    set({ ttsConfigPath });
+    invoke("save_paths", {
+      python_path: get().pythonPath,
+      comfy_path: get().comfyPath,
+      tts_model_path: get().ttsModelPath,
+      tts_config_path: ttsConfigPath,
+      tts_speaker: get().ttsSpeaker,
+      tts_language: get().ttsLanguage,
+    }).catch(() => {});
+  },
+  setTtsSpeaker: (ttsSpeaker: string) => {
+    set({ ttsSpeaker });
+    invoke("save_paths", {
+      python_path: get().pythonPath,
+      comfy_path: get().comfyPath,
+      tts_model_path: get().ttsModelPath,
+      tts_config_path: get().ttsConfigPath,
+      tts_speaker: ttsSpeaker,
+      tts_language: get().ttsLanguage,
+    }).catch(() => {});
+  },
+  setTtsLanguage: (ttsLanguage: string) => {
+    set({ ttsLanguage });
+    invoke("save_paths", {
+      python_path: get().pythonPath,
+      comfy_path: get().comfyPath,
+      tts_model_path: get().ttsModelPath,
+      tts_config_path: get().ttsConfigPath,
+      tts_speaker: get().ttsSpeaker,
+      tts_language: ttsLanguage,
+    }).catch(() => {});
   },
   load: async () => {
     if (get().loaded) return;
     try {
-      const res = await invoke<{ python_path?: string; comfy_path?: string }>("load_paths");
+      const res = await invoke<{
+        python_path?: string;
+        comfy_path?: string;
+        tts_model_path?: string;
+        tts_config_path?: string;
+        tts_speaker?: string;
+        tts_language?: string;
+      }>("load_paths");
       set({
         pythonPath: res.python_path || "",
         comfyPath: res.comfy_path || "",
+        ttsModelPath: res.tts_model_path || "",
+        ttsConfigPath: res.tts_config_path || "",
+        ttsSpeaker: res.tts_speaker || "",
+        ttsLanguage: res.tts_language || "",
         loaded: true,
       });
     } catch {


### PR DESCRIPTION
## Summary
- add TTS model settings and UI fields
- forward voice model settings to dj_mix backend
- expose hook for invoking dj_mix with chosen model

## Testing
- `npx vitest run`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a952bc207083258d43a64bf53271e4