### PR TITLE
feat: add accessible tooltips to song form

### DIFF
--- a/src/components/HelpIcon.tsx
+++ b/src/components/HelpIcon.tsx
@@ -1,10 +1,38 @@
+import { useState } from "react";
 import { FaQuestionCircle } from "react-icons/fa";
+import Tooltip from "@mui/material/Tooltip";
+import IconButton from "@mui/material/IconButton";
 
 export default function HelpIcon({ text }: { text: string }) {
+  const [open, setOpen] = useState(false);
   return (
-    <FaQuestionCircle
+    <Tooltip
       title={text}
-      style={{ marginLeft: 4, cursor: "help", opacity: 0.6 }}
-    />
+      open={open}
+      onClose={() => setOpen(false)}
+      disableFocusListener
+      disableHoverListener
+      disableTouchListener
+      arrow
+    >
+      <IconButton
+        size="small"
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((o) => !o);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") setOpen(false);
+        }}
+        aria-label="help"
+        style={{ marginLeft: 4, padding: 2, cursor: "help", opacity: 0.6 }}
+      >
+        <FaQuestionCircle />
+      </IconButton>
+    </Tooltip>
   );
 }

--- a/src/components/PolishControls.tsx
+++ b/src/components/PolishControls.tsx
@@ -35,13 +35,16 @@ export default function PolishControls({
   return (
     <div className={clsx(styles.panel, "mt-3")}>
       <details open>
-        <summary className="cursor-pointer text-xs opacity-80">
-          Polish <HelpIcon text="Optional mix polish effects" />
-        </summary>
+          <summary className="cursor-pointer text-xs opacity-80">
+            Polish <HelpIcon text="Optional mix polish effects" />
+          </summary>
         <div className="mt-2">
           <div className={styles.optionGrid}>
             <label className={styles.optionCard}>
-              <span>Stereo widen</span>
+              <span>
+                Stereo widen
+                <HelpIcon text="Expands stereo field (default off)" />
+              </span>
               <input
                 type="checkbox"
                 checked={hqStereo}
@@ -49,7 +52,10 @@ export default function PolishControls({
               />
             </label>
             <label className={styles.optionCard}>
-              <span>Room reverb</span>
+              <span>
+                Room reverb
+                <HelpIcon text="Adds small-room ambience (default off)" />
+              </span>
               <input
                 type="checkbox"
                 checked={hqReverb}
@@ -57,7 +63,10 @@ export default function PolishControls({
               />
             </label>
             <label className={styles.optionCard}>
-              <span>Sidechain (kick)</span>
+              <span>
+                Sidechain (kick)
+                <HelpIcon text="Pump mix with kick drum (default off)" />
+              </span>
               <input
                 type="checkbox"
                 checked={hqSidechain}
@@ -65,7 +74,10 @@ export default function PolishControls({
               />
             </label>
             <label className={styles.optionCard}>
-              <span>Chorus</span>
+              <span>
+                Chorus
+                <HelpIcon text="Adds gentle chorus effect (default off)" />
+              </span>
               <input
                 type="checkbox"
                 checked={hqChorus}
@@ -80,7 +92,7 @@ export default function PolishControls({
             <div className="mt-2">
               <label className={styles.label}>
                 Limiter Drive
-                <HelpIcon text="Amount of saturation added by the limiter" />
+                <HelpIcon text="Limiter saturation amount (1.00 neutral)" />
               </label>
               <input
                 type="range"
@@ -92,14 +104,17 @@ export default function PolishControls({
                 className={styles.slider}
               />
               <div className={styles.small}>{limiterDrive.toFixed(2)}× saturation</div>
-              <div className={clsx(styles.toggle, "mt-2")}>
+              <label className={clsx(styles.toggle, "mt-2")}>
                 <input
                   type="checkbox"
                   checked={dither}
                   onChange={(e) => setDither(e.target.checked)}
                 />
-                <span className={styles.small}>Dither</span>
-              </div>
+                <span className={styles.small}>
+                  Dither
+                  <HelpIcon text="Adds subtle noise for smoother export (default off)" />
+                </span>
+              </label>
             </div>
           </details>
         </div>

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -874,8 +874,13 @@ export default function SongForm() {
         </div>
 
         {/* title + output folder */}
+        <label htmlFor="titleBase" className={styles.label}>
+          Song Title Base
+          <HelpIcon text="Base title for songs, e.g., 'Morning Chill'" />
+        </label>
         <div className={styles.row}>
           <input
+            id="titleBase"
             className={styles.input}
             placeholder="Song title base"
             value={titleBase}
@@ -898,60 +903,92 @@ export default function SongForm() {
         <details className="mt-3">
           <summary className="cursor-pointer text-xs opacity-80">Core</summary>
           <div className={styles.grid3}>
-          <div className={styles.panel}>
-            <label className={styles.label}>
-              BPM: {bpm}
-              <HelpIcon text="Song tempo in beats per minute" />
-            </label>
-            <input
-              type="range"
-              min={60}
-              max={200}
-              value={bpm}
-              onChange={(e) => setBpm(Number(e.target.value))}
-              className={clsx(styles.input, "p-0")}
-            />
-          </div>
-          <div className={styles.panel}>
-            <label className={styles.label}>
-              Key
-              <HelpIcon text="Musical key; choose Auto for random" />
-            </label>
-            <div className={styles.row}>
-              <select value={key} onChange={(e) => setKey(e.target.value)} className={clsx(styles.input, "py-2 px-3") }>
-                {KEYS.map((k) => (
-                  <option key={k} value={k}>{displayKey(k)}</option>
-                ))}
-              </select>
-            </div>
-            <div className={clsx(styles.toggle, "mt-2") }>
-              <input type="checkbox" checked={autoKeyPerSong} onChange={(e) => setAutoKeyPerSong(e.target.checked)} disabled={key === "Auto"} />
-              <span className={styles.small}>Rotate key per song</span>
-            </div>
-            {key === "Auto" && (
-              <div className={styles.small}>Disabled when key is set to Auto</div>
-            )}
-          </div>
-          <div className={styles.panel}>
-            <label className={styles.label}>
-              Seed
-              <HelpIcon text="Randomness seed for reproducibility" />
-            </label>
-            <input
-              type="number"
-              value={seedBase}
-              onChange={(e) => setSeedBase(Number(e.target.value || 0))}
-              className={styles.input}
-            />
-            <div className={clsx(styles.row, "mt-2") }>
-              <label className={clsx(styles.small, "flex-1") }>
-                <input type="radio" name="seedmode" checked={seedMode === "increment"} onChange={() => setSeedMode("increment")} /> Increment (base + i)
+            <div className={styles.panel}>
+              <label htmlFor="bpm" className={styles.label}>
+                BPM: {bpm}
+                <HelpIcon text="Song tempo in beats per minute (e.g., 90)" />
               </label>
-              <label className={clsx(styles.small, "flex-1") }>
-                <input type="radio" name="seedmode" checked={seedMode === "random"} onChange={() => setSeedMode("random")} /> Deterministic random
-              </label>
+              <input
+                id="bpm"
+                type="range"
+                min={60}
+                max={200}
+                value={bpm}
+                onChange={(e) => setBpm(Number(e.target.value))}
+                className={clsx(styles.input, "p-0")}
+              />
             </div>
-          </div>
+            <div className={styles.panel}>
+              <label htmlFor="key" className={styles.label}>
+                Key
+                <HelpIcon text="Musical key (e.g., C minor). Choose Auto for random." />
+              </label>
+              <div className={styles.row}>
+                <select
+                  id="key"
+                  value={key}
+                  onChange={(e) => setKey(e.target.value)}
+                  className={clsx(styles.input, "py-2 px-3")}
+                >
+                  {KEYS.map((k) => (
+                    <option key={k} value={k}>{displayKey(k)}</option>
+                  ))}
+                </select>
+              </div>
+              <label className={clsx(styles.toggle, "mt-2") } htmlFor="autoKeyPerSong">
+                <input
+                  id="autoKeyPerSong"
+                  type="checkbox"
+                  checked={autoKeyPerSong}
+                  onChange={(e) => setAutoKeyPerSong(e.target.checked)}
+                  disabled={key === "Auto"}
+                />
+                <span className={styles.small}>
+                  Rotate key per song
+                  <HelpIcon text="Cycle through different keys for each song" />
+                </span>
+              </label>
+              {key === "Auto" && (
+                <div className={styles.small}>Disabled when key is set to Auto</div>
+              )}
+            </div>
+            <div className={styles.panel}>
+              <label htmlFor="seed" className={styles.label}>
+                Seed
+                <HelpIcon text="Randomness seed for reproducibility (default 12345)" />
+              </label>
+              <input
+                id="seed"
+                type="number"
+                value={seedBase}
+                onChange={(e) => setSeedBase(Number(e.target.value || 0))}
+                className={styles.input}
+              />
+              <fieldset className={clsx(styles.row, "mt-2")}>
+                <legend className={styles.small}>
+                  Seed Mode
+                  <HelpIcon text="How to vary the seed between songs" />
+                </legend>
+                <label className={clsx(styles.small, "flex-1") } htmlFor="seedmode-increment">
+                  <input
+                    id="seedmode-increment"
+                    type="radio"
+                    name="seedmode"
+                    checked={seedMode === "increment"}
+                    onChange={() => setSeedMode("increment")}
+                  /> Increment (base + i)
+                </label>
+                <label className={clsx(styles.small, "flex-1") } htmlFor="seedmode-random">
+                  <input
+                    id="seedmode-random"
+                    type="radio"
+                    name="seedmode"
+                    checked={seedMode === "random"}
+                    onChange={() => setSeedMode("random")}
+                  /> Deterministic random
+                </label>
+              </fieldset>
+            </div>
           </div>
         </details>
 
@@ -959,8 +996,13 @@ export default function SongForm() {
         <details className={clsx(styles.panel, "mt-3")}>
           <summary className="cursor-pointer text-xs opacity-80">Structure</summary>
           <div className="mt-2">
-          <div className={clsx(styles.row, "mb-2")}>
+          <label htmlFor="templateSelect" className={styles.label}>
+            Structure Template
+            <HelpIcon text="Choose a structure template" />
+          </label>
+          <div className={clsx(styles.row, "mb-2")}> 
             <select
+              id="templateSelect"
               value={selectedTemplate}
               onChange={(e) => {
                 const name = e.target.value;
@@ -983,7 +1025,11 @@ export default function SongForm() {
             {selectedTemplate === "" &&
               (creatingTemplate ? (
                 <>
+                  <label htmlFor="newTemplateName" className="sr-only">
+                    Template name
+                  </label>
                   <input
+                    id="newTemplateName"
                     className={styles.input}
                     placeholder="Template name"
                     value={newTemplateName}
@@ -1043,8 +1089,13 @@ export default function SongForm() {
                 </button>
               ))}
           </div>
-          <div className={clsx(styles.row, "mb-2")}>
+          <label htmlFor="sectionPreset" className={styles.label}>
+            Preset Layout
+            <HelpIcon text="Quickly apply a predefined arrangement" />
+          </label>
+          <div className={clsx(styles.row, "mb-2")}> 
             <select
+              id="sectionPreset"
               value={sectionPreset}
               onChange={(e) => {
                 const name = e.target.value;
@@ -1075,8 +1126,12 @@ export default function SongForm() {
                 className="p-2 rounded-lg min-w-[120px]"
                 style={{ backgroundColor: theme.palette.action.hover }}
               >
-                <div className={styles.small}>{sec.name}</div>
+                <label htmlFor={`bars-${i}`} className={styles.small}>
+                  {sec.name} Bars
+                  <HelpIcon text="Number of bars in this section" />
+                </label>
                 <input
+                  id={`bars-${i}`}
                   type="number"
                   value={sec.barsStr ?? String(sec.bars)}
                   onChange={(e) => {
@@ -1109,7 +1164,12 @@ export default function SongForm() {
                     Enter bars ≥1
                   </div>
                 ) : null}
+                <label htmlFor={`chords-${i}`} className={styles.small}>
+                  Chords
+                  <HelpIcon text="Chord progression, e.g., Cmaj7 Fmaj7" />
+                </label>
                 <input
+                  id={`chords-${i}`}
                   type="text"
                   value={sec.chords.join(" ")}
                   placeholder="Chords"
@@ -1193,8 +1253,13 @@ export default function SongForm() {
         />
         {/* album mode toggle */}
         <div className={styles.panel}>
-          <label className={styles.toggle}>
-            <input type="checkbox" checked={albumMode} onChange={(e) => setAlbumMode(e.target.checked)} />
+          <label className={styles.toggle} htmlFor="albumMode">
+            <input
+              id="albumMode"
+              type="checkbox"
+              checked={albumMode}
+              onChange={(e) => setAlbumMode(e.target.checked)}
+            />
             <span className={styles.small}>
               Album mode
               <HelpIcon text="Render multiple tracks as an album" />
@@ -1202,11 +1267,12 @@ export default function SongForm() {
           </label>
           {albumMode && (
             <>
-              <label className={styles.label}>
+              <label htmlFor="trackCount" className={styles.label}>
                 Track Count
-                <HelpIcon text="Number of tracks in album mode" />
+                <HelpIcon text="Number of tracks in album mode (3–12)" />
               </label>
               <input
+                id="trackCount"
                 type="number"
                 min={3}
                 max={12}
@@ -1218,25 +1284,35 @@ export default function SongForm() {
                 }
                 className={styles.input}
               />
-              <label className={styles.label}>Album Name</label>
+              <label htmlFor="albumName" className={styles.label}>
+                Album Name
+                <HelpIcon text="Name for the album" />
+              </label>
               <input
+                id="albumName"
                 className={styles.input}
                 placeholder="Album name"
                 value={albumName}
                 onChange={(e) => setAlbumName(e.target.value)}
               />
               {trackNames.map((name, i) => (
-                <input
-                  key={i}
-                  className={styles.input}
-                  placeholder={`Track ${i + 1} name`}
-                  value={name}
-                  onChange={(e) => {
-                    const arr = [...trackNames];
-                    arr[i] = e.target.value;
-                    setTrackNames(arr);
-                  }}
-                />
+                <div key={i}>
+                  <label htmlFor={`track-${i}`} className={styles.label}>
+                    Track {i + 1} Name
+                    <HelpIcon text="Optional track title" />
+                  </label>
+                  <input
+                    id={`track-${i}`}
+                    className={styles.input}
+                    placeholder={`Track ${i + 1} name`}
+                    value={name}
+                    onChange={(e) => {
+                      const arr = [...trackNames];
+                      arr[i] = e.target.value;
+                      setTrackNames(arr);
+                    }}
+                  />
+                </div>
               ))}
             </>
           )}

--- a/src/components/TemplateSelector.tsx
+++ b/src/components/TemplateSelector.tsx
@@ -19,10 +19,10 @@ export default function TemplateSelector({
 }: Props) {
   return (
     <div className={styles.panel}>
-      <label className={styles.label}>
+      <div className={styles.label}>
         Song Templates
         <HelpIcon text="Select a preset arrangement and settings" />
-      </label>
+      </div>
       <select
         aria-label="Song Templates"
         value={selectedTemplate}

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -16,28 +16,33 @@ exports[`SongForm > renders default form 1`] = `
       <div
         class="_panel_62bdff"
       >
-        <label
+        <div
           class="_label_62bdff"
         >
           Song Templates
-          <svg
-            fill="currentColor"
-            height="1em"
-            stroke="currentColor"
-            stroke-width="0"
-            style="margin-left: 4px; cursor: help; opacity: 0.6;"
-            viewBox="0 0 512 512"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
+          <button
+            aria-label="help"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+            tabindex="0"
+            type="button"
           >
-            <title>
-              Select a preset arrangement and settings
-            </title>
-            <path
-              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-            />
-          </svg>
-        </label>
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </button>
+        </div>
         <select
           aria-label="Song Templates"
           class="_input_62bdff py-2 px-3"
@@ -198,11 +203,40 @@ exports[`SongForm > renders default form 1`] = `
           Restore defaults
         </button>
       </div>
+      <label
+        class="_label_62bdff"
+        for="titleBase"
+      >
+        Song Title Base
+        <button
+          aria-label="help"
+          class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+          data-mui-internal-clone-element="true"
+          style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 512 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+            />
+          </svg>
+        </button>
+      </label>
       <div
         class="_row_62bdff"
       >
         <input
           class="_input_62bdff"
+          id="titleBase"
           placeholder="Song title base"
           value=""
         />
@@ -238,28 +272,35 @@ exports[`SongForm > renders default form 1`] = `
           >
             <label
               class="_label_62bdff"
+              for="bpm"
             >
               BPM: 80
-              <svg
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                stroke-width="0"
-                style="margin-left: 4px; cursor: help; opacity: 0.6;"
-                viewBox="0 0 512 512"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                aria-label="help"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                tabindex="0"
+                type="button"
               >
-                <title>
-                  Song tempo in beats per minute
-                </title>
-                <path
-                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                />
-              </svg>
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </button>
             </label>
             <input
               class="_input_62bdff p-0"
+              id="bpm"
               max="200"
               min="60"
               type="range"
@@ -271,31 +312,38 @@ exports[`SongForm > renders default form 1`] = `
           >
             <label
               class="_label_62bdff"
+              for="key"
             >
               Key
-              <svg
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                stroke-width="0"
-                style="margin-left: 4px; cursor: help; opacity: 0.6;"
-                viewBox="0 0 512 512"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                aria-label="help"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                tabindex="0"
+                type="button"
               >
-                <title>
-                  Musical key; choose Auto for random
-                </title>
-                <path
-                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                />
-              </svg>
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </button>
             </label>
             <div
               class="_row_62bdff"
             >
               <select
                 class="_input_62bdff py-2 px-3"
+                id="key"
               >
                 <option
                   value="Auto"
@@ -404,19 +452,43 @@ exports[`SongForm > renders default form 1`] = `
                 </option>
               </select>
             </div>
-            <div
+            <label
               class="_toggle_62bdff mt-2"
+              for="autoKeyPerSong"
             >
               <input
                 disabled=""
+                id="autoKeyPerSong"
                 type="checkbox"
               />
               <span
                 class="_small_62bdff"
               >
                 Rotate key per song
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
               </span>
-            </div>
+            </label>
             <div
               class="_small_62bdff"
             >
@@ -428,38 +500,74 @@ exports[`SongForm > renders default form 1`] = `
           >
             <label
               class="_label_62bdff"
+              for="seed"
             >
               Seed
-              <svg
-                fill="currentColor"
-                height="1em"
-                stroke="currentColor"
-                stroke-width="0"
-                style="margin-left: 4px; cursor: help; opacity: 0.6;"
-                viewBox="0 0 512 512"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
+              <button
+                aria-label="help"
+                class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                data-mui-internal-clone-element="true"
+                style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                tabindex="0"
+                type="button"
               >
-                <title>
-                  Randomness seed for reproducibility
-                </title>
-                <path
-                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                />
-              </svg>
+                <svg
+                  fill="currentColor"
+                  height="1em"
+                  stroke="currentColor"
+                  stroke-width="0"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                  />
+                </svg>
+              </button>
             </label>
             <input
               class="_input_62bdff"
+              id="seed"
               type="number"
               value="12345"
             />
-            <div
+            <fieldset
               class="_row_62bdff mt-2"
             >
+              <legend
+                class="_small_62bdff"
+              >
+                Seed Mode
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
+              </legend>
               <label
                 class="_small_62bdff flex-1"
+                for="seedmode-increment"
               >
                 <input
+                  id="seedmode-increment"
                   name="seedmode"
                   type="radio"
                 />
@@ -467,15 +575,17 @@ exports[`SongForm > renders default form 1`] = `
               </label>
               <label
                 class="_small_62bdff flex-1"
+                for="seedmode-random"
               >
                 <input
                   checked=""
+                  id="seedmode-random"
                   name="seedmode"
                   type="radio"
                 />
                  Deterministic random
               </label>
-            </div>
+            </fieldset>
           </div>
         </div>
       </details>
@@ -490,11 +600,40 @@ exports[`SongForm > renders default form 1`] = `
         <div
           class="mt-2"
         >
+          <label
+            class="_label_62bdff"
+            for="templateSelect"
+          >
+            Structure Template
+            <button
+              aria-label="help"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 512 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                />
+              </svg>
+            </button>
+          </label>
           <div
             class="_row_62bdff mb-2"
           >
             <select
               class="_input_62bdff py-2 px-3"
+              id="templateSelect"
             >
               <option
                 value=""
@@ -643,11 +782,40 @@ exports[`SongForm > renders default form 1`] = `
               New Template
             </button>
           </div>
+          <label
+            class="_label_62bdff"
+            for="sectionPreset"
+          >
+            Preset Layout
+            <button
+              aria-label="help"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+              tabindex="0"
+              type="button"
+            >
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 512 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                />
+              </svg>
+            </button>
+          </label>
           <div
             class="_row_62bdff mb-2"
           >
             <select
               class="_input_62bdff py-2 px-3"
+              id="sectionPreset"
             >
               <option
                 value=""
@@ -685,23 +853,28 @@ exports[`SongForm > renders default form 1`] = `
             class="_label_62bdff"
           >
             Structure (bars)
-            <svg
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              style="margin-left: 4px; cursor: help; opacity: 0.6;"
-              viewBox="0 0 512 512"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-label="help"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+              tabindex="0"
+              type="button"
             >
-              <title>
-                Order of song sections with lengths and chords
-              </title>
-              <path
-                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-              />
-            </svg>
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 512 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                />
+              </svg>
+            </button>
           </label>
           <div
             class="flex gap-2 flex-wrap"
@@ -710,18 +883,71 @@ exports[`SongForm > renders default form 1`] = `
               class="p-2 rounded-lg min-w-[120px]"
               style="background-color: rgba(0, 0, 0, 0.04);"
             >
-              <div
+              <label
                 class="_small_62bdff"
+                for="bars-0"
               >
-                Intro
-              </div>
+                Intro Bars
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
+              </label>
               <input
                 class="_input_62bdff"
+                id="bars-0"
                 type="number"
                 value="4"
               />
+              <label
+                class="_small_62bdff"
+                for="chords-0"
+              >
+                Chords
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
+              </label>
               <input
                 class="_input_62bdff mt-1"
+                id="chords-0"
                 placeholder="Chords"
                 type="text"
                 value=""
@@ -731,18 +957,71 @@ exports[`SongForm > renders default form 1`] = `
               class="p-2 rounded-lg min-w-[120px]"
               style="background-color: rgba(0, 0, 0, 0.04);"
             >
-              <div
+              <label
                 class="_small_62bdff"
+                for="bars-1"
               >
-                A
-              </div>
+                A Bars
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
+              </label>
               <input
                 class="_input_62bdff"
+                id="bars-1"
                 type="number"
                 value="8"
               />
+              <label
+                class="_small_62bdff"
+                for="chords-1"
+              >
+                Chords
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
+              </label>
               <input
                 class="_input_62bdff mt-1"
+                id="chords-1"
                 placeholder="Chords"
                 type="text"
                 value=""
@@ -752,18 +1031,71 @@ exports[`SongForm > renders default form 1`] = `
               class="p-2 rounded-lg min-w-[120px]"
               style="background-color: rgba(0, 0, 0, 0.04);"
             >
-              <div
+              <label
                 class="_small_62bdff"
+                for="bars-2"
               >
-                B
-              </div>
+                B Bars
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
+              </label>
               <input
                 class="_input_62bdff"
+                id="bars-2"
                 type="number"
                 value="8"
               />
+              <label
+                class="_small_62bdff"
+                for="chords-2"
+              >
+                Chords
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
+              </label>
               <input
                 class="_input_62bdff mt-1"
+                id="chords-2"
                 placeholder="Chords"
                 type="text"
                 value=""
@@ -773,18 +1105,71 @@ exports[`SongForm > renders default form 1`] = `
               class="p-2 rounded-lg min-w-[120px]"
               style="background-color: rgba(0, 0, 0, 0.04);"
             >
-              <div
+              <label
                 class="_small_62bdff"
+                for="bars-3"
               >
-                A
-              </div>
+                A Bars
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
+              </label>
               <input
                 class="_input_62bdff"
+                id="bars-3"
                 type="number"
                 value="8"
               />
+              <label
+                class="_small_62bdff"
+                for="chords-3"
+              >
+                Chords
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
+              </label>
               <input
                 class="_input_62bdff mt-1"
+                id="chords-3"
                 placeholder="Chords"
                 type="text"
                 value=""
@@ -794,18 +1179,71 @@ exports[`SongForm > renders default form 1`] = `
               class="p-2 rounded-lg min-w-[120px]"
               style="background-color: rgba(0, 0, 0, 0.04);"
             >
-              <div
+              <label
                 class="_small_62bdff"
+                for="bars-4"
               >
-                B
-              </div>
+                B Bars
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
+              </label>
               <input
                 class="_input_62bdff"
+                id="bars-4"
                 type="number"
                 value="8"
               />
+              <label
+                class="_small_62bdff"
+                for="chords-4"
+              >
+                Chords
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
+              </label>
               <input
                 class="_input_62bdff mt-1"
+                id="chords-4"
                 placeholder="Chords"
                 type="text"
                 value=""
@@ -815,18 +1253,71 @@ exports[`SongForm > renders default form 1`] = `
               class="p-2 rounded-lg min-w-[120px]"
               style="background-color: rgba(0, 0, 0, 0.04);"
             >
-              <div
+              <label
                 class="_small_62bdff"
+                for="bars-5"
               >
-                Outro
-              </div>
+                Outro Bars
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
+              </label>
               <input
                 class="_input_62bdff"
+                id="bars-5"
                 type="number"
                 value="4"
               />
+              <label
+                class="_small_62bdff"
+                for="chords-5"
+              >
+                Chords
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
+              </label>
               <input
                 class="_input_62bdff mt-1"
+                id="chords-5"
                 placeholder="Chords"
                 type="text"
                 value=""
@@ -862,23 +1353,28 @@ exports[`SongForm > renders default form 1`] = `
                 class="_label_62bdff"
               >
                 Mood
-                <svg
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  style="margin-left: 4px; cursor: help; opacity: 0.6;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
                 >
-                  <title>
-                    Tags describing the vibe
-                  </title>
-                  <path
-                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  />
-                </svg>
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
               </label>
               <div
                 class="_optionGrid_62bdff"
@@ -955,23 +1451,28 @@ exports[`SongForm > renders default form 1`] = `
                 class="_label_62bdff"
               >
                 Instruments
-                <svg
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  style="margin-left: 4px; cursor: help; opacity: 0.6;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
                 >
-                  <title>
-                    Select instruments to include
-                  </title>
-                  <path
-                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  />
-                </svg>
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
               </label>
               <div
                 class="_optionGrid_62bdff"
@@ -1413,23 +1914,28 @@ exports[`SongForm > renders default form 1`] = `
                 class="_label_62bdff"
               >
                 Lead Instrument
-                <svg
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  style="margin-left: 4px; cursor: help; opacity: 0.6;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
                 >
-                  <title>
-                    Choose the instrument that carries the main melody
-                  </title>
-                  <path
-                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  />
-                </svg>
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
               </label>
               <div
                 class="_optionGrid_62bdff"
@@ -1552,23 +2058,28 @@ exports[`SongForm > renders default form 1`] = `
                 class="_label_62bdff"
               >
                 Ambience
-                <svg
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  style="margin-left: 4px; cursor: help; opacity: 0.6;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
                 >
-                  <title>
-                    Background ambience sounds
-                  </title>
-                  <path
-                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  />
-                </svg>
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
               </label>
               <div
                 class="_optionGrid_62bdff"
@@ -1714,23 +2225,28 @@ exports[`SongForm > renders default form 1`] = `
                 class="_label_62bdff"
               >
                 Drum Pattern
-                <svg
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  style="margin-left: 4px; cursor: help; opacity: 0.6;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
                 >
-                  <title>
-                    Choose a groove style or no drums
-                  </title>
-                  <path
-                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  />
-                </svg>
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
               </label>
               <select
                 class="_input_62bdff py-2 px-3"
@@ -1794,23 +2310,28 @@ exports[`SongForm > renders default form 1`] = `
                 class="_label_62bdff"
               >
                 Variety (0-100%)
-                <svg
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  style="margin-left: 4px; cursor: help; opacity: 0.6;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
                 >
-                  <title>
-                    Amount of fills and swing
-                  </title>
-                  <path
-                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  />
-                </svg>
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
               </label>
               <input
                 class="_slider_62bdff"
@@ -1832,23 +2353,28 @@ exports[`SongForm > renders default form 1`] = `
                 class="_label_62bdff"
               >
                 Chord Span
-                <svg
-                  fill="currentColor"
-                  height="1em"
-                  stroke="currentColor"
-                  stroke-width="0"
-                  style="margin-left: 4px; cursor: help; opacity: 0.6;"
-                  viewBox="0 0 512 512"
-                  width="1em"
-                  xmlns="http://www.w3.org/2000/svg"
+                <button
+                  aria-label="help"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                  tabindex="0"
+                  type="button"
                 >
-                  <title>
-                    Number of beats each chord lasts
-                  </title>
-                  <path
-                    d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                  />
-                </svg>
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 512 512"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                    />
+                  </svg>
+                </button>
               </label>
               <select
                 class="_input_62bdff py-2 px-3"
@@ -1883,23 +2409,28 @@ exports[`SongForm > renders default form 1`] = `
             class="cursor-pointer text-xs opacity-80"
           >
             Polish 
-            <svg
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              style="margin-left: 4px; cursor: help; opacity: 0.6;"
-              viewBox="0 0 512 512"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-label="help"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+              tabindex="0"
+              type="button"
             >
-              <title>
-                Optional mix polish effects
-              </title>
-              <path
-                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-              />
-            </svg>
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 512 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                />
+              </svg>
+            </button>
           </summary>
           <div
             class="mt-2"
@@ -1912,6 +2443,28 @@ exports[`SongForm > renders default form 1`] = `
               >
                 <span>
                   Stereo widen
+                  <button
+                    aria-label="help"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                      />
+                    </svg>
+                  </button>
                 </span>
                 <input
                   checked=""
@@ -1923,6 +2476,28 @@ exports[`SongForm > renders default form 1`] = `
               >
                 <span>
                   Room reverb
+                  <button
+                    aria-label="help"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                      />
+                    </svg>
+                  </button>
                 </span>
                 <input
                   checked=""
@@ -1934,6 +2509,28 @@ exports[`SongForm > renders default form 1`] = `
               >
                 <span>
                   Sidechain (kick)
+                  <button
+                    aria-label="help"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                      />
+                    </svg>
+                  </button>
                 </span>
                 <input
                   checked=""
@@ -1945,6 +2542,28 @@ exports[`SongForm > renders default form 1`] = `
               >
                 <span>
                   Chorus
+                  <button
+                    aria-label="help"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                      />
+                    </svg>
+                  </button>
                 </span>
                 <input
                   checked=""
@@ -1967,23 +2586,28 @@ exports[`SongForm > renders default form 1`] = `
                   class="_label_62bdff"
                 >
                   Limiter Drive
-                  <svg
-                    fill="currentColor"
-                    height="1em"
-                    stroke="currentColor"
-                    stroke-width="0"
-                    style="margin-left: 4px; cursor: help; opacity: 0.6;"
-                    viewBox="0 0 512 512"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
+                  <button
+                    aria-label="help"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                    tabindex="0"
+                    type="button"
                   >
-                    <title>
-                      Amount of saturation added by the limiter
-                    </title>
-                    <path
-                      d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-                    />
-                  </svg>
+                    <svg
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                      />
+                    </svg>
+                  </button>
                 </label>
                 <input
                   class="_slider_62bdff"
@@ -1998,7 +2622,7 @@ exports[`SongForm > renders default form 1`] = `
                 >
                   1.02× saturation
                 </div>
-                <div
+                <label
                   class="_toggle_62bdff mt-2"
                 >
                   <input
@@ -2009,8 +2633,30 @@ exports[`SongForm > renders default form 1`] = `
                     class="_small_62bdff"
                   >
                     Dither
+                    <button
+                      aria-label="help"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <svg
+                        fill="currentColor"
+                        height="1em"
+                        stroke="currentColor"
+                        stroke-width="0"
+                        viewBox="0 0 512 512"
+                        width="1em"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                        />
+                      </svg>
+                    </button>
                   </span>
-                </div>
+                </label>
               </div>
             </details>
           </div>
@@ -2021,31 +2667,38 @@ exports[`SongForm > renders default form 1`] = `
       >
         <label
           class="_toggle_62bdff"
+          for="albumMode"
         >
           <input
+            id="albumMode"
             type="checkbox"
           />
           <span
             class="_small_62bdff"
           >
             Album mode
-            <svg
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              style="margin-left: 4px; cursor: help; opacity: 0.6;"
-              viewBox="0 0 512 512"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-label="help"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+              tabindex="0"
+              type="button"
             >
-              <title>
-                Render multiple tracks as an album
-              </title>
-              <path
-                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-              />
-            </svg>
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 512 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                />
+              </svg>
+            </button>
           </span>
         </label>
       </div>
@@ -2059,23 +2712,28 @@ exports[`SongForm > renders default form 1`] = `
             class="_label_62bdff"
           >
             How many songs?
-            <svg
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              style="margin-left: 4px; cursor: help; opacity: 0.6;"
-              viewBox="0 0 512 512"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-label="help"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+              tabindex="0"
+              type="button"
             >
-              <title>
-                Number of songs to render in this batch
-              </title>
-              <path
-                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-              />
-            </svg>
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 512 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                />
+              </svg>
+            </button>
           </label>
           <input
             class="_input_62bdff"
@@ -2110,23 +2768,28 @@ exports[`SongForm > renders default form 1`] = `
             class="_label_62bdff"
           >
             BPM Jitter (0-30%, per song)
-            <svg
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              style="margin-left: 4px; cursor: help; opacity: 0.6;"
-              viewBox="0 0 512 512"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              aria-label="help"
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+              data-mui-internal-clone-element="true"
+              style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+              tabindex="0"
+              type="button"
             >
-              <title>
-                Random tempo variation around base BPM
-              </title>
-              <path
-                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-              />
-            </svg>
+              <svg
+                fill="currentColor"
+                height="1em"
+                stroke="currentColor"
+                stroke-width="0"
+                viewBox="0 0 512 512"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                />
+              </svg>
+            </button>
           </label>
           <input
             class="_slider_62bdff"
@@ -2172,23 +2835,28 @@ exports[`SongForm > renders default form 1`] = `
           >
             Preview snippet
           </button>
-          <svg
-            fill="currentColor"
-            height="1em"
-            stroke="currentColor"
-            stroke-width="0"
-            style="margin-left: 4px; cursor: help; opacity: 0.6;"
-            viewBox="0 0 512 512"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
+          <button
+            aria-label="help"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+            data-mui-internal-clone-element="true"
+            style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+            tabindex="0"
+            type="button"
           >
-            <title>
-              Play a quick 5-second preview
-            </title>
-            <path
-              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
-            />
-          </svg>
+            <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+              />
+            </svg>
+          </button>
         </div>
         <button
           class="_playBtn_62bdff"


### PR DESCRIPTION
## Summary
- add keyboard-accessible tooltip component
- label song form fields with examples and helpful hints
- describe mix polish options with default notes

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68aab1f98ff08325a969e263fc297df1