### PR TITLE
feat(song): use searchable template selector

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -38,6 +38,22 @@ function openDetails(title: string) {
   fireEvent.click(screen.getByText(title));
 }
 
+function openTemplateOptions() {
+  openDetails('Structure');
+  const input = screen.getByLabelText(/song templates/i);
+  fireEvent.mouseDown(input);
+  return input;
+}
+
+function selectTemplate(name: string) {
+  const input = openTemplateOptions();
+  const option = screen
+    .getAllByRole('option', { name })
+    .find((el) => el.tagName === 'LI');
+  if (option) fireEvent.click(option);
+  return input;
+}
+
 describe('SongForm', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -142,15 +158,15 @@ describe('SongForm', () => {
 
   it('remembers last used template', () => {
     render(<SongForm />);
-    openDetails('Structure');
-    const select = screen.getByLabelText(/song templates/i) as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: 'Study Session' } });
-    expect(select.value).toBe('Study Session');
+    selectTemplate('Study Session');
+    expect(
+      (screen.getByLabelText(/song templates/i) as HTMLInputElement).value
+    ).toBe('Study Session');
     cleanup();
     render(<SongForm />);
     openDetails('Structure');
     expect(
-      (screen.getByLabelText(/song templates/i) as HTMLSelectElement).value
+      (screen.getByLabelText(/song templates/i) as HTMLInputElement).value
     ).toBe('Study Session');
   });
 
