### PR TITLE
feat(lofi): expose weather preset and toggle

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -6,6 +6,7 @@ import { open as openPath } from "@tauri-apps/plugin-opener";
 import { invoke, convertFileSrc } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useLofi } from "../features/lofi/SongForm";
+import { WEATHER_PRESETS } from "../features/lofi/weather";
 import Waveform from "./Waveform";
 import TemplateSelector from "./TemplateSelector";
 import VibeControls from "./VibeControls";
@@ -346,6 +347,9 @@ export default function SongForm() {
     setBpm: setPreviewBpm,
     setKey: setPreviewKey,
     setSeed: setPreviewSeed,
+    weatherPreset,
+    weatherEnabled,
+    setWeatherEnabled,
   } = useLofi();
 
   // one audio element
@@ -855,6 +859,22 @@ export default function SongForm() {
     <div className={styles.page}>
       <div className={styles.card}>
         <div className={styles.h1}>Blossom — Song Builder (Batch + Vibes)</div>
+
+        {weatherPreset && (
+          <div className={styles.row}>
+            <div className={styles.small}>
+              Weather preset: {weatherPreset} (BPM {WEATHER_PRESETS[weatherPreset].bpm}, Key {displayKey(WEATHER_PRESETS[weatherPreset].key)})
+            </div>
+            <label className={styles.toggle}>
+              <input
+                type="checkbox"
+                checked={weatherEnabled}
+                onChange={(e) => setWeatherEnabled(e.target.checked)}
+              />
+              Use weather
+            </label>
+          </div>
+        )}
 
         {/* template selector */}
         <TemplateSelector

--- a/src/features/lofi/SongForm.ts
+++ b/src/features/lofi/SongForm.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import * as Tone from 'tone';
-import type { LofiState } from './types';
+import type { LofiState, WeatherPreset } from './types';
 import {
   renderSpokenWord,
   fileToBuffer,
@@ -340,6 +340,8 @@ type Actions = {
   setBpm: (bpm: number) => void;
   setSeed: (seed: number) => void;
   setKey: (key: string) => void;
+  setWeatherPreset: (preset: WeatherPreset | null) => void;
+  setWeatherEnabled: (enabled: boolean) => void;
 };
 
 export const useLofi = create<LofiState & Actions>((set, get) => ({
@@ -347,6 +349,8 @@ export const useLofi = create<LofiState & Actions>((set, get) => ({
   bpm: 80,
   seed: 0,
   key: 'C',
+  weatherPreset: null,
+  weatherEnabled: true,
 
   play: async () => {
     init();
@@ -378,5 +382,13 @@ export const useLofi = create<LofiState & Actions>((set, get) => ({
   setKey: (key) => {
     makePattern(get().seed, key);
     set({ key });
+  },
+
+  setWeatherPreset: (weatherPreset) => {
+    set({ weatherPreset });
+  },
+
+  setWeatherEnabled: (weatherEnabled) => {
+    set({ weatherEnabled });
   },
 }));

--- a/src/features/lofi/types.ts
+++ b/src/features/lofi/types.ts
@@ -1,6 +1,10 @@
+export type WeatherPreset = 'sunny' | 'rain' | 'snow';
+
 export type LofiState = {
   isPlaying: boolean;
   bpm: number;
   seed: number;
   key: string;
+  weatherPreset: WeatherPreset | null;
+  weatherEnabled: boolean;
 };

--- a/src/features/lofi/weather.ts
+++ b/src/features/lofi/weather.ts
@@ -2,6 +2,12 @@ import { useLofi } from './SongForm';
 
 export type WeatherCondition = 'sunny' | 'rain' | 'snow';
 
+export const WEATHER_PRESETS: Record<WeatherCondition, { bpm: number; key: string }> = {
+  rain: { bpm: 70, key: 'D' },
+  snow: { bpm: 60, key: 'E' },
+  sunny: { bpm: 90, key: 'C' },
+};
+
 const rainCodes = new Set<number>([
   51, 53, 55, 56, 57, // drizzle
   61, 63, 65, 66, 67, // rain
@@ -29,20 +35,11 @@ export async function fetchWeather(lat: number, lon: number): Promise<WeatherCon
 
 export function applyWeather(condition: WeatherCondition) {
   const lofi = useLofi.getState();
-  switch (condition) {
-    case 'rain':
-      lofi.setBpm(70);
-      lofi.setKey('D');
-      break;
-    case 'snow':
-      lofi.setBpm(60);
-      lofi.setKey('E');
-      break;
-    default:
-      lofi.setBpm(90);
-      lofi.setKey('C');
-      break;
-  }
+  const preset = WEATHER_PRESETS[condition];
+  lofi.setBpm(preset.bpm);
+  lofi.setKey(preset.key);
+  lofi.setWeatherPreset(condition);
+  lofi.setWeatherEnabled(true);
 }
 
 export async function generateWeatherTrack(lat: number, lon: number) {


### PR DESCRIPTION
## Summary
- track weather presets in lofi store and weather module
- surface preset details and enable/disable toggle in song form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aab5f2ea488325b4bbffd0407c1963