### PR TITLE
Persist encounter as plain data and rehydrate

### DIFF
--- a/src/store/encounter.ts
+++ b/src/store/encounter.ts
@@ -21,7 +21,43 @@ export const useEncounterStore = create<EncounterState>()(
         ),
       endEncounter: () => set({ encounter: null }),
     }),
-    { name: 'encounter-store' }
+    {
+      name: 'encounter-store',
+      serialize: (state) =>
+        JSON.stringify({
+          state: {
+            ...state.state,
+            encounter: state.state.encounter
+              ? {
+                  participants: state.state.encounter.participants,
+                  current: state.state.encounter.current,
+                }
+              : null,
+          },
+          version: state.version,
+        }),
+      deserialize: (str) => {
+        const parsed = JSON.parse(str) as {
+          state: {
+            encounter: { participants: Participant[]; current: number } | null;
+          };
+          version: number;
+        };
+        return {
+          state: {
+            ...parsed.state,
+            encounter: parsed.state.encounter
+              ? new Encounter(
+                  parsed.state.encounter.participants,
+                  parsed.state.encounter.current,
+                  true,
+                )
+              : null,
+          },
+          version: parsed.version,
+        };
+      },
+    }
   )
 );
 


### PR DESCRIPTION
## Summary
- Persist only simple encounter data (participants and turn index)
- Rehydrate Encounter instances on load using custom serialize/deserialize

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a97ade6c5c832599d7968eda28f27d