### PR TITLE
feat: require world selection for DND

### DIFF
--- a/src/features/dnd/LoreForm.tsx
+++ b/src/features/dnd/LoreForm.tsx
@@ -1,20 +1,21 @@
 import { useState } from "react";
-import { Typography, TextField, Button, MenuItem, Grid, Box } from "@mui/material";
+import { Typography, TextField, Button, Grid, Box } from "@mui/material";
 import { zLore } from "./schemas";
 import { LoreData } from "./types";
-import { useWorlds } from "../../store/worlds";
 import LorePdfUpload from "./LorePdfUpload";
 import { useDndTheme, themeStyles } from "./theme";
 
-export default function LoreForm() {
+interface Props {
+  world: string;
+}
+
+export default function LoreForm({ world }: Props) {
   const [name, setName] = useState("");
   const [summary, setSummary] = useState("");
   const [location, setLocation] = useState("");
   const [hooks, setHooks] = useState("");
   const [tags, setTags] = useState("");
   const [result, setResult] = useState<LoreData | null>(null);
-  const worlds = useWorlds((s) => s.worlds);
-  const [world, setWorld] = useState("");
   const theme = useDndTheme();
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -40,26 +41,8 @@ export default function LoreForm() {
           <Typography variant="h6">Lore Form</Typography>
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
-            select
-            label="World"
-            value={world}
-            onChange={(e) => setWorld(e.target.value)}
-            fullWidth
-            margin="normal"
-          >
-            {worlds.map((w) => (
-              <MenuItem key={w} value={w}>
-                {w}
-              </MenuItem>
-            ))}
-          </TextField>
+          <LorePdfUpload world={world} />
         </Grid>
-        {world && (
-          <Grid item xs={12} md={6}>
-            <LorePdfUpload world={world} />
-          </Grid>
-        )}
         <Grid item xs={12} md={6}>
           <TextField
             label="Name"

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   FormControlLabel,
   Checkbox,
-  MenuItem,
   Grid,
   Box,
 } from "@mui/material";
@@ -13,11 +12,14 @@ import FormErrorText from "./FormErrorText";
 import { z } from "zod";
 import { zNpc } from "../../dnd/schemas/npc";
 import { NpcData } from "./types";
-import { useWorlds } from "../../store/worlds";
 import NpcPdfUpload from "./NpcPdfUpload";
 import { useDndTheme, themeStyles } from "./theme";
 
-export default function NpcForm() {
+interface Props {
+  world: string;
+}
+
+export default function NpcForm({ world }: Props) {
   const [name, setName] = useState("");
   const [species, setSpecies] = useState("");
   const [role, setRole] = useState("");
@@ -37,8 +39,6 @@ export default function NpcForm() {
   const [tags, setTags] = useState("");
   const [errors, setErrors] = useState<Record<string, string | null>>({});
   const [result, setResult] = useState<NpcData | null>(null);
-  const worlds = useWorlds((s) => s.worlds);
-  const [world, setWorld] = useState("");
   const theme = useDndTheme();
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -106,26 +106,8 @@ export default function NpcForm() {
           <Typography variant="h6">NPC Form</Typography>
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
-            select
-            label="World"
-            value={world}
-            onChange={(e) => setWorld(e.target.value)}
-            fullWidth
-            margin="normal"
-          >
-            {worlds.map((w) => (
-              <MenuItem key={w} value={w}>
-                {w}
-              </MenuItem>
-            ))}
-          </TextField>
+          <NpcPdfUpload world={world} />
         </Grid>
-        {world && (
-          <Grid item xs={12} md={6}>
-            <NpcPdfUpload world={world} />
-          </Grid>
-        )}
         <Grid item xs={12} md={6}>
           <TextField
             label="Name"

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -22,55 +22,79 @@ import SpellForm from "../features/dnd/SpellForm";
 import DiceRoller from "../features/dnd/DiceRoller";
 import TabletopMap from "../features/dnd/TabletopMap";
 import WarTable from "../features/dnd/WarTable";
+import { useWorlds } from "../store/worlds";
 
 export default function DND() {
   const [tab, setTab] = useState(0);
   const [selectedTheme, setSelectedTheme] = useState<DndTheme>("Parchment");
+  const [world, setWorld] = useState("");
+  const worlds = useWorlds((s) => s.worlds);
   const handleChange = (_e: SyntheticEvent, v: number) => setTab(v);
   return (
     <DndThemeContext.Provider value={selectedTheme}>
       <Box sx={{ p: 2 }}>
-        <Tabs
-          value={tab}
-          onChange={handleChange}
-          variant="scrollable"
-          scrollButtons="auto"
-          sx={{ bgcolor: "#f3e5ab" }}
-        >
-          <Tab icon={<Person />} label="NPC" />
-          <Tab icon={<MenuBook />} label="Lore" />
-          <Tab icon={<TravelExplore />} label="Quest" />
-          <Tab icon={<SportsKabaddi />} label="Encounter" />
-          <Tab icon={<Gavel />} label="Rulebook" />
-          <Tab icon={<AutoStories />} label="Spellbook" />
-          <Tab icon={<Casino />} label="Dice" />
-          <Tab icon={<Map />} label="Tabletop" />
-          <Tab icon={<MilitaryTech />} label="War Table" />
-        </Tabs>
         <Box sx={{ my: 2, maxWidth: 200 }}>
           <TextField
             select
-            label="Theme"
-            value={selectedTheme}
-            onChange={(e) => setSelectedTheme(e.target.value as DndTheme)}
+            label="World"
+            value={world}
+            onChange={(e) => setWorld(e.target.value)}
             fullWidth
           >
-            {themes.map((t) => (
-              <MenuItem key={t} value={t}>
-                {t}
+            {worlds.map((w) => (
+              <MenuItem key={w} value={w}>
+                {w}
               </MenuItem>
             ))}
           </TextField>
         </Box>
-        {tab === 0 && <NpcForm />}
-        {tab === 1 && <LoreForm />}
-        {tab === 2 && <QuestForm />}
-        {tab === 3 && <EncounterForm />}
-        {tab === 4 && <RuleForm />}
-        {tab === 5 && <SpellForm />}
-        {tab === 6 && <DiceRoller />}
-        {tab === 7 && <TabletopMap />}
-        {tab === 8 && <WarTable />}
+        {world && (
+          <>
+            <Tabs
+              value={tab}
+              onChange={handleChange}
+              variant="scrollable"
+              scrollButtons="auto"
+              sx={{ bgcolor: "#f3e5ab" }}
+            >
+              <Tab icon={<Person />} label="NPC" />
+              <Tab icon={<MenuBook />} label="Lore" />
+              <Tab icon={<TravelExplore />} label="Quest" />
+              <Tab icon={<SportsKabaddi />} label="Encounter" />
+              <Tab icon={<Gavel />} label="Rulebook" />
+              <Tab icon={<AutoStories />} label="Spellbook" />
+              <Tab icon={<Casino />} label="Dice" />
+              <Tab icon={<Map />} label="Tabletop" />
+              <Tab icon={<MilitaryTech />} label="War Table" />
+            </Tabs>
+            <Box sx={{ my: 2, maxWidth: 200 }}>
+              <TextField
+                select
+                label="Theme"
+                value={selectedTheme}
+                onChange={(e) =>
+                  setSelectedTheme(e.target.value as DndTheme)
+                }
+                fullWidth
+              >
+                {themes.map((t) => (
+                  <MenuItem key={t} value={t}>
+                    {t}
+                  </MenuItem>
+                ))}
+              </TextField>
+            </Box>
+            {tab === 0 && <NpcForm world={world} />}
+            {tab === 1 && <LoreForm world={world} />}
+            {tab === 2 && <QuestForm />}
+            {tab === 3 && <EncounterForm />}
+            {tab === 4 && <RuleForm />}
+            {tab === 5 && <SpellForm />}
+            {tab === 6 && <DiceRoller />}
+            {tab === 7 && <TabletopMap />}
+            {tab === 8 && <WarTable />}
+          </>
+        )}
       </Box>
     </DndThemeContext.Provider>
   );


### PR DESCRIPTION
## Summary
- require selecting a world before accessing DND tools
- pass selected world to NPC and Lore forms, removing per-form world dropdowns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8a27ff9c8325ab3a0067b16baa56