### PR TITLE
feat: add theme selector and context for DnD forms

### DIFF
--- a/src/features/dnd/EncounterForm.tsx
+++ b/src/features/dnd/EncounterForm.tsx
@@ -1,15 +1,9 @@
 import { useState } from "react";
-import {
-  Typography,
-  TextField,
-  Button,
-  MenuItem,
-  Grid,
-} from "@mui/material";
+import { Typography, TextField, Button, Grid, Box } from "@mui/material";
 import FormErrorText from "./FormErrorText";
 import { zEncounter } from "./schemas";
-import { EncounterData, DndTheme } from "./types";
-import { themes, themeStyles } from "./theme";
+import { EncounterData } from "./types";
+import { themeStyles, useDndTheme } from "./theme";
 
 export default function EncounterForm() {
   const [name, setName] = useState("");
@@ -19,9 +13,9 @@ export default function EncounterForm() {
   const [terrain, setTerrain] = useState("");
   const [treasure, setTreasure] = useState("");
   const [scaling, setScaling] = useState("");
-  const [theme, setTheme] = useState<DndTheme>("Parchment");
   const [result, setResult] = useState<EncounterData | null>(null);
   const [errors, setErrors] = useState<{ level?: string }>({});
+  const theme = useDndTheme();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -48,7 +42,7 @@ export default function EncounterForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <Box component="form" onSubmit={handleSubmit} sx={themeStyles[theme]}>
       <Grid container spacing={2}>
         <Grid item xs={12}>
           <Typography variant="h6">Encounter Form</Typography>
@@ -126,22 +120,6 @@ export default function EncounterForm() {
             margin="normal"
           />
         </Grid>
-        <Grid item xs={12} md={6}>
-          <TextField
-            select
-            label="Theme"
-            value={theme}
-            onChange={(e) => setTheme(e.target.value as DndTheme)}
-            fullWidth
-            margin="normal"
-          >
-            {themes.map((t) => (
-              <MenuItem key={t} value={t}>
-                {t}
-              </MenuItem>
-            ))}
-          </TextField>
-        </Grid>
         <Grid item xs={12}>
           <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
             Submit
@@ -188,6 +166,6 @@ export default function EncounterForm() {
           </Grid>
         )}
       </Grid>
-    </form>
+    </Box>
   );
 }

--- a/src/features/dnd/LoreForm.tsx
+++ b/src/features/dnd/LoreForm.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { Typography, TextField, Button, MenuItem, Grid } from "@mui/material";
+import { Typography, TextField, Button, MenuItem, Grid, Box } from "@mui/material";
 import { zLore } from "./schemas";
 import { LoreData } from "./types";
 import { useWorlds } from "../../store/worlds";
 import LorePdfUpload from "./LorePdfUpload";
+import { useDndTheme, themeStyles } from "./theme";
 
 export default function LoreForm() {
   const [name, setName] = useState("");
@@ -14,6 +15,7 @@ export default function LoreForm() {
   const [result, setResult] = useState<LoreData | null>(null);
   const worlds = useWorlds((s) => s.worlds);
   const [world, setWorld] = useState("");
+  const theme = useDndTheme();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -32,7 +34,7 @@ export default function LoreForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <Box component="form" onSubmit={handleSubmit} sx={themeStyles[theme]}>
       <Grid container spacing={2}>
         <Grid item xs={12}>
           <Typography variant="h6">Lore Form</Typography>
@@ -114,6 +116,6 @@ export default function LoreForm() {
           </Grid>
         )}
       </Grid>
-    </form>
+    </Box>
   );
 }

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -7,6 +7,7 @@ import {
   Checkbox,
   MenuItem,
   Grid,
+  Box,
 } from "@mui/material";
 import FormErrorText from "./FormErrorText";
 import { z } from "zod";
@@ -14,6 +15,7 @@ import { zNpc } from "../../dnd/schemas/npc";
 import { NpcData } from "./types";
 import { useWorlds } from "../../store/worlds";
 import NpcPdfUpload from "./NpcPdfUpload";
+import { useDndTheme, themeStyles } from "./theme";
 
 export default function NpcForm() {
   const [name, setName] = useState("");
@@ -37,6 +39,7 @@ export default function NpcForm() {
   const [result, setResult] = useState<NpcData | null>(null);
   const worlds = useWorlds((s) => s.worlds);
   const [world, setWorld] = useState("");
+  const theme = useDndTheme();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -97,7 +100,7 @@ export default function NpcForm() {
     }
   };
   return (
-    <form onSubmit={handleSubmit}>
+    <Box component="form" onSubmit={handleSubmit} sx={themeStyles[theme]}>
       <Grid container spacing={2}>
         <Grid item xs={12}>
           <Typography variant="h6">NPC Form</Typography>
@@ -401,6 +404,6 @@ export default function NpcForm() {
           </Grid>
         )}
       </Grid>
-    </form>
+    </Box>
   );
 }

