### PR TITLE
refactor: update path opener import

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useAudioDefaults } from "../features/audioDefaults/useAudioDefaults";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
-import { open as openPath } from "@tauri-apps/plugin-opener";
+import { openPath } from "@tauri-apps/plugin-opener";
 import { invoke, convertFileSrc } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useLofi } from "../features/lofi/SongForm";


### PR DESCRIPTION
## Summary
- use `openPath` from Tauri opener plugin in `SongForm`

## Testing
- `npm test`
- `npm run tauri dev` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_68aaba1e358883258fe1b5d6a511830e