### PR TITLE
Improve responsive layout for different window sizes

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -20,7 +20,11 @@ export default function TopBar() {
       <Tooltip title="Home">
         <IconButton
           onClick={() => nav("/")}
-          sx={{ ...fixedIconButtonSx, left: 12, ...activeSx("/") }}
+          sx={{
+            ...fixedIconButtonSx,
+            left: { xs: 8, sm: 12 },
+            ...activeSx("/"),
+          }}
           aria-label="Home"
           aria-current={pathname === "/" ? "page" : undefined}
         >
@@ -31,7 +35,11 @@ export default function TopBar() {
       <Tooltip title="User">
         <IconButton
           onClick={() => nav("/user")}
-          sx={{ ...fixedIconButtonSx, left: 60, ...activeSx("/user") }}
+          sx={{
+            ...fixedIconButtonSx,
+            left: { xs: 44, sm: 60 },
+            ...activeSx("/user"),
+          }}
           aria-label="User"
           aria-current={pathname === "/user" ? "page" : undefined}
         >
@@ -44,7 +52,7 @@ export default function TopBar() {
           onClick={() => setOpen(true)}
           sx={{
             ...fixedIconButtonSx,
-            right: 12,
+            right: { xs: 8, sm: 12 },
             ...(open
               ? { color: "#000", backgroundColor: "#fff", borderRadius: 4 }
               : { color: "white" }),

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,7 +6,12 @@
 /* default to dark to match existing behavior */
 :root { color-scheme: dark; }
 * { box-sizing: border-box; }
-html, body, #root { height: 100%; margin: 0; }
+html, body, #root {
+  height: 100%;
+  width: 100%;
+  min-height: 100vh;
+  margin: 0;
+}
 body {
   font-family: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Arial;
 }


### PR DESCRIPTION
## Summary
- Expand root element styling to use full viewport size
- Make top bar icon positions responsive for narrow screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aac02661008325b3bd1b8eafee0006