### PR TITLE
feat: show render progress in song form

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -24,6 +24,10 @@ vi.mock('../features/lofi/SongForm', () => ({
     setSeed: vi.fn(),
   }),
 }));
+vi.mock('../store/tasks', () => ({
+  useTasks: (selector: any) =>
+    selector({ tasks: {}, subscribe: vi.fn().mockResolvedValue(() => {}) }),
+}));
 
 function openSection(id: string) {
   const summary = screen.getByTestId(id).querySelector('summary') as HTMLElement;


### PR DESCRIPTION
## Summary
- subscribe SongForm to the task store and derive progress from active song/album tasks
- mock task store in SongForm tests to accommodate new subscription

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaad3da0bc832595231a274b1786f8