### PR TITLE
Fix task progress percentage

### DIFF
--- a/src/components/TaskQueue/TaskList.tsx
+++ b/src/components/TaskQueue/TaskList.tsx
@@ -48,7 +48,7 @@ export default function TaskList() {
             </Typography>
             <LinearProgress
               variant="determinate"
-              value={task.progress}
+              value={Math.max(0, Math.min(100, task.progress * 100))}
               sx={{ my: 0.5 }}
             />
             <Box sx={{ display: "flex", justifyContent: "space-between" }}>


### PR DESCRIPTION
## Summary
- Convert task progress to percentage for `LinearProgress`
- Clamp progress value between 0 and 100 to prevent overflow

## Testing
- `npm test -- --run`
- `npm run build` *(fails: TS6133 React is declared but its value is never read)*

------
https://chatgpt.com/codex/tasks/task_e_68aaad4c827083258cf3ec1ff9967073