### PR TITLE
feat: add ids to quests and objectives

### DIFF
--- a/src/components/QuestLog.test.tsx
+++ b/src/components/QuestLog.test.tsx
@@ -6,17 +6,19 @@ import { Quest } from '../dnd/quests';
 describe('QuestLog', () => {
   it('displays active and completed quests', () => {
     const activeQuest = new Quest(
+      'quest-1',
       'Find the Sword',
       [
-        { description: 'Reach the cave', completed: true },
-        { description: 'Retrieve the sword', completed: false },
+        { id: 'obj-1', description: 'Reach the cave', completed: true },
+        { id: 'obj-2', description: 'Retrieve the sword', completed: false },
       ],
       { experience: 100 }
     );
 
     const completedQuest = new Quest(
+      'quest-2',
       'Visit the King',
-      [{ description: 'Travel to the castle', completed: true }],
+      [{ id: 'obj-3', description: 'Travel to the castle', completed: true }],
       { items: ['Crown'] },
       'completed'
     );

--- a/src/components/QuestLog.tsx
+++ b/src/components/QuestLog.tsx
@@ -10,12 +10,12 @@ export default function QuestLog({ quests }: Props) {
   const completed = quests.filter((q) => q.status === 'completed');
 
   const renderQuest = (quest: Quest) => (
-    <ListItem key={quest.title} alignItems="flex-start">
+    <ListItem key={quest.id} alignItems="flex-start">
       <Stack>
         <Typography variant="subtitle1">{quest.title}</Typography>
         <List sx={{ pl: 2 }}>
-          {quest.objectives.map((obj, idx) => (
-            <ListItem key={idx} sx={{ display: 'list-item' }}>
+          {quest.objectives.map((obj) => (
+            <ListItem key={obj.id} sx={{ display: 'list-item' }}>
               <Typography variant="body2">
                 {obj.completed ? '✓ ' : ''}
                 {obj.description}

--- a/src/dnd/quests/Quest.ts
+++ b/src/dnd/quests/Quest.ts
@@ -1,4 +1,5 @@
 export interface QuestObjective {
+  id: string;
   description: string;
   completed: boolean;
 }
@@ -11,17 +12,20 @@ export interface QuestReward {
 export type QuestStatus = 'active' | 'completed';
 
 export class Quest {
+  id: string;
   title: string;
   objectives: QuestObjective[];
   reward: QuestReward;
   status: QuestStatus;
 
   constructor(
+    id: string,
     title: string,
     objectives: QuestObjective[],
     reward: QuestReward,
     status: QuestStatus = 'active'
   ) {
+    this.id = id;
     this.title = title;
     this.objectives = objectives;
     this.reward = reward;


### PR DESCRIPTION
## Summary
- add unique id to Quest and QuestObjective types
- use stable quest and objective ids for list keys

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a97af2b11c8325b4d22c13f9c09480