### PR TITLE
Update CPU usage calls in task queue

### DIFF
--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -145,11 +145,11 @@ impl TaskQueue {
                                     (l.cpu, l.memory)
                                 };
                                 let mut sys = System::new();
-                                sys.refresh_cpu();
+                                sys.refresh_cpu_usage();
                                 std::thread::sleep(Duration::from_millis(100));
-                                sys.refresh_cpu();
+                                sys.refresh_cpu_usage();
                                 sys.refresh_memory();
-                                let cpu_usage = sys.global_cpu_info().cpu_usage();
+                                let cpu_usage = sys.global_cpu_usage();
                                 let mem_usage = if sys.total_memory() > 0 {
                                     (sys.used_memory() as f32 / sys.total_memory() as f32) * 100.0
                                 } else {


### PR DESCRIPTION
## Summary
- replace deprecated `refresh_cpu` with `refresh_cpu_usage`
- use `global_cpu_usage` API instead of `global_cpu_info().cpu_usage()`

## Testing
- `cargo build --manifest-path src-tauri/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68aaa48ee2f88325b7ef392d34db5fdb