### PR TITLE
Use timezone-aware timestamp conversions

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,7 +12,7 @@ use dirs;
 
 use crate::stocks::{stocks_fetch as stocks_fetch_impl, StockBundle};
 use crate::task_queue::{Task, TaskCommand, TaskQueue};
-use chrono::{Local, NaiveDateTime};
+use chrono::{DateTime, Local, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_yaml;
@@ -1483,7 +1483,7 @@ pub async fn stock_forecast<R: Runtime>(
     let mut recent_parts = Vec::new();
     for (ts, close) in timestamps.iter().zip(closes.iter()) {
         if let (Some(ts), Some(price)) = (ts.as_i64(), close.as_f64()) {
-            if let Some(dt) = NaiveDateTime::from_timestamp_opt(ts, 0) {
+            if let Some(dt) = DateTime::<Utc>::from_timestamp(ts, 0) {
                 let date = dt.format("%Y-%m-%d").to_string();
                 recent_parts.push(format!("{date}: {:.2}", price));
             }
@@ -1507,7 +1507,7 @@ pub async fn stock_forecast<R: Runtime>(
     let mut long_parts = Vec::new();
     for (ts, close) in timestamps.iter().zip(closes.iter()) {
         if let (Some(ts), Some(price)) = (ts.as_i64(), close.as_f64()) {
-            if let Some(dt) = NaiveDateTime::from_timestamp_opt(ts, 0) {
+            if let Some(dt) = DateTime::<Utc>::from_timestamp(ts, 0) {
                 let date = dt.format("%Y-%m-%d").to_string();
                 long_parts.push(format!("{date}: {:.2}", price));
             }
@@ -1575,7 +1575,7 @@ pub async fn fetch_stock_news(symbol: String) -> Result<Vec<NewsArticle>, String
         let summary = item["summary"].as_str().unwrap_or("").to_string();
         let ts = item["time_published"].as_str().unwrap_or("");
         let timestamp = NaiveDateTime::parse_from_str(ts, "%Y%m%dT%H%M%S")
-            .map(|dt| dt.timestamp())
+            .map(|dt| dt.and_utc().timestamp())
             .unwrap_or(0);
         if !title.is_empty() && !link.is_empty() {
             out.push(NewsArticle {

--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -145,11 +145,11 @@ impl TaskQueue {
                                     (l.cpu, l.memory)
                                 };
                                 let mut sys = System::new();
-                                sys.refresh_cpu();
+                                sys.refresh_cpu_all();
                                 std::thread::sleep(Duration::from_millis(100));
-                                sys.refresh_cpu();
+                                sys.refresh_cpu_all();
                                 sys.refresh_memory();
-                                let cpu_usage = sys.global_cpu_info().cpu_usage();
+                                let cpu_usage = sys.global_cpu_usage();
                                 let mem_usage = if sys.total_memory() > 0 {
                                     (sys.used_memory() as f32 / sys.total_memory() as f32) * 100.0
                                 } else {


### PR DESCRIPTION
## Summary
- switch stock timestamp parsing to `DateTime::<Utc>::from_timestamp`
- avoid deprecated `NaiveDateTime::timestamp` via `and_utc().timestamp()`
- update sysinfo API calls to `refresh_cpu_all`/`global_cpu_usage`

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_68aaa24e51848325be76b8f3084f4c69