### PR TITLE
Remove dark mode toggle and align settings with theme

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -186,7 +186,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
     hqChorus,
     toggleHqChorus,
   } = useAudioDefaults();
-  const { theme, setTheme, mode, setMode } = useTheme();
+  const { theme, setTheme } = useTheme();
   const { showTutorial, setShowTutorial } = useComfyTutorial();
   const { modules, toggleModule } = useSettings();
   const [audioSaved, setAudioSaved] = useState(false);
@@ -202,7 +202,6 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   const [ttsLanguageDraft, setTtsLanguageDraft] = useState(ttsLanguage);
   const [folderDraft, setFolderDraft] = useState(folder);
   const [themeDraft, setThemeDraft] = useState<Theme>(theme);
-  const [modeDraft, setModeDraft] = useState(mode);
 
   useEffect(() => setPythonDraft(pythonPath), [pythonPath]);
   useEffect(() => setComfyDraft(comfyPath), [comfyPath]);
@@ -212,7 +211,6 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   useEffect(() => setTtsLanguageDraft(ttsLanguage), [ttsLanguage]);
   useEffect(() => setFolderDraft(folder), [folder]);
   useEffect(() => setThemeDraft(theme), [theme]);
-  useEffect(() => setModeDraft(mode), [mode]);
 
   return (
     <Drawer anchor="right" open={open} onClose={onClose}>
@@ -381,22 +379,11 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
               ))}
             </Select>
           </FormControl>
-          <FormControlLabel
-            sx={{ mt: 1 }}
-            control={
-              <Switch
-                checked={modeDraft === "dark"}
-                onChange={(e) => setModeDraft(e.target.checked ? "dark" : "light")}
-              />
-            }
-            label="Dark Mode"
-          />
           <Button
             variant="contained"
             sx={{ mt: 2 }}
             onClick={() => {
               setTheme(themeDraft);
-              setMode(modeDraft);
               setAppearanceSaved(true);
             }}
           >

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -4,11 +4,7 @@ import {
   useEffect,
   useMemo,
 } from "react";
-import {
-  ThemeProvider as MuiThemeProvider,
-  CssBaseline,
-  PaletteMode,
-} from "@mui/material";
+import { ThemeProvider as MuiThemeProvider, CssBaseline } from "@mui/material";
 import { createAppTheme } from "../../theme";
 import { useUsers } from "../users/useUsers";
 
@@ -31,8 +27,6 @@ export type Theme =
 interface ThemeContextType {
   theme: Theme;
   setTheme: (theme: Theme) => void;
-  mode: PaletteMode;
-  setMode: (mode: PaletteMode) => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
@@ -42,12 +36,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     const id = state.currentUserId;
     return id ? state.users[id].theme : "default";
   });
-  const mode = useUsers((state) => {
-    const id = state.currentUserId;
-    return id ? state.users[id].mode : "dark";
-  });
   const setTheme = useUsers((state) => state.setTheme);
-  const setMode = useUsers((state) => state.setMode);
 
   useEffect(() => {
     const classes = [
@@ -71,13 +60,13 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   }, [theme]);
 
   useEffect(() => {
-    document.documentElement.style.colorScheme = mode;
-  }, [mode]);
+    document.documentElement.style.colorScheme = 'dark';
+  }, []);
 
-  const muiTheme = useMemo(() => createAppTheme(mode), [mode]);
+  const muiTheme = useMemo(() => createAppTheme(), []);
 
   return (
-    <ThemeContext.Provider value={{ theme, setTheme, mode, setMode }}>
+    <ThemeContext.Provider value={{ theme, setTheme }}>
       <MuiThemeProvider theme={muiTheme}>
         <CssBaseline />
         {children}

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { Theme } from '../theme/ThemeContext';
-import type { PaletteMode } from '@mui/material';
 
 type ModuleKey =
   | 'objects'
@@ -40,7 +39,6 @@ const defaultModules: ModulesState = {
     id: string;
     name: string;
     theme: Theme;
-    mode: PaletteMode;
     money: number;
     modules: ModulesState;
     cpuLimit: number;
@@ -53,7 +51,6 @@ const defaultModules: ModulesState = {
     addUser: (name: string) => void;
     switchUser: (id: string) => void;
     setTheme: (theme: Theme) => void;
-    setMode: (mode: PaletteMode) => void;
     toggleModule: (key: ModuleKey) => void;
     setCpuLimit: (limit: number) => void;
     setMemLimit: (limit: number) => void;
@@ -73,7 +70,6 @@ export const useUsers = create<UsersState>()(
                 id,
                 name,
                 theme: 'default',
-                mode: 'dark',
                 money: 5000,
                 modules: { ...defaultModules },
                 cpuLimit: 90,
@@ -91,16 +87,6 @@ export const useUsers = create<UsersState>()(
           users: {
             ...state.users,
             [id]: { ...state.users[id], theme },
-          },
-        }));
-      },
-      setMode: (mode) => {
-        const id = get().currentUserId;
-        if (!id) return;
-        set((state) => ({
-          users: {
-            ...state.users,
-            [id]: { ...state.users[id], mode },
           },
         }));
       },

--- a/src/pages/GeneralChat.test.tsx
+++ b/src/pages/GeneralChat.test.tsx
@@ -18,7 +18,6 @@ describe('GeneralChat', () => {
           id: 'test',
           name: 'Test User',
           theme: 'default',
-          mode: 'dark',
           money: 5000,
           modules: { ...defaultModules },
         },

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -18,7 +18,6 @@ export default function User() {
         <p><strong>ID:</strong> {user.id}</p>
         <p><strong>Name:</strong> {user.name}</p>
         <p><strong>Theme:</strong> {user.theme}</p>
-        <p><strong>Mode:</strong> {user.mode}</p>
         <p><strong>Money:</strong> {user.money}</p>
         <div>
           <h2>Modules</h2>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,10 +1,10 @@
-import { createTheme, PaletteMode } from '@mui/material/styles';
+import { createTheme } from '@mui/material/styles';
 
 export const colors = {
   primary: '#1976d2',
   secondary: '#9c27b0',
-  background: '#f5f5f5',
-  surface: '#ffffff',
+  background: '#121212',
+  surface: '#1e1e1e',
   status: {
     scheduled: '#1976d2',
     canceled: '#d32f2f',
@@ -15,10 +15,10 @@ export const colors = {
 
 export const spacing = 8;
 
-export const createAppTheme = (mode: PaletteMode) =>
+export const createAppTheme = () =>
   createTheme({
     palette: {
-      mode,
+      mode: 'dark',
       primary: { main: colors.primary },
       secondary: { main: colors.secondary },
       background: { default: colors.background, paper: colors.surface },


### PR DESCRIPTION
## Summary
- Replace light/dark palette logic with a default dark theme so the settings drawer matches the chosen theme.
- Remove dark mode state from users and settings UI, leaving only theme selection.
- Update tests and user page to reflect removal of mode settings.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aabf47067483259b14dd969fd7c85f