### PR TITLE
feat(calendar): add quick add button

### DIFF
--- a/src/components/CalendarDay.test.tsx
+++ b/src/components/CalendarDay.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import CalendarDay from './CalendarDay';
+import type { CalendarEvent } from '../features/calendar/types';
+
+describe('CalendarDay', () => {
+  it('adds event via quick add button', () => {
+    const onDayClick = vi.fn();
+    const onPrefill = vi.fn();
+    render(
+      <CalendarDay
+        day={1}
+        events={[] as CalendarEvent[]}
+        onDayClick={onDayClick}
+        onPrefill={onPrefill}
+        isToday={false}
+        isFocused={false}
+        isSelected={false}
+      />
+    );
+    const btn = screen.getByRole('button', { name: /add event/i });
+    fireEvent.click(btn);
+    expect(onPrefill).toHaveBeenCalledWith(1);
+    expect(onDayClick).toHaveBeenCalledTimes(1);
+    expect(onDayClick.mock.calls[0][0]).toBe(1);
+  });
+});

--- a/src/components/CalendarDay.tsx
+++ b/src/components/CalendarDay.tsx
@@ -1,4 +1,5 @@
-import { Box, Typography, Tooltip } from '@mui/material';
+import { Box, Typography, Tooltip, IconButton } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
 import React, { useCallback } from 'react';
 import { useStatusColors } from '../features/calendar/statusColors';
 import type { CalendarEvent } from '../features/calendar/types';
@@ -37,6 +38,15 @@ const CalendarDay = React.memo(
       [day, onDayClick]
     );
 
+    const handleAdd = useCallback(
+      (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+        onPrefill(day);
+        onDayClick(day, e as unknown as React.MouseEvent<HTMLDivElement>);
+      },
+      [day, onDayClick, onPrefill]
+    );
+
     return (
       <Box
         data-testid={`day-${day}`}
@@ -62,11 +72,28 @@ const CalendarDay = React.memo(
           },
         }}
       >
-        {holiday && (
-          <Tooltip title={holiday}>
-            <Box sx={{ position: 'absolute', top: 4, right: 4, fontSize: 12 }}>🎉</Box>
-          </Tooltip>
-        )}
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 4,
+            right: 4,
+            display: 'flex',
+            gap: 0.5,
+          }}
+        >
+          <IconButton
+            size="small"
+            aria-label={`Add event for day ${day}`}
+            onClick={handleAdd}
+          >
+            <AddIcon fontSize="small" />
+          </IconButton>
+          {holiday && (
+            <Tooltip title={holiday}>
+              <Box sx={{ fontSize: 12 }}>🎉</Box>
+            </Tooltip>
+          )}
+        </Box>
         <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
           {day}
         </Typography>


### PR DESCRIPTION
## Summary
- add accessible "+" button to calendar days for one-click quick add
- test that quick add button triggers prefill and day click handlers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aac1937b7883258904edaf9beea1db