### PR TITLE
Add pyaudioop dependency for Python 3.13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Install the following tools before working with the project:
 
 - **Rust** – required for the Tauri backend. Install via [rustup](https://rustup.rs/).
 - **Node.js** – version 18 or later for the React/Vite front‑end.
-- **Python** – version 3.10+ for audio scripts.
+- **Python** – version 3.10+ for audio scripts. Python 3.13 or later also
+  requires the [`pyaudioop`](https://pypi.org/project/pyaudioop/) module.
 - **FFmpeg** – used by the Python scripts for reading and writing audio. Ensure
   `ffmpeg` and `ffprobe` are available on your `PATH`. On macOS or Linux install
   via your package manager (for example `brew install ffmpeg` or `sudo apt install ffmpeg`).
@@ -25,6 +26,9 @@ npm install
 # create/activate a Python environment, then
 pip install -r requirements.txt  # or: pip install .
 ```
+
+`pyaudioop` is included in the requirements and will be installed automatically on
+Python 3.13+ to replace the removed `audioop` module.
 
 ## Running the Tauri app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ aiohttp>=3.9.0
 TTS>=0.15
 torch>=2.0
 vosk>=0.3.45
+pyaudioop ; python_version >= "3.13"  # audioop module for Python 3.13+

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,6 @@ setup(
         'numpy>=1.21.0',
         'pydub>=0.25.0',
         'gTTS>=2.5.1',
+        'pyaudioop; python_version >= "3.13"',
     ],
 )


### PR DESCRIPTION
## Summary
- include `pyaudioop` in `requirements.txt` and `setup.py` so audio scripts work on Python 3.13+
- document `pyaudioop` in the build instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab644ac12483259ba45f1e7de9eca9