@@ -186,39 +202,52 @@ describe('SongForm', () => {
 
   it('shows Arcane Clash template option', () => {
     render(<SongForm />);
-    openDetails('Structure');
-    expect(screen.getAllByText('Arcane Clash')[0]).toBeInTheDocument();
+    const input = openTemplateOptions();
+    expect(
+      screen.getAllByRole('option', { name: 'Arcane Clash' })[0]
+    ).toBeInTheDocument();
+    fireEvent.keyDown(input, { key: 'Escape' });
   });
 
   it('shows Bossa Nova template option', () => {
     render(<SongForm />);
-    openDetails('Structure');
-    expect(screen.getAllByText('Bossa Nova')[0]).toBeInTheDocument();
+    const input = openTemplateOptions();
+    expect(
+      screen.getAllByRole('option', { name: 'Bossa Nova' })[0]
+    ).toBeInTheDocument();
+    fireEvent.keyDown(input, { key: 'Escape' });
   });
 
   it("shows King's Last Stand template option", () => {
     render(<SongForm />);
-    openDetails('Structure');
-    expect(screen.getAllByText("King's Last Stand")[0]).toBeInTheDocument();
+    const input = openTemplateOptions();
+    expect(
+      screen.getAllByRole('option', { name: "King's Last Stand" })[0]
+    ).toBeInTheDocument();
+    fireEvent.keyDown(input, { key: 'Escape' });
   });
 
   it('shows Ocean Breeze template option', () => {
     render(<SongForm />);
-    openDetails('Structure');
-    expect(screen.getAllByText('Ocean Breeze')[0]).toBeInTheDocument();
+    const input = openTemplateOptions();
+    expect(
+      screen.getAllByRole('option', { name: 'Ocean Breeze' })[0]
+    ).toBeInTheDocument();
+    fireEvent.keyDown(input, { key: 'Escape' });
   });
 
   it('shows City Lights template option', () => {
     render(<SongForm />);
-    openDetails('Structure');
-    expect(screen.getAllByText('City Lights')[0]).toBeInTheDocument();
+    const input = openTemplateOptions();
+    expect(
+      screen.getAllByRole('option', { name: 'City Lights' })[0]
+    ).toBeInTheDocument();
+    fireEvent.keyDown(input, { key: 'Escape' });
   });
 
   it('applies Bossa Nova template', () => {
     render(<SongForm />);
-    openDetails('Structure');
-    const select = screen.getByLabelText(/song templates/i) as HTMLSelectElement;
-    fireEvent.change(select, { target: { value: 'Bossa Nova' } });
+    selectTemplate('Bossa Nova');
     openSection('rhythm-section');
     const label = screen.getByText('Drum Pattern');
     const drumSelect = label.parentElement!.querySelector('select') as HTMLSelectElement;
@@ -242,10 +271,11 @@ describe('SongForm', () => {
       JSON.stringify({ Foo: PRESET_TEMPLATES['Classic Lofi'] })
     );
     render(<SongForm />);
-    openDetails('Structure');
-    const select = screen.getByLabelText(/song templates/i) as HTMLSelectElement;
-    const options = Array.from(select.options).map((o) => o.value);
-    expect(options).toContain('Bossa Nova');
+    const input = openTemplateOptions();
+    expect(
+      screen.getAllByRole('option', { name: 'Bossa Nova' })[0]
+    ).toBeInTheDocument();
+    fireEvent.keyDown(input, { key: 'Escape' });
   });
 
   it('passes selected instruments in spec', async () => {

--- a/src/components/TemplateSelector.tsx
+++ b/src/components/TemplateSelector.tsx
@@ -1,6 +1,8 @@
 import HelpIcon from "./HelpIcon";
 import type { TemplateSpec } from "./SongForm";
 import React from "react";
+import Autocomplete from "@mui/material/Autocomplete";
+import TextField from "@mui/material/TextField";
 import styles from "./SongForm.module.css";
 import clsx from "clsx";
 
@@ -17,31 +19,63 @@ export default function TemplateSelector({
   setSelectedTemplate,
   applyTemplate,
 }: Props) {
+  const templateOptions = React.useMemo(
+    () => [
+      { label: "Custom Structure", value: "" },
+      ...Object.keys(templates).map((name) => ({ label: name, value: name })),
+    ],
+    [templates]
+  );
+
+  const selectedOption = templateOptions.find(
+    (o) => o.value === selectedTemplate
+  ) ?? null;
+
+  const tpl = selectedTemplate ? templates[selectedTemplate] : null;
+
   return (
     <div className={styles.panel}>
       <div className={styles.label}>
         Song Templates
         <HelpIcon text="Select a preset arrangement and settings" />
       </div>
-      <select
-        aria-label="Song Templates"
-        value={selectedTemplate}
-        onChange={(e) => {
-          const templateName = e.target.value;
+      <Autocomplete
+        options={templateOptions}
+        value={selectedOption}
+        onChange={(_e, newValue) => {
+          const templateName = newValue?.value ?? "";
           setSelectedTemplate(templateName);
           if (templateName && templates[templateName]) {
             applyTemplate(templates[templateName]);
           }
         }}
-        className={clsx(styles.input, "py-2 px-3")}
-      >
-        <option value="">Custom Structure</option>
-        {Object.keys(templates).map((name) => (
-          <option key={name} value={name}>
-            {name}
-          </option>
-        ))}
-      </select>
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            inputProps={{
+              ...params.inputProps,
+              "aria-label": "Song Templates",
+              className: clsx(styles.input, "py-2 px-3"),
+            }}
+            placeholder="Select template"
+          />
+        )}
+      />
+      {tpl && (
+        <div className={clsx(styles.small, "mt-2")}
+        >
+          <div>
+            <strong>Structure:</strong>{" "}
+            {tpl.structure.map((s) => `${s.name} (${s.bars})`).join(", ")}
+          </div>
+          <div>
+            <strong>BPM:</strong> {tpl.bpm}
+          </div>
+          <div>
+            <strong>Mood:</strong> {tpl.mood.join(", ")}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -43,151 +43,90 @@ exports[`SongForm > renders default form 1`] = `
             </svg>
           </button>
         </div>
-        <select
-          aria-label="Song Templates"
-          class="_input_62bdff py-2 px-3"
+        <div
+          class="MuiAutocomplete-root MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon css-1tlcqt-MuiAutocomplete-root"
         >
-          <option
-            value=""
+          <div
+            class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
           >
-            Custom Structure
-          </option>
-          <option
-            value="Classic Lofi"
-          >
-            Classic Lofi
-          </option>
-          <option
-            value="Study Session"
-          >
-            Study Session
-          </option>
-          <option
-            value="Jazz Cafe"
-          >
-            Jazz Cafe
-          </option>
-          <option
-            value="Midnight Drive"
-          >
-            Midnight Drive
-          </option>
-          <option
-            value="Rain & Coffee"
-          >
-            Rain & Coffee
-          </option>
-          <option
-            value="Bossa Nova"
-          >
-            Bossa Nova
-          </option>
-          <option
-            value="Quick Beat"
-          >
-            Quick Beat
-          </option>
-          <option
-            value="New Fantasy"
-          >
-            New Fantasy
-          </option>
-          <option
-            value="Sleep"
-          >
-            Sleep
-          </option>
-          <option
-            value="Sunset Sketches"
-          >
-            Sunset Sketches
-          </option>
-          <option
-            value="Neon Rain"
-          >
-            Neon Rain
-          </option>
-          <option
-            value="Loft Morning"
-          >
-            Loft Morning
-          </option>
-          <option
-            value="Late Night Coding"
-          >
-            Late Night Coding
-          </option>
-          <option
-            value="Forest Spirits"
-          >
-            Forest Spirits
-          </option>
-          <option
-            value="Linear Drift"
-          >
-            Linear Drift
-          </option>
-          <option
-            value="Odd Odyssey"
-          >
-            Odd Odyssey
-          </option>
-          <option
-            value="Arcane Clash"
-          >
-            Arcane Clash
-          </option>
-          <option
-            value="King's Last Stand"
-          >
-            King's Last Stand
-          </option>
-          <option
-            value="Dragon's Fury"
-          >
-            Dragon's Fury
-          </option>
-          <option
-            value="Siege of Stormkeep"
-          >
-            Siege of Stormkeep
-          </option>
-          <option
-            value="Final Hour at the Citadel"
-          >
-            Final Hour at the Citadel
-          </option>
-          <option
-            value="Ocean Breeze"
-          >
-            Ocean Breeze
-          </option>
-          <option
-            value="City Lights"
-          >
-            City Lights
-          </option>
-          <option
-            value="Starlit Voyage"
-          >
-            Starlit Voyage
-          </option>
-          <option
-            value="Sunset VHS"
-          >
-            Sunset VHS
-          </option>
-          <option
-            value="Neon Palms"
-          >
-            Neon Palms
-          </option>
-          <option
-            value="Night Swim"
-          >
-            Night Swim
-          </option>
-        </select>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiAutocomplete-inputRoot css-1n04w30-MuiInputBase-root-MuiOutlinedInput-root"
+            >
+              <input
+                aria-autocomplete="list"
+                aria-expanded="false"
+                aria-invalid="false"
+                aria-label="Song Templates"
+                autocapitalize="none"
+                autocomplete="off"
+                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedEnd _input_62bdff py-2 px-3 css-1dune0f-MuiInputBase-input-MuiOutlinedInput-input"
+                id="«r2»"
+                placeholder="Select template"
+                role="combobox"
+                spellcheck="false"
+                type="text"
+                value="Custom Structure"
+              />
+              <div
+                class="MuiAutocomplete-endAdornment css-1uhhrmm-MuiAutocomplete-endAdornment"
+              >
+                <button
+                  aria-label="Clear"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-clearIndicator css-1x7n7v0-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-clearIndicator"
+                  tabindex="-1"
+                  title="Clear"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="CloseIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Open"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium MuiAutocomplete-popupIndicator css-2y136s-MuiButtonBase-root-MuiIconButton-root-MuiAutocomplete-popupIndicator"
+                  tabindex="-1"
+                  title="Open"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                    data-testid="ArrowDropDownIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 10l5 5 5-5z"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-1nf2c5d-MuiNotchedOutlined-root"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="notranslate"
+                  >
+                    ​
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
       </div>
       <div
         class="_row_62bdff"


### PR DESCRIPTION
## Summary
- replace select with MUI Autocomplete for song template selection
- show key details of selected template
- adapt SongForm tests to new template picker

## Testing
- `npm test -- src/components/SongForm.test.tsx -u`


------
https://chatgpt.com/codex/tasks/task_e_68aac4c3343483259978160a4cff3031