### PR TITLE
Allow deterministic RNG for dice rolls

### DIFF
--- a/src/dnd/npcs/MonsterAI.test.ts
+++ b/src/dnd/npcs/MonsterAI.test.ts
@@ -1,7 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { Encounter } from "../encounters";
 import { attack, selectTarget, MonsterAI, type Npc } from "./index";
-import * as rules from "../rules";
 
 describe("Monster AI", () => {
   const baseGoblin: Npc = {
@@ -26,10 +25,8 @@ describe("Monster AI", () => {
     const goblin = { ...baseGoblin };
     const hero = { ...baseHero, name: "hero1" };
     const ally = { ...baseHero, name: "hero2" };
-    const spy = vi.spyOn(Math, "random").mockReturnValue(0.9);
-    const target = selectTarget(goblin, [hero, ally], "random");
+    const target = selectTarget(goblin, [hero, ally], "random", () => 0.9);
     expect(target).toBe(ally);
-    spy.mockRestore();
   });
 
   it("selects target with lowest HP", () => {
@@ -43,10 +40,8 @@ describe("Monster AI", () => {
   it("applies damage on hit", () => {
     const goblin = { ...baseGoblin };
     const hero = { ...baseHero };
-    const spy = vi.spyOn(rules, "rollDice").mockReturnValue(15);
-    attack(goblin, hero);
+    attack(goblin, hero, undefined, () => 0.7);
     expect(hero.hp).toBe(5);
-    spy.mockRestore();
   });
 
   it("plays monster turn in encounter", () => {
@@ -57,11 +52,9 @@ describe("Monster AI", () => {
       { name: hero.name, initiative: 10 },
     ]);
     const ai = new MonsterAI([goblin, hero]);
-    const spy = vi.spyOn(rules, "rollDice").mockReturnValue(15);
-    const next = ai.takeTurn(encounter);
+    const next = ai.takeTurn(encounter, () => 0.7);
     expect(ai.combatants[hero.name].hp).toBe(5);
     expect(next.current).toBe(1);
-    spy.mockRestore();
   });
 
   it("plays monster turn targeting lowest HP opponent", () => {
@@ -74,10 +67,8 @@ describe("Monster AI", () => {
       { name: wounded.name, initiative: 5 },
     ]);
     const ai = new MonsterAI([goblin, healthy, wounded], "lowest-hp");
-    const spy = vi.spyOn(rules, "rollDice").mockReturnValue(15);
-    ai.takeTurn(encounter);
+    ai.takeTurn(encounter, () => 0.7);
     expect(ai.combatants[wounded.name].hp).toBe(0);
     expect(ai.combatants[healthy.name].hp).toBe(10);
-    spy.mockRestore();
   });
 });

--- a/src/dnd/npcs/MonsterAI.ts
+++ b/src/dnd/npcs/MonsterAI.ts
@@ -13,7 +13,10 @@ export class MonsterAI {
     this.strategy = strategy;
   }
 
-  takeTurn(encounter: Encounter, roll?: number): Encounter {
+  takeTurn(
+    encounter: Encounter,
+    rng: () => number = Math.random
+  ): Encounter {
     if (encounter.participants.length === 0) {
       return encounter;
     }
@@ -27,9 +30,9 @@ export class MonsterAI {
       .filter(
         (c): c is Npc => !!c && c.name !== actor.name && c.hp > 0
       );
-    const target = selectTarget(actor, candidates, this.strategy);
+    const target = selectTarget(actor, candidates, this.strategy, rng);
     if (target) {
-      attack(actor, target, roll);
+      attack(actor, target, undefined, rng);
     }
     return encounter.advance();
   }

--- a/src/dnd/npcs/ai.ts
+++ b/src/dnd/npcs/ai.ts
@@ -6,7 +6,8 @@ export type TargetStrategy = "random" | "lowest-hp";
 export function selectTarget(
   self: Npc,
   combatants: Npc[],
-  strategy: TargetStrategy = "random"
+  strategy: TargetStrategy = "random",
+  rng: () => number = Math.random
 ): Npc | undefined {
   const targets = combatants.filter(
     (c) => c.name !== self.name && c.hp > 0
@@ -17,16 +18,18 @@ export function selectTarget(
   if (strategy === "lowest-hp") {
     return targets.reduce((lowest, c) => (c.hp < lowest.hp ? c : lowest));
   }
-  const index = Math.floor(Math.random() * targets.length);
+  const index = Math.floor(rng() * targets.length);
   return targets[index];
 }
 
 export function attack(
   attacker: Npc,
   target: Npc,
-  roll: number = rollDice(20)
+  roll?: number,
+  rng: () => number = Math.random
 ): boolean {
-  const hit = roll + attacker.attackBonus >= target.ac;
+  const actualRoll = roll ?? rollDice(20, rng);
+  const hit = actualRoll + attacker.attackBonus >= target.ac;
   if (hit) {
     target.hp = Math.max(0, target.hp - attacker.damage);
   }

--- a/src/dnd/rules/CombatEngine.ts
+++ b/src/dnd/rules/CombatEngine.ts
@@ -12,15 +12,17 @@ export class CombatEngine {
   static resolveAttack(
     attacker: Character,
     defenderAC: number,
-    weapon: Weapon
+    weapon: Weapon,
+    rng: () => number = Math.random
   ) {
-    const attack = attackRoll(attacker, weapon.ability, defenderAC);
+    const attack = attackRoll(attacker, weapon.ability, defenderAC, rng);
     if (attack.hit) {
       const abilityMod = attacker.abilities[weapon.ability] ?? 0;
       const damage = calculateDamage(
         weapon.diceCount,
         weapon.diceSides,
-        abilityMod + (weapon.modifier ?? 0)
+        abilityMod + (weapon.modifier ?? 0),
+        rng
       );
       const totalDamage = attack.critical ? damage.total * 2 : damage.total;
       return { ...attack, damage: totalDamage };

--- a/src/dnd/rules/core.ts
+++ b/src/dnd/rules/core.ts
@@ -4,9 +4,10 @@ import { rollDice } from "./dice";
 export function abilityCheck(
   character: Character,
   ability: Ability,
-  dc: number
+  dc: number,
+  rng: () => number = Math.random
 ) {
-  const roll = rollDice(20);
+  const roll = rollDice(20, rng);
   const modifier = character.abilities[ability] ?? 0;
   const total = roll + modifier;
   return { roll, total, success: total >= dc };
@@ -15,9 +16,10 @@ export function abilityCheck(
 export function attackRoll(
   attacker: Character,
   ability: Ability,
-  targetAC: number
+  targetAC: number,
+  rng: () => number = Math.random
 ) {
-  const roll = rollDice(20);
+  const roll = rollDice(20, rng);
   const modifier = attacker.abilities[ability] ?? 0;
   const total = roll + modifier;
   const critical = roll === 20;
@@ -29,9 +31,10 @@ export function attackRoll(
 export function calculateDamage(
   diceCount: number,
   diceSides: number,
-  modifier = 0
+  modifier = 0,
+  rng: () => number = Math.random
 ) {
-  const rolls = Array.from({ length: diceCount }, () => rollDice(diceSides));
+  const rolls = Array.from({ length: diceCount }, () => rollDice(diceSides, rng));
   const total = rolls.reduce((a, b) => a + b, 0) + modifier;
   return { rolls, total };
 }
@@ -39,9 +42,10 @@ export function calculateDamage(
 export function savingThrow(
   character: Character,
   ability: Ability,
-  dc: number
+  dc: number,
+  rng: () => number = Math.random
 ) {
-  const roll = rollDice(20);
+  const roll = rollDice(20, rng);
   const modifier = character.abilities[ability] ?? 0;
   const total = roll + modifier;
   return { roll, total, success: total >= dc };

--- a/src/dnd/rules/dice.test.ts
+++ b/src/dnd/rules/dice.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { rollDice } from "./dice";
+
+describe("rollDice", () => {
+  it("uses provided rng for deterministic results", () => {
+    const rng = () => 0.5;
+    const first = rollDice(6, rng);
+    const second = rollDice(6, rng);
+    expect(first).toBe(4);
+    expect(second).toBe(4);
+  });
+});
+

--- a/src/dnd/rules/dice.ts
+++ b/src/dnd/rules/dice.ts
@@ -1,3 +1,6 @@
-export function rollDice(sides: number): number {
-  return Math.floor(Math.random() * sides) + 1;
+export function rollDice(
+  sides: number,
+  rng: () => number = Math.random
+): number {
+  return Math.floor(rng() * sides) + 1;
 }


### PR DESCRIPTION
## Summary
- allow passing a custom RNG to `rollDice` and propagate through core rule helpers and Monster AI
- accept RNG in MonsterAI for deterministic combat
- add deterministic roll test and update existing tests to use seeded RNG

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68aa2f42e2a88325afaa1ddc16376fa3