--- a/src/features/dnd/QuestForm.tsx
+++ b/src/features/dnd/QuestForm.tsx
@@ -1,15 +1,9 @@
 import { useState } from "react";
-import {
-  Typography,
-  TextField,
-  Button,
-  MenuItem,
-  Grid,
-} from "@mui/material";
+import { Typography, TextField, Button, Grid, Box } from "@mui/material";
 import FormErrorText from "./FormErrorText";
 import { zQuest } from "./schemas";
-import { QuestData, DndTheme } from "./types";
-import { themes, themeStyles } from "./theme";
+import { QuestData } from "./types";
+import { themeStyles, useDndTheme } from "./theme";
 
 export default function QuestForm() {
   const [name, setName] = useState("");
@@ -20,9 +14,9 @@ export default function QuestForm() {
   const [items, setItems] = useState("");
   const [favors, setFavors] = useState("");
   const [complications, setComplications] = useState("");
-  const [theme, setTheme] = useState<DndTheme>("Parchment");
   const [result, setResult] = useState<QuestData | null>(null);
   const [errors, setErrors] = useState<{ tier?: string; gp?: string }>({});
+  const theme = useDndTheme();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -58,7 +52,7 @@ export default function QuestForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <Box component="form" onSubmit={handleSubmit} sx={themeStyles[theme]}>
       <Grid container spacing={2}>
         <Grid item xs={12}>
           <Typography variant="h6">Quest Form</Typography>
@@ -155,22 +149,6 @@ export default function QuestForm() {
             margin="normal"
           />
         </Grid>
-        <Grid item xs={12} md={6}>
-          <TextField
-            select
-            label="Theme"
-            value={theme}
-            onChange={(e) => setTheme(e.target.value as DndTheme)}
-            fullWidth
-            margin="normal"
-          >
-            {themes.map((t) => (
-              <MenuItem key={t} value={t}>
-                {t}
-              </MenuItem>
-            ))}
-          </TextField>
-        </Grid>
         <Grid item xs={12}>
           <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
             Submit
@@ -209,6 +187,6 @@ export default function QuestForm() {
           </Grid>
         )}
       </Grid>
-    </form>
+    </Box>
   );
 }

--- a/src/features/dnd/RuleForm.tsx
+++ b/src/features/dnd/RuleForm.tsx
@@ -8,11 +8,13 @@ import {
   Select,
   MenuItem,
   Grid,
+  Box,
 } from "@mui/material";
 import { zRule } from "./schemas";
 import type { RuleData } from "./types";
 import rulesIndex from "../../../dnd/rules/index.json";
 import RulePdfUpload from "./RulePdfUpload";
+import { useDndTheme, themeStyles } from "./theme";
 
 const ruleFiles = import.meta.glob("../../../dnd/rules/*.md", {
   as: "raw",
@@ -33,6 +35,7 @@ export default function RuleForm() {
   const [tags, setTags] = useState("");
   const [result, setResult] = useState<RuleData | null>(null);
   const [originalRule, setOriginalRule] = useState<RuleData | null>(null);
+  const theme = useDndTheme();
 
   const handleSelect = (e: any) => {
     const id = e.target.value;
@@ -67,7 +70,7 @@ export default function RuleForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <Box component="form" onSubmit={handleSubmit} sx={themeStyles[theme]}>
       <Grid container spacing={2}>
         <Grid item xs={12}>
           <Typography variant="h6">Rulebook</Typography>
@@ -136,6 +139,6 @@ export default function RuleForm() {
           </Grid>
         )}
       </Grid>
-    </form>
+    </Box>
   );
 }

--- a/src/features/dnd/SpellForm.tsx
+++ b/src/features/dnd/SpellForm.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
-import { Typography, TextField, Button, Grid } from "@mui/material";
+import { Typography, TextField, Button, Grid, Box } from "@mui/material";
 import SpellPdfUpload from "./SpellPdfUpload";
 import { zSpell } from "./schemas";
 import type { SpellData } from "./types";
+import { useDndTheme, themeStyles } from "./theme";
 
 export default function SpellForm() {
   const [name, setName] = useState("");
@@ -15,6 +16,7 @@ export default function SpellForm() {
   const [description, setDescription] = useState("");
   const [tags, setTags] = useState("");
   const [result, setResult] = useState<SpellData | null>(null);
+  const theme = useDndTheme();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -35,7 +37,7 @@ export default function SpellForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <Box component="form" onSubmit={handleSubmit} sx={themeStyles[theme]}>
       <Grid container spacing={2}>
         <Grid item xs={12}>
           <Typography variant="h6">Spellbook</Typography>
@@ -136,6 +138,6 @@ export default function SpellForm() {
           </Grid>
         )}
       </Grid>
-    </form>
+    </Box>
   );
 }

