### PR TITLE
Handle TaskList subscription errors

### DIFF
--- a/src/components/TaskQueue/TaskList.tsx
+++ b/src/components/TaskQueue/TaskList.tsx
@@ -9,9 +9,14 @@ export default function TaskList() {
 
   useEffect(() => {
     let unlisten: (() => void) | null = null;
-    subscribe().then((u) => {
-      unlisten = u;
-    });
+    (async () => {
+      try {
+        unlisten = await subscribe();
+      } catch (err) {
+        console.error("Failed to subscribe", err);
+        unlisten?.();
+      }
+    })();
     return () => {
       unlisten?.();
     };


### PR DESCRIPTION
## Summary
- Wrap TaskList subscription in async IIFE with try/catch
- Log failed subscriptions and ensure cleanup always runs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aab1c0708c83259a7ef148d3ea8498