### PR TITLE
feat: import lore pdfs

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -66,10 +66,13 @@ fn main() {
             commands::parse_rule_pdf,
             commands::parse_npc_pdf,
             commands::enqueue_parse_npc_pdf,
+            commands::parse_lore_pdf,
             // Blender:
             commands::blender_run_script,
             commands::save_npc,
             commands::list_npcs,
+            commands::save_lore,
+            commands::list_lore,
             // Paths:
             commands::load_paths,
             commands::save_paths,

--- a/src/features/dnd/LoreForm.tsx
+++ b/src/features/dnd/LoreForm.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
-import { Typography, TextField, Button } from "@mui/material";
+import { Typography, TextField, Button, MenuItem } from "@mui/material";
 import { zLore } from "./schemas";
 import { LoreData } from "./types";
+import { useWorlds } from "../../store/worlds";
+import LorePdfUpload from "./LorePdfUpload";
 
 export default function LoreForm() {
   const [name, setName] = useState("");
@@ -10,6 +12,8 @@ export default function LoreForm() {
   const [hooks, setHooks] = useState("");
   const [tags, setTags] = useState("");
   const [result, setResult] = useState<LoreData | null>(null);
+  const worlds = useWorlds((s) => s.worlds);
+  const [world, setWorld] = useState("");
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -30,6 +34,21 @@ export default function LoreForm() {
   return (
     <form onSubmit={handleSubmit}>
       <Typography variant="h6">Lore Form</Typography>
+      <TextField
+        select
+        label="World"
+        value={world}
+        onChange={(e) => setWorld(e.target.value)}
+        fullWidth
+        margin="normal"
+      >
+        {worlds.map((w) => (
+          <MenuItem key={w} value={w}>
+            {w}
+          </MenuItem>
+        ))}
+      </TextField>
+      {world && <LorePdfUpload world={world} />}
       <TextField
         label="Name"
         value={name}

--- a/src/features/dnd/LorePdfUpload.tsx
+++ b/src/features/dnd/LorePdfUpload.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { invoke } from "@tauri-apps/api/core";
+import { useTasks } from "../../store/tasks";
+import type { LoreData } from "./types";
+
+interface Props {
+  world: string;
+}
+
+export default function LorePdfUpload({ world }: Props) {
+  const enqueueTask = useTasks((s) => s.enqueueTask);
+  const tasks = useTasks((s) => s.tasks);
+  const [taskId, setTaskId] = useState<number | null>(null);
+
+  async function handleUpload() {
+    const selected = await open({ filters: [{ name: "PDF", extensions: ["pdf"] }] });
+    if (typeof selected === "string") {
+      const id = await enqueueTask("Import Lore PDF", {
+        ParseLorePdf: { path: selected, world },
+      });
+      setTaskId(id);
+    }
+  }
+
+  useEffect(() => {
+    if (!taskId) return;
+    const task = tasks[taskId];
+    if (task && task.status === "completed" && Array.isArray(task.result)) {
+      const parsed = task.result as LoreData[];
+      (async () => {
+        const existing = await invoke<LoreData[]>("list_lore", { world });
+        for (const lore of parsed) {
+          const dup = existing.find(
+            (e) => e.id === lore.id || e.name === lore.name
+          );
+          let overwrite = true;
+          if (dup) {
+            overwrite = window.confirm(`Lore ${lore.name} exists. Overwrite?`);
+          }
+          if (overwrite) {
+            await invoke("save_lore", { world, lore, overwrite });
+          }
+        }
+      })();
+    }
+  }, [taskId, tasks, world]);
+
+  return (
+    <div>
+      <button type="button" onClick={handleUpload} disabled={!world}>
+        Upload Lore PDF
+      </button>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add LorePdfUpload and integrate with LoreForm
- support ParseLorePdf tasks and lore storage
- implement lore extraction in Python PDF tools

## Testing
- `npm test`
- `cd src-tauri/python && pytest` *(fails: AssertionError in tests/test_determinism.py::test_deterministic_render)*

------
https://chatgpt.com/codex/tasks/task_e_68a96916cf1c83258b2a629ddcc601de