### PR TITLE
feat: add typed ability scores

### DIFF
--- a/dnd/npcs/mara-ravensong.md
+++ b/dnd/npcs/mara-ravensong.md
@@ -21,12 +21,12 @@ statblock:
   hp: 22
   speed: "30 ft."
   abilities:
-    str: 10
-    dex: 14
-    con: 12
-    int: 13
-    wis: 11
-    cha: 15
+    strength: 10
+    dexterity: 14
+    constitution: 12
+    intelligence: 13
+    wisdom: 11
+    charisma: 15
 tags: [port, underworld, rumor-broker, music:melancholy, biome:coastal, vibe:rainy]
 relationships:
   - { type: contact, target: npc_jax_caldwell, note: "buys maps" }

--- a/dnd/schemas/npc.schema.json
+++ b/dnd/schemas/npc.schema.json
@@ -96,6 +96,16 @@
           "type": "object",
           "additionalProperties": {
             "type": "number"
+          },
+          "propertyNames": {
+            "enum": [
+              "strength",
+              "dexterity",
+              "constitution",
+              "intelligence",
+              "wisdom",
+              "charisma"
+            ]
           }
         },
         "level": {

--- a/src/components/CharacterSheet.tsx
+++ b/src/components/CharacterSheet.tsx
@@ -1,16 +1,31 @@
 import { useState } from 'react';
 import { Stack, TextField, Button, Typography } from '@mui/material';
 import { useCharacter } from '../store/character';
-import type { Character } from '../dnd/characters';
+import type { Ability, Character } from '../dnd/characters';
 import InventoryPanel from './InventoryPanel';
 import SpellBook from './SpellBook';
 
 export default function CharacterSheet() {
   const stored = useCharacter((s) => s.character);
   const setCharacter = useCharacter((s) => s.setCharacter);
+  const abilityKeys: Ability[] = [
+    'strength',
+    'dexterity',
+    'constitution',
+    'intelligence',
+    'wisdom',
+    'charisma',
+  ];
   const [character, setCharacterState] = useState<Character>(
     stored ?? {
-      abilities: { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 },
+      abilities: {
+        strength: 10,
+        dexterity: 10,
+        constitution: 10,
+        intelligence: 10,
+        wisdom: 10,
+        charisma: 10,
+      },
       class: '',
       level: 1,
       hp: 0,
@@ -20,7 +35,7 @@ export default function CharacterSheet() {
     }
   );
 
-  const updateAbility = (key: string, value: number) =>
+  const updateAbility = (key: Ability, value: number) =>
     setCharacterState((prev) => ({
       ...prev,
       abilities: { ...prev.abilities, [key]: value },
@@ -62,7 +77,7 @@ export default function CharacterSheet() {
       />
       <Typography variant="h6">Abilities</Typography>
       <Stack direction="row" spacing={1}>
-        {['str', 'dex', 'con', 'int', 'wis', 'cha'].map((key) => (
+        {abilityKeys.map((key) => (
           <TextField
             key={key}
             label={key.toUpperCase()}

--- a/src/dnd/characters/index.ts
+++ b/src/dnd/characters/index.ts
@@ -1,8 +1,16 @@
 import type { Item } from "../items";
 import type { Spell } from "../spells";
 
+export type Ability =
+  | "strength"
+  | "dexterity"
+  | "constitution"
+  | "intelligence"
+  | "wisdom"
+  | "charisma";
+
 export interface Character {
-  abilities: Record<string, number>;
+  abilities: Record<Ability, number>;
   class: string;
   level: number;
   hp: number;

--- a/src/dnd/rules/CombatEngine.ts
+++ b/src/dnd/rules/CombatEngine.ts
@@ -1,10 +1,10 @@
-import { Character } from "../characters";
+import { Character, type Ability } from "../characters";
 import { attackRoll, calculateDamage } from "./core";
 
 export interface Weapon {
   diceCount: number;
   diceSides: number;
-  ability: string;
+  ability: Ability;
   modifier?: number;
 }
 

--- a/src/dnd/rules/core.ts
+++ b/src/dnd/rules/core.ts
@@ -1,9 +1,9 @@
-import { Character } from "../characters";
+import { Character, type Ability } from "../characters";
 import { rollDice } from "./dice";
 
 export function abilityCheck(
   character: Character,
-  ability: string,
+  ability: Ability,
   dc: number
 ) {
   const roll = rollDice(20);
@@ -14,7 +14,7 @@ export function abilityCheck(
 
 export function attackRoll(
   attacker: Character,
-  ability: string,
+  ability: Ability,
   targetAC: number
 ) {
   const roll = rollDice(20);
@@ -38,7 +38,7 @@ export function calculateDamage(
 
 export function savingThrow(
   character: Character,
-  ability: string,
+  ability: Ability,
   dc: number
 ) {
   const roll = rollDice(20);

--- a/src/dnd/rules/rules.test.ts
+++ b/src/dnd/rules/rules.test.ts
@@ -11,7 +11,14 @@ import * as dice from "./dice";
 
 describe("dnd rules", () => {
   const baseChar: Character = {
-    abilities: { strength: 3, dexterity: 2 },
+    abilities: {
+      strength: 3,
+      dexterity: 2,
+      constitution: 0,
+      intelligence: 0,
+      wisdom: 0,
+      charisma: 0,
+    },
     class: "fighter",
     level: 1,
     hp: 10,

--- a/src/dnd/schemas/npc.ts
+++ b/src/dnd/schemas/npc.ts
@@ -1,10 +1,27 @@
 import { z } from "zod";
+import type { Ability } from "../characters";
 
 export const zVoice = z.object({
   style: z.string().min(1),
   provider: z.string().min(1),
   preset: z.string().min(1),
 });
+
+const abilities: [
+  Ability,
+  Ability,
+  Ability,
+  Ability,
+  Ability,
+  Ability,
+] = [
+  "strength",
+  "dexterity",
+  "constitution",
+  "intelligence",
+  "wisdom",
+  "charisma",
+];
 
 export const zNpc = z.object({
   id: z.string().min(1),
@@ -23,7 +40,7 @@ export const zNpc = z.object({
   sections: z.record(z.unknown()).optional(),
   statblock: z.record(z.unknown()),
   tags: z.array(z.string()).nonempty(),
-  abilities: z.record(z.number()).optional(),
+  abilities: z.record(z.enum(abilities), z.number()).optional(),
   level: z.number().int().min(1).optional(),
   hp: z.number().int().min(0).optional(),
   inventory: z.array(z.string()).optional(),

--- a/src/store/npcs.ts
+++ b/src/store/npcs.ts
@@ -1,13 +1,14 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { invoke } from '@tauri-apps/api/core';
+import type { Ability } from '../dnd/characters';
 
 export interface NPC {
   id: string;
   name: string;
   race: string;
   class: string;
-  abilities?: Record<string, number>;
+  abilities?: Record<Ability, number>;
   level?: number;
   hp?: number;
   inventory?: string[];


### PR DESCRIPTION
## Summary
- define an `Ability` union for D&D stats and use `Record<Ability, number>` for character and weapon data
- update character sheet, NPC store, and schemas to rely on the ability union
- adjust tests and regenerate NPC JSON schema

## Testing
- `CI=true npm test`
- `npm run schemas:generate`


------
https://chatgpt.com/codex/tasks/task_e_68a9722c1bec8325945644641985af77