### PR TITLE
feat: queue rule pdf imports

### DIFF
--- a/scripts/validate-dnd.ts
+++ b/scripts/validate-dnd.ts
@@ -1,10 +1,11 @@
-import { zNpc, zLore, zQuest, zSpell } from "../src/features/dnd/schemas";
+import { zNpc, zLore, zQuest, zSpell, zRule } from "../src/features/dnd/schemas";
 
 const schemas: Record<string, any> = {
   npc: zNpc,
   lore: zLore,
   quest: zQuest,
   spell: zSpell,
+  rule: zRule,
 };
 
 const [, , kind, jsonStr] = process.argv;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -71,6 +71,8 @@ fn main() {
             commands::blender_run_script,
             commands::save_npc,
             commands::list_npcs,
+            commands::save_rule,
+            commands::list_rules,
             commands::save_spell,
             commands::list_spells,
             commands::save_lore,

--- a/src/features/dnd/RulePdfUpload.tsx
+++ b/src/features/dnd/RulePdfUpload.tsx
@@ -1,14 +1,17 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
+import { useTasks } from "../../store/tasks";
+import type { RuleData } from "./types";
 
 interface RuleRecord {
   name: string;
   description: string;
 }
 
-interface ParsedRule extends RuleRecord {
-  origin: "official" | "custom";
+interface RuleIndexEntry {
+  id: string;
+  name: string;
 }
 
 const OFFICIAL_RULES = new Set([
@@ -19,34 +22,56 @@ const OFFICIAL_RULES = new Set([
 ]);
 
 export default function RulePdfUpload() {
-  const [rules, setRules] = useState<ParsedRule[]>([]);
+  const enqueueTask = useTasks((s) => s.enqueueTask);
+  const tasks = useTasks((s) => s.tasks);
+  const [taskId, setTaskId] = useState<number | null>(null);
 
   async function handleUpload() {
     const selected = await open({ filters: [{ name: "PDF", extensions: ["pdf"] }] });
     if (typeof selected === "string") {
-      const extracted = await invoke<RuleRecord[]>("parse_rule_pdf", { path: selected });
-      const classified = extracted.map((r) => ({
-        ...r,
-        origin: OFFICIAL_RULES.has(r.name) ? "official" : "custom",
-      }));
-      setRules(classified);
+      const id = await enqueueTask("Import Rule PDF", {
+        ParseRulePdf: { path: selected },
+      });
+      setTaskId(id);
     }
   }
+
+  useEffect(() => {
+    if (!taskId) return;
+    const task = tasks[taskId];
+    if (task && task.status === "completed" && Array.isArray(task.result)) {
+      const raw = task.result as RuleRecord[];
+      const parsed: RuleData[] = raw.map((r) => ({
+        id: `rule_${r.name.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`,
+        name: r.name,
+        description: r.description,
+        tags: OFFICIAL_RULES.has(r.name) ? ["core"] : ["custom"],
+      }));
+      (async () => {
+        const existing = await invoke<RuleIndexEntry[]>("list_rules");
+        for (const rule of parsed) {
+          const dup = existing.find(
+            (e) => e.id === rule.id || e.name === rule.name,
+          );
+          let overwrite = true;
+          if (dup) {
+            overwrite = window.confirm(
+              `Rule ${rule.name} exists. Overwrite?`,
+            );
+          }
+          if (overwrite) {
+            await invoke("save_rule", { rule, overwrite });
+          }
+        }
+      })();
+    }
+  }, [taskId, tasks]);
 
   return (
     <div>
       <button type="button" onClick={handleUpload}>
         Upload Rule PDF
       </button>
-      {rules.length > 0 && (
-        <ul>
-          {rules.map((r) => (
-            <li key={r.name}>
-              {r.name} – {r.origin}
-            </li>
-          ))}
-        </ul>
-      )}
     </div>
   );
 }

--- a/src/features/dnd/schemas.ts
+++ b/src/features/dnd/schemas.ts
@@ -53,6 +53,7 @@ export const zRule = zDndBase.extend({
   description: z.string().min(1),
   tags: z.array(z.string()).nonempty(),
   sourceId: z.string().min(1).optional(),
+  sections: z.record(z.string()).optional(),
 });
 
 export const zSpell = zDndBase.extend({

--- a/src/features/dnd/tests/schemas.test.ts
+++ b/src/features/dnd/tests/schemas.test.ts
@@ -270,6 +270,7 @@ describe("dnd schemas", () => {
       name: "Flanking",
       description: "Gain advantage when allies surround an enemy",
       tags: ["combat"],
+      sections: { example: "some text" },
     };
     expect(zRule.parse(rule)).toEqual(rule);
   });

--- a/src/features/dnd/types.ts
+++ b/src/features/dnd/types.ts
@@ -43,6 +43,7 @@ export interface RuleData extends DndBase {
   description: string;
   tags: string[];
   sourceId?: string;
+  sections?: Record<string, string>;
 }
 
 export interface SpellData extends DndBase {


### PR DESCRIPTION
## Summary
- queue Rule PDF parsing tasks with overwrite prompts
- add ParseRulePdf backend task and rule storage
- allow extra rule sections via schema

## Testing
- `npm test`
- `cargo test` *(fails: system library `glib-2.0` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9722374cc83258da845a9eb0eea8e