### PR TITLE
feat: add grid layout to dnd forms

### DIFF
--- a/src/features/dnd/EncounterForm.tsx
+++ b/src/features/dnd/EncounterForm.tsx
@@ -4,6 +4,7 @@ import {
   TextField,
   Button,
   MenuItem,
+  Grid,
 } from "@mui/material";
 import { zEncounter } from "./schemas";
 import { EncounterData, DndTheme } from "./types";
@@ -47,116 +48,142 @@ export default function EncounterForm() {
 
   return (
     <form onSubmit={handleSubmit}>
-      <Typography variant="h6">Encounter Form</Typography>
-      <TextField
-        label="Name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Level"
-        type="number"
-        value={level ?? ""}
-        onChange={(e) => {
-          const val = e.target.value;
-          setLevel(val === "" ? undefined : Number(val));
-          setErrors((prev) => ({ ...prev, level: undefined }));
-        }}
-        error={!!errors.level}
-        helperText={errors.level}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Creatures (comma separated)"
-        value={creatures}
-        onChange={(e) => setCreatures(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Tactics"
-        value={tactics}
-        onChange={(e) => setTactics(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Terrain"
-        value={terrain}
-        onChange={(e) => setTerrain(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Treasure"
-        value={treasure}
-        onChange={(e) => setTreasure(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Scaling"
-        value={scaling}
-        onChange={(e) => setScaling(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        select
-        label="Theme"
-        value={theme}
-        onChange={(e) => setTheme(e.target.value as DndTheme)}
-        fullWidth
-        margin="normal"
-      >
-        {themes.map((t) => (
-          <MenuItem key={t} value={t}>
-            {t}
-          </MenuItem>
-        ))}
-      </TextField>
-      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
-        Submit
-      </Button>
-      <div style={{ ...themeStyles[theme], marginTop: "1rem" }}>
-        <h3>{name || "Encounter Preview"}</h3>
-        {level && (
-          <p>
-            <strong>Level:</strong> {level}
-          </p>
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <Typography variant="h6">Encounter Form</Typography>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Level"
+            type="number"
+            value={level ?? ""}
+            onChange={(e) => {
+              const val = e.target.value;
+              setLevel(val === "" ? undefined : Number(val));
+              setErrors((prev) => ({ ...prev, level: undefined }));
+            }}
+            error={!!errors.level}
+            helperText={errors.level}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Creatures (comma separated)"
+            value={creatures}
+            onChange={(e) => setCreatures(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Tactics"
+            value={tactics}
+            onChange={(e) => setTactics(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Terrain"
+            value={terrain}
+            onChange={(e) => setTerrain(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Treasure"
+            value={treasure}
+            onChange={(e) => setTreasure(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Scaling"
+            value={scaling}
+            onChange={(e) => setScaling(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            select
+            label="Theme"
+            value={theme}
+            onChange={(e) => setTheme(e.target.value as DndTheme)}
+            fullWidth
+            margin="normal"
+          >
+            {themes.map((t) => (
+              <MenuItem key={t} value={t}>
+                {t}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+        <Grid item xs={12}>
+          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
+            Submit
+          </Button>
+        </Grid>
+        <Grid item xs={12}>
+          <div style={{ ...themeStyles[theme], marginTop: "1rem" }}>
+            <h3>{name || "Encounter Preview"}</h3>
+            {level && (
+              <p>
+                <strong>Level:</strong> {level}
+              </p>
+            )}
+            {creatures && (
+              <p>
+                <strong>Creatures:</strong> {creatures}
+              </p>
+            )}
+            {tactics && (
+              <p>
+                <strong>Tactics:</strong> {tactics}
+              </p>
+            )}
+            {terrain && (
+              <p>
+                <strong>Terrain:</strong> {terrain}
+              </p>
+            )}
+            {treasure && (
+              <p>
+                <strong>Treasure:</strong> {treasure}
+              </p>
+            )}
+            {scaling && (
+              <p>
+                <strong>Scaling:</strong> {scaling}
+              </p>
+            )}
+          </div>
+        </Grid>
+        {result && (
+          <Grid item xs={12}>
+            <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>
+          </Grid>
         )}
-        {creatures && (
-          <p>
-            <strong>Creatures:</strong> {creatures}
-          </p>
-        )}
-        {tactics && (
-          <p>
-            <strong>Tactics:</strong> {tactics}
-          </p>
-        )}
-        {terrain && (
-          <p>
-            <strong>Terrain:</strong> {terrain}
-          </p>
-        )}
-        {treasure && (
-          <p>
-            <strong>Treasure:</strong> {treasure}
-          </p>
-        )}
-        {scaling && (
-          <p>
-            <strong>Scaling:</strong> {scaling}
-          </p>
-        )}
-      </div>
-      {result && (
-        <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>
-      )}
+      </Grid>
     </form>
   );
 }

--- a/src/features/dnd/LoreForm.tsx
+++ b/src/features/dnd/LoreForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Typography, TextField, Button, MenuItem } from "@mui/material";
+import { Typography, TextField, Button, MenuItem, Grid } from "@mui/material";
 import { zLore } from "./schemas";
 import { LoreData } from "./types";
 import { useWorlds } from "../../store/worlds";
@@ -33,61 +33,87 @@ export default function LoreForm() {
 
   return (
     <form onSubmit={handleSubmit}>
-      <Typography variant="h6">Lore Form</Typography>
-      <TextField
-        select
-        label="World"
-        value={world}
-        onChange={(e) => setWorld(e.target.value)}
-        fullWidth
-        margin="normal"
-      >
-        {worlds.map((w) => (
-          <MenuItem key={w} value={w}>
-            {w}
-          </MenuItem>
-        ))}
-      </TextField>
-      {world && <LorePdfUpload world={world} />}
-      <TextField
-        label="Name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Summary"
-        value={summary}
-        onChange={(e) => setSummary(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Location"
-        value={location}
-        onChange={(e) => setLocation(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Hooks (comma separated)"
-        value={hooks}
-        onChange={(e) => setHooks(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Tags (comma separated)"
-        value={tags}
-        onChange={(e) => setTags(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
-        Submit
-      </Button>
-      {result && <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>}
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <Typography variant="h6">Lore Form</Typography>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            select
+            label="World"
+            value={world}
+            onChange={(e) => setWorld(e.target.value)}
+            fullWidth
+            margin="normal"
+          >
+            {worlds.map((w) => (
+              <MenuItem key={w} value={w}>
+                {w}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+        {world && (
+          <Grid item xs={12} md={6}>
+            <LorePdfUpload world={world} />
+          </Grid>
+        )}
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Summary"
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Location"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Hooks (comma separated)"
+            value={hooks}
+            onChange={(e) => setHooks(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Tags (comma separated)"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
+            Submit
+          </Button>
+        </Grid>
+        {result && (
+          <Grid item xs={12}>
+            <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>
+          </Grid>
+        )}
+      </Grid>
     </form>
   );
 }

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -6,6 +6,7 @@ import {
   FormControlLabel,
   Checkbox,
   MenuItem,
+  Grid,
 } from "@mui/material";
 import { z } from "zod";
 import { zNpc } from "../../dnd/schemas/npc";
@@ -94,207 +95,256 @@ export default function NpcForm() {
       }
     }
   };
-
   return (
     <form onSubmit={handleSubmit}>
-      <Typography variant="h6">NPC Form</Typography>
-      <TextField
-        select
-        label="World"
-        value={world}
-        onChange={(e) => setWorld(e.target.value)}
-        fullWidth
-        margin="normal"
-      >
-        {worlds.map((w) => (
-          <MenuItem key={w} value={w}>
-            {w}
-          </MenuItem>
-        ))}
-      </TextField>
-      {world && <NpcPdfUpload world={world} />}
-      <TextField
-        label="Name"
-        value={name}
-        onChange={(e) => {
-          setName(e.target.value);
-          setErrors((prev) => ({ ...prev, name: null }));
-        }}
-        fullWidth
-        margin="normal"
-        error={Boolean(errors.name)}
-        helperText={errors.name}
-      />
-      <TextField
-        label="Species"
-        value={species}
-        onChange={(e) => {
-          setSpecies(e.target.value);
-          setErrors((prev) => ({ ...prev, species: null }));
-        }}
-        fullWidth
-        margin="normal"
-        error={Boolean(errors.species)}
-        helperText={errors.species}
-      />
-      <TextField
-        label="Role"
-        value={role}
-        onChange={(e) => {
-          setRole(e.target.value);
-          setErrors((prev) => ({ ...prev, role: null }));
-        }}
-        fullWidth
-        margin="normal"
-        error={Boolean(errors.role)}
-        helperText={errors.role}
-      />
-      <TextField
-        label="Alignment"
-        value={alignment}
-        onChange={(e) => {
-          setAlignment(e.target.value);
-          setErrors((prev) => ({ ...prev, alignment: null }));
-        }}
-        fullWidth
-        margin="normal"
-        error={Boolean(errors.alignment)}
-        helperText={errors.alignment}
-      />
-      <FormControlLabel
-        control={
-          <Checkbox
-            checked={playerCharacter}
-            onChange={(e) => setPlayerCharacter(e.target.checked)}
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <Typography variant="h6">NPC Form</Typography>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            select
+            label="World"
+            value={world}
+            onChange={(e) => setWorld(e.target.value)}
+            fullWidth
+            margin="normal"
+          >
+            {worlds.map((w) => (
+              <MenuItem key={w} value={w}>
+                {w}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+        {world && (
+          <Grid item xs={12} md={6}>
+            <NpcPdfUpload world={world} />
+          </Grid>
+        )}
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Name"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              setErrors((prev) => ({ ...prev, name: null }));
+            }}
+            fullWidth
+            margin="normal"
+            error={Boolean(errors.name)}
+            helperText={errors.name}
           />
-        }
-        label="Player Character"
-      />
-      <TextField
-        label="Backstory"
-        value={backstory}
-        onChange={(e) => setBackstory(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Location"
-        value={location}
-        onChange={(e) => setLocation(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Hooks (comma separated)"
-        value={hooks}
-        onChange={(e) => {
-          setHooks(e.target.value);
-          setErrors((prev) => ({ ...prev, hooks: null }));
-        }}
-        fullWidth
-        margin="normal"
-        error={Boolean(errors.hooks)}
-        helperText={errors.hooks}
-      />
-      <TextField
-        label="Quirks (comma separated)"
-        value={quirks}
-        onChange={(e) => setQuirks(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Voice Style"
-        value={voiceStyle}
-        onChange={(e) => {
-          setVoiceStyle(e.target.value);
-          setErrors((prev) => ({ ...prev, ["voice.style"]: null }));
-        }}
-        fullWidth
-        margin="normal"
-        error={Boolean(errors["voice.style"])}
-        helperText={errors["voice.style"]}
-      />
-      <TextField
-        label="Voice Provider"
-        value={voiceProvider}
-        onChange={(e) => {
-          setVoiceProvider(e.target.value);
-          setErrors((prev) => ({ ...prev, ["voice.provider"]: null }));
-        }}
-        fullWidth
-        margin="normal"
-        error={Boolean(errors["voice.provider"])}
-        helperText={errors["voice.provider"]}
-      />
-      <TextField
-        label="Voice Preset"
-        value={voicePreset}
-        onChange={(e) => {
-          setVoicePreset(e.target.value);
-          setErrors((prev) => ({ ...prev, ["voice.preset"]: null }));
-        }}
-        fullWidth
-        margin="normal"
-        error={Boolean(errors["voice.preset"])}
-        helperText={errors["voice.preset"]}
-      />
-      <TextField
-        label="Portrait URL"
-        value={portrait}
-        onChange={(e) => setPortrait(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Icon URL"
-        value={icon}
-        onChange={(e) => setIcon(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Statblock JSON"
-        value={statblock}
-        onChange={(e) => {
-          setStatblock(e.target.value);
-          setErrors((prev) => ({ ...prev, statblock: null }));
-        }}
-        fullWidth
-        margin="normal"
-        multiline
-        error={Boolean(errors.statblock)}
-        helperText={errors.statblock}
-      />
-      <TextField
-        label="Custom Sections JSON"
-        value={sections}
-        onChange={(e) => {
-          setSections(e.target.value);
-          setErrors((prev) => ({ ...prev, sections: null }));
-        }}
-        fullWidth
-        margin="normal"
-        multiline
-        error={Boolean(errors.sections)}
-        helperText={errors.sections}
-      />
-      <TextField
-        label="Tags (comma separated)"
-        value={tags}
-        onChange={(e) => {
-          setTags(e.target.value);
-          setErrors((prev) => ({ ...prev, tags: null }));
-        }}
-        fullWidth
-        margin="normal"
-        error={Boolean(errors.tags)}
-        helperText={errors.tags}
-      />
-      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
-        Submit
-      </Button>
-      {result && <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>}
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Species"
+            value={species}
+            onChange={(e) => {
+              setSpecies(e.target.value);
+              setErrors((prev) => ({ ...prev, species: null }));
+            }}
+            fullWidth
+            margin="normal"
+            error={Boolean(errors.species)}
+            helperText={errors.species}
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Role"
+            value={role}
+            onChange={(e) => {
+              setRole(e.target.value);
+              setErrors((prev) => ({ ...prev, role: null }));
+            }}
+            fullWidth
+            margin="normal"
+            error={Boolean(errors.role)}
+            helperText={errors.role}
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Alignment"
+            value={alignment}
+            onChange={(e) => {
+              setAlignment(e.target.value);
+              setErrors((prev) => ({ ...prev, alignment: null }));
+            }}
+            fullWidth
+            margin="normal"
+            error={Boolean(errors.alignment)}
+            helperText={errors.alignment}
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={playerCharacter}
+                onChange={(e) => setPlayerCharacter(e.target.checked)}
+              />
+            }
+            label="Player Character"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Backstory"
+            value={backstory}
+            onChange={(e) => setBackstory(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Location"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Hooks (comma separated)"
+            value={hooks}
+            onChange={(e) => {
+              setHooks(e.target.value);
+              setErrors((prev) => ({ ...prev, hooks: null }));
+            }}
+            fullWidth
+            margin="normal"
+            error={Boolean(errors.hooks)}
+            helperText={errors.hooks}
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Quirks (comma separated)"
+            value={quirks}
+            onChange={(e) => setQuirks(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Voice Style"
+            value={voiceStyle}
+            onChange={(e) => {
+              setVoiceStyle(e.target.value);
+              setErrors((prev) => ({ ...prev, ["voice.style"]: null }));
+            }}
+            fullWidth
+            margin="normal"
+            error={Boolean(errors["voice.style"])}
+            helperText={errors["voice.style"]}
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Voice Provider"
+            value={voiceProvider}
+            onChange={(e) => {
+              setVoiceProvider(e.target.value);
+              setErrors((prev) => ({ ...prev, ["voice.provider"]: null }));
+            }}
+            fullWidth
+            margin="normal"
+            error={Boolean(errors["voice.provider"])}
+            helperText={errors["voice.provider"]}
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Voice Preset"
+            value={voicePreset}
+            onChange={(e) => {
+              setVoicePreset(e.target.value);
+              setErrors((prev) => ({ ...prev, ["voice.preset"]: null }));
+            }}
+            fullWidth
+            margin="normal"
+            error={Boolean(errors["voice.preset"])}
+            helperText={errors["voice.preset"]}
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Portrait URL"
+            value={portrait}
+            onChange={(e) => setPortrait(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Icon URL"
+            value={icon}
+            onChange={(e) => setIcon(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Statblock JSON"
+            value={statblock}
+            onChange={(e) => {
+              setStatblock(e.target.value);
+              setErrors((prev) => ({ ...prev, statblock: null }));
+            }}
+            fullWidth
+            margin="normal"
+            multiline
+            error={Boolean(errors.statblock)}
+            helperText={errors.statblock}
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Custom Sections JSON"
+            value={sections}
+            onChange={(e) => {
+              setSections(e.target.value);
+              setErrors((prev) => ({ ...prev, sections: null }));
+            }}
+            fullWidth
+            margin="normal"
+            multiline
+            error={Boolean(errors.sections)}
+            helperText={errors.sections}
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Tags (comma separated)"
+            value={tags}
+            onChange={(e) => {
+              setTags(e.target.value);
+              setErrors((prev) => ({ ...prev, tags: null }));
+            }}
+            fullWidth
+            margin="normal"
+            error={Boolean(errors.tags)}
+            helperText={errors.tags}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
+            Submit
+          </Button>
+        </Grid>
+        {result && (
+          <Grid item xs={12}>
+            <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>
+          </Grid>
+        )}
+      </Grid>
     </form>
   );
 }

--- a/src/features/dnd/QuestForm.tsx
+++ b/src/features/dnd/QuestForm.tsx
@@ -4,6 +4,7 @@ import {
   TextField,
   Button,
   MenuItem,
+  Grid,
 } from "@mui/material";
 import { zQuest } from "./schemas";
 import { QuestData, DndTheme } from "./types";
@@ -57,122 +58,150 @@ export default function QuestForm() {
 
   return (
     <form onSubmit={handleSubmit}>
-      <Typography variant="h6">Quest Form</Typography>
-      <TextField
-        label="Name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Tier"
-        type="number"
-        value={tier ?? ""}
-        onChange={(e) => {
-          const val = e.target.value;
-          setTier(val === "" ? undefined : Number(val));
-          setErrors((prev) => ({ ...prev, tier: undefined }));
-        }}
-        error={!!errors.tier}
-        helperText={errors.tier}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Summary"
-        value={summary}
-        onChange={(e) => setSummary(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Beats (comma separated)"
-        value={beats}
-        onChange={(e) => setBeats(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Reward GP"
-        type="number"
-        value={gp ?? ""}
-        onChange={(e) => {
-          const val = e.target.value;
-          setGp(val === "" ? undefined : Number(val));
-          setErrors((prev) => ({ ...prev, gp: undefined }));
-        }}
-        error={!!errors.gp}
-        helperText={errors.gp}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Reward Items"
-        value={items}
-        onChange={(e) => setItems(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Reward Favors"
-        value={favors}
-        onChange={(e) => setFavors(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Complications (comma separated)"
-        value={complications}
-        onChange={(e) => setComplications(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        select
-        label="Theme"
-        value={theme}
-        onChange={(e) => setTheme(e.target.value as DndTheme)}
-        fullWidth
-        margin="normal"
-      >
-        {themes.map((t) => (
-          <MenuItem key={t} value={t}>
-            {t}
-          </MenuItem>
-        ))}
-      </TextField>
-      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
-        Submit
-      </Button>
-      <div style={{ ...themeStyles[theme], marginTop: "1rem" }}>
-        <h3>{name || "Quest Preview"}</h3>
-        {summary && (
-          <p>
-            <strong>Summary:</strong> {summary}
-          </p>
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <Typography variant="h6">Quest Form</Typography>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Tier"
+            type="number"
+            value={tier ?? ""}
+            onChange={(e) => {
+              const val = e.target.value;
+              setTier(val === "" ? undefined : Number(val));
+              setErrors((prev) => ({ ...prev, tier: undefined }));
+            }}
+            error={!!errors.tier}
+            helperText={errors.tier}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Summary"
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Beats (comma separated)"
+            value={beats}
+            onChange={(e) => setBeats(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Reward GP"
+            type="number"
+            value={gp ?? ""}
+            onChange={(e) => {
+              const val = e.target.value;
+              setGp(val === "" ? undefined : Number(val));
+              setErrors((prev) => ({ ...prev, gp: undefined }));
+            }}
+            error={!!errors.gp}
+            helperText={errors.gp}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Reward Items"
+            value={items}
+            onChange={(e) => setItems(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Reward Favors"
+            value={favors}
+            onChange={(e) => setFavors(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Complications (comma separated)"
+            value={complications}
+            onChange={(e) => setComplications(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            select
+            label="Theme"
+            value={theme}
+            onChange={(e) => setTheme(e.target.value as DndTheme)}
+            fullWidth
+            margin="normal"
+          >
+            {themes.map((t) => (
+              <MenuItem key={t} value={t}>
+                {t}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Grid>
+        <Grid item xs={12}>
+          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
+            Submit
+          </Button>
+        </Grid>
+        <Grid item xs={12}>
+          <div style={{ ...themeStyles[theme], marginTop: "1rem" }}>
+            <h3>{name || "Quest Preview"}</h3>
+            {summary && (
+              <p>
+                <strong>Summary:</strong> {summary}
+              </p>
+            )}
+            {beats && (
+              <p>
+                <strong>Beats:</strong> {beats}
+              </p>
+            )}
+            {(gp || items || favors) && (
+              <p>
+                <strong>Rewards:</strong> {gp && `GP: ${gp} `}
+                {items && `Items: ${items} `}
+                {favors && `Favors: ${favors}`}
+              </p>
+            )}
+            {complications && (
+              <p>
+                <strong>Complications:</strong> {complications}
+              </p>
+            )}
+          </div>
+        </Grid>
+        {result && (
+          <Grid item xs={12}>
+            <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>
+          </Grid>
         )}
-        {beats && (
-          <p>
-            <strong>Beats:</strong> {beats}
-          </p>
-        )}
-        {(gp || items || favors) && (
-          <p>
-            <strong>Rewards:</strong> {gp && `GP: ${gp} `}
-            {items && `Items: ${items} `}
-            {favors && `Favors: ${favors}`}
-          </p>
-        )}
-        {complications && (
-          <p>
-            <strong>Complications:</strong> {complications}
-          </p>
-        )}
-      </div>
-      {result && (
-        <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>
-      )}
+      </Grid>
     </form>
   );
 }

--- a/src/features/dnd/RuleForm.tsx
+++ b/src/features/dnd/RuleForm.tsx
@@ -7,6 +7,7 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  Grid,
 } from "@mui/material";
 import { zRule } from "./schemas";
 import type { RuleData } from "./types";
@@ -67,56 +68,74 @@ export default function RuleForm() {
 
   return (
     <form onSubmit={handleSubmit}>
-      <Typography variant="h6">Rulebook</Typography>
-      <RulePdfUpload />
-      <FormControl fullWidth margin="normal">
-        <InputLabel id="rule-select-label">Base Rule</InputLabel>
-        <Select
-          labelId="rule-select-label"
-          value={selectedId}
-          label="Base Rule"
-          onChange={handleSelect}
-        >
-          <MenuItem value="new">Create New Rule</MenuItem>
-          {existingRules.map((r) => (
-            <MenuItem key={r.id} value={r.id}>
-              {r.name}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
-      <TextField
-        label="Name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Description"
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-        fullWidth
-        multiline
-        margin="normal"
-      />
-      <TextField
-        label="Tags (comma separated)"
-        value={tags}
-        onChange={(e) => setTags(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
-        Submit
-      </Button>
-      {result && (
-        <pre style={{ marginTop: "1rem" }}>
-          {originalRule &&
-            `Original:\n${JSON.stringify(originalRule, null, 2)}\n\n`}
-          {`Custom:\n${JSON.stringify(result, null, 2)}`}
-        </pre>
-      )}
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <Typography variant="h6">Rulebook</Typography>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <RulePdfUpload />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <FormControl fullWidth margin="normal">
+            <InputLabel id="rule-select-label">Base Rule</InputLabel>
+            <Select
+              labelId="rule-select-label"
+              value={selectedId}
+              label="Base Rule"
+              onChange={handleSelect}
+            >
+              <MenuItem value="new">Create New Rule</MenuItem>
+              {existingRules.map((r) => (
+                <MenuItem key={r.id} value={r.id}>
+                  {r.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            fullWidth
+            multiline
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Tags (comma separated)"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
+            Submit
+          </Button>
+        </Grid>
+        {result && (
+          <Grid item xs={12}>
+            <pre style={{ marginTop: "1rem" }}>
+              {originalRule &&
+                `Original:\n${JSON.stringify(originalRule, null, 2)}\n\n`}
+              {`Custom:\n${JSON.stringify(result, null, 2)}`}
+            </pre>
+          </Grid>
+        )}
+      </Grid>
     </form>
   );
 }

--- a/src/features/dnd/SpellForm.tsx
+++ b/src/features/dnd/SpellForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Typography, TextField, Button } from "@mui/material";
+import { Typography, TextField, Button, Grid } from "@mui/material";
 import SpellPdfUpload from "./SpellPdfUpload";
 import { zSpell } from "./schemas";
 import type { SpellData } from "./types";
@@ -36,76 +36,106 @@ export default function SpellForm() {
 
   return (
     <form onSubmit={handleSubmit}>
-      <Typography variant="h6">Spellbook</Typography>
-      <SpellPdfUpload />
-      <TextField
-        label="Name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Level"
-        value={level}
-        onChange={(e) => setLevel(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="School"
-        value={school}
-        onChange={(e) => setSchool(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Casting Time"
-        value={castingTime}
-        onChange={(e) => setCastingTime(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Range"
-        value={range}
-        onChange={(e) => setRange(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Components (comma separated)"
-        value={components}
-        onChange={(e) => setComponents(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Duration"
-        value={duration}
-        onChange={(e) => setDuration(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <TextField
-        label="Description"
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-        fullWidth
-        multiline
-        margin="normal"
-      />
-      <TextField
-        label="Tags (comma separated)"
-        value={tags}
-        onChange={(e) => setTags(e.target.value)}
-        fullWidth
-        margin="normal"
-      />
-      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
-        Submit
-      </Button>
-      {result && <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>}
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <Typography variant="h6">Spellbook</Typography>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <SpellPdfUpload />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Level"
+            value={level}
+            onChange={(e) => setLevel(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="School"
+            value={school}
+            onChange={(e) => setSchool(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Casting Time"
+            value={castingTime}
+            onChange={(e) => setCastingTime(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Range"
+            value={range}
+            onChange={(e) => setRange(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Components (comma separated)"
+            value={components}
+            onChange={(e) => setComponents(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Duration"
+            value={duration}
+            onChange={(e) => setDuration(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            fullWidth
+            multiline
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Tags (comma separated)"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            fullWidth
+            margin="normal"
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
+            Submit
+          </Button>
+        </Grid>
+        {result && (
+          <Grid item xs={12}>
+            <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>
+          </Grid>
+        )}
+      </Grid>
     </form>
   );
 }


### PR DESCRIPTION
## Summary
- use MUI Grid to organize all DnD forms into two-column layouts
- expand submit buttons and previews to full width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa9fc0ebe08325bfbff0bdc833db03