--- a/src/features/dnd/theme.ts
+++ b/src/features/dnd/theme.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties } from "react";
+import { type CSSProperties, createContext, useContext } from "react";
 import { DndTheme } from "./types";
 
 export const themes: DndTheme[] = ["Parchment", "Ink", "Minimal"];
@@ -21,3 +21,7 @@ export const themeStyles: Record<DndTheme, CSSProperties> = {
     fontFamily: "sans-serif",
   },
 };
+
+export const DndThemeContext = createContext<DndTheme>("Parchment");
+
+export const useDndTheme = () => useContext(DndThemeContext);

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -1,4 +1,4 @@
-import { Box, Tab, Tabs } from "@mui/material";
+import { Box, Tab, Tabs, TextField, MenuItem } from "@mui/material";
 import {
   Person,
   MenuBook,
@@ -11,6 +11,8 @@ import {
   MilitaryTech,
 } from "@mui/icons-material";
 import { SyntheticEvent, useState } from "react";
+import { DndThemeContext, themes } from "../features/dnd/theme";
+import type { DndTheme } from "../features/dnd/types";
 import NpcForm from "../features/dnd/NpcForm";
 import LoreForm from "../features/dnd/LoreForm";
 import QuestForm from "../features/dnd/QuestForm";
@@ -23,35 +25,53 @@ import WarTable from "../features/dnd/WarTable";
 
 export default function DND() {
   const [tab, setTab] = useState(0);
+  const [selectedTheme, setSelectedTheme] = useState<DndTheme>("Parchment");
   const handleChange = (_e: SyntheticEvent, v: number) => setTab(v);
   return (
-    <Box sx={{ p: 2 }}>
-      <Tabs
-        value={tab}
-        onChange={handleChange}
-        variant="scrollable"
-        scrollButtons="auto"
-        sx={{ bgcolor: "#f3e5ab" }}
-      >
-        <Tab icon={<Person />} label="NPC" />
-        <Tab icon={<MenuBook />} label="Lore" />
-        <Tab icon={<TravelExplore />} label="Quest" />
-        <Tab icon={<SportsKabaddi />} label="Encounter" />
-        <Tab icon={<Gavel />} label="Rulebook" />
-        <Tab icon={<AutoStories />} label="Spellbook" />
-        <Tab icon={<Casino />} label="Dice" />
-        <Tab icon={<Map />} label="Tabletop" />
-        <Tab icon={<MilitaryTech />} label="War Table" />
-      </Tabs>
-      {tab === 0 && <NpcForm />}
-      {tab === 1 && <LoreForm />}
-      {tab === 2 && <QuestForm />}
-      {tab === 3 && <EncounterForm />}
-      {tab === 4 && <RuleForm />}
-      {tab === 5 && <SpellForm />}
-      {tab === 6 && <DiceRoller />}
-      {tab === 7 && <TabletopMap />}
-      {tab === 8 && <WarTable />}
-    </Box>
+    <DndThemeContext.Provider value={selectedTheme}>
+      <Box sx={{ p: 2 }}>
+        <Tabs
+          value={tab}
+          onChange={handleChange}
+          variant="scrollable"
+          scrollButtons="auto"
+          sx={{ bgcolor: "#f3e5ab" }}
+        >
+          <Tab icon={<Person />} label="NPC" />
+          <Tab icon={<MenuBook />} label="Lore" />
+          <Tab icon={<TravelExplore />} label="Quest" />
+          <Tab icon={<SportsKabaddi />} label="Encounter" />
+          <Tab icon={<Gavel />} label="Rulebook" />
+          <Tab icon={<AutoStories />} label="Spellbook" />
+          <Tab icon={<Casino />} label="Dice" />
+          <Tab icon={<Map />} label="Tabletop" />
+          <Tab icon={<MilitaryTech />} label="War Table" />
+        </Tabs>
+        <Box sx={{ my: 2, maxWidth: 200 }}>
+          <TextField
+            select
+            label="Theme"
+            value={selectedTheme}
+            onChange={(e) => setSelectedTheme(e.target.value as DndTheme)}
+            fullWidth
+          >
+            {themes.map((t) => (
+              <MenuItem key={t} value={t}>
+                {t}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Box>
+        {tab === 0 && <NpcForm />}
+        {tab === 1 && <LoreForm />}
+        {tab === 2 && <QuestForm />}
+        {tab === 3 && <EncounterForm />}
+        {tab === 4 && <RuleForm />}
+        {tab === 5 && <SpellForm />}
+        {tab === 6 && <DiceRoller />}
+        {tab === 7 && <TabletopMap />}
+        {tab === 8 && <WarTable />}
+      </Box>
+    </DndThemeContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- add DnD theme context and style definitions
- allow users to choose DnD theme on the DND page
- apply selected theme to all DnD forms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa8c228108325b6708a8a81c96211