### PR TITLE
Use async sleep in task queue

### DIFF
--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -146,7 +146,7 @@ impl TaskQueue {
                                 };
                                 let mut sys = System::new();
                                 sys.refresh_cpu_usage();
-                                std::thread::sleep(Duration::from_millis(100));
+                                tokio::time::sleep(Duration::from_millis(100)).await;
                                 sys.refresh_cpu_usage();
                                 sys.refresh_memory();
                                 let cpu_usage = sys.global_cpu_usage();


### PR DESCRIPTION
## Summary
- replace blocking std thread sleep with async tokio sleep in task queue

## Testing
- `cargo check` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aab98c93988325ac726184d39d2779