### PR TITLE
Use refresh_cpu_usage for CPU metrics

### DIFF
--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -145,9 +145,9 @@ impl TaskQueue {
                                     (l.cpu, l.memory)
                                 };
                                 let mut sys = System::new();
-                                sys.refresh_cpu_all();
+                                sys.refresh_cpu_usage();
                                 std::thread::sleep(Duration::from_millis(100));
-                                sys.refresh_cpu_all();
+                                sys.refresh_cpu_usage();
                                 sys.refresh_memory();
                                 let cpu_usage = sys.global_cpu_usage();
                                 let mem_usage = if sys.total_memory() > 0 {


### PR DESCRIPTION
## Summary
- replace deprecated `refresh_cpu_all` with `refresh_cpu_usage`
- continue using `global_cpu_usage` to read aggregate CPU load

## Testing
- `cargo test` *(fails: javascriptcoregtk-4.1 library missing)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa72a02bc8325a7373f7209a4b220