### PR TITLE
feat: separate album output path

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -752,10 +752,9 @@ pub async fn generate_album<R: Runtime>(
 ) -> Result<AlbumMeta, String> {
     let album_name = meta
         .album_name
-        .clone()
         .unwrap_or_else(|| "album".to_string());
-    let base_out = meta.out_dir.clone().unwrap_or_else(|| ".".to_string());
-    let album_dir = PathBuf::from(base_out).join(&album_name);
+    let base_out = meta.out_dir.unwrap_or_else(|| ".".to_string());
+    let album_dir = PathBuf::from(&base_out).join(&album_name);
     fs::create_dir_all(&album_dir).map_err(|e| e.to_string())?;
 
     let track_names = meta.track_names.unwrap_or_default();

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -710,7 +710,7 @@ export default function SongForm() {
 
     try {
       setBusy(true);
-      await invoke("generate_album", {
+      const res: { album_dir: string } = await invoke("generate_album", {
         meta: {
           track_count: trackCount,
           title_base: titleBase,
@@ -719,6 +719,7 @@ export default function SongForm() {
           out_dir: outDir,
         },
       });
+      setOutDir(res.album_dir);
     } catch (e: any) {
       const message = e?.message || String(e);
       setErr(message);


### PR DESCRIPTION
## Summary
- send output directory and album name separately when generating an album
- create album folder under selected output path on backend
- display final album folder path in the UI after generation

## Testing
- `npm test -- --run`
- `cd src-tauri && cargo test` *(fails: missing javascriptcoregtk-4.1 and compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a96920178c8325b1a079b64b9aef85