### PR TITLE
feat(settings): streamline python path

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -80,6 +80,7 @@ fn main() {
             // Paths:
             commands::load_paths,
             commands::save_paths,
+            commands::detect_python,
             // Stocks:
             commands::stocks_fetch,
             commands::stock_forecast,

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -166,6 +166,7 @@ function PathField({
 export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   const {
     pythonPath,
+    defaultPythonPath,
     setPythonPath,
     comfyPath,
     setComfyPath,
@@ -209,6 +210,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   const [ttsLanguageDraft, setTtsLanguageDraft] = useState(ttsLanguage);
   const [folderDraft, setFolderDraft] = useState(folder);
   const [themeDraft, setThemeDraft] = useState<Theme>(theme);
+  const [editPython, setEditPython] = useState(false);
 
   useEffect(() => setPythonDraft(pythonPath), [pythonPath]);
   useEffect(() => setComfyDraft(comfyPath), [comfyPath]);
@@ -254,6 +256,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
     if (!value) return;
     const item = searchIndex.find((i) => i.label === value);
     if (item) {
+      if (item.elementId === "python-path") setEditPython(true);
       setSection(item.section);
       setTimeout(() => {
         document.getElementById(item.elementId)?.scrollIntoView({ behavior: "smooth" });
@@ -264,7 +267,33 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   const EnvironmentSection = () => (
     <>
       <Typography variant="subtitle1">Paths</Typography>
-      <PathField id="python-path" label="Python Path" value={pythonDraft} onChange={setPythonDraft} />
+      {!editPython ? (
+        <Button
+          variant="outlined"
+          sx={{ mt: 1, mb: 1 }}
+          onClick={() => setEditPython(true)}
+        >
+          Edit Python path
+        </Button>
+      ) : (
+        <Box>
+          <PathField
+            id="python-path"
+            label="Python Path"
+            value={pythonDraft}
+            onChange={setPythonDraft}
+          />
+          {pythonDraft !== defaultPythonPath && (
+            <Button
+              variant="text"
+              sx={{ mt: 1 }}
+              onClick={() => setPythonDraft(defaultPythonPath)}
+            >
+              Use default
+            </Button>
+          )}
+        </Box>
+      )}
       <PathField
         id="comfy-path"
         label="ComfyUI Folder"
@@ -311,6 +340,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
           setTtsSpeaker(ttsSpeakerDraft);
           setTtsLanguage(ttsLanguageDraft);
           setPathsSaved(true);
+          setEditPython(false);
         }}
       >
         Save Paths

--- a/src/features/paths/usePaths.ts
+++ b/src/features/paths/usePaths.ts
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 
 interface PathsState {
   pythonPath: string;
+  defaultPythonPath: string;
   comfyPath: string;
   ttsModelPath: string;
   ttsConfigPath: string;
@@ -21,6 +22,7 @@ interface PathsState {
 
 const usePathsStore = create<PathsState>((set, get) => ({
   pythonPath: "",
+  defaultPythonPath: "",
   comfyPath: "",
   ttsModelPath: "",
   ttsConfigPath: "",
@@ -104,8 +106,10 @@ const usePathsStore = create<PathsState>((set, get) => ({
         tts_speaker?: string;
         tts_language?: string;
       }>("load_paths");
+      const detected = await invoke<string>("detect_python");
       set({
         pythonPath: res.python_path || "",
+        defaultPythonPath: detected,
         comfyPath: res.comfy_path || "",
         ttsModelPath: res.tts_model_path || "",
         ttsConfigPath: res.tts_config_path || "",


### PR DESCRIPTION
## Summary
- auto-detect python interpreter and expose detect_python command
- track default python path and hide manual editing behind an explicit toggle
- allow reverting to the auto-detected path with a "Use default" option

## Testing
- `npm test`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab81b78dd4832595ee2540161299e7