### PR TITLE
Use audioop-lts for Python 3.13 audio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the following tools before working with the project:
 - **Rust** – required for the Tauri backend. Install via [rustup](https://rustup.rs/).
 - **Node.js** – version 18 or later for the React/Vite front‑end.
 - **Python** – version 3.10+ for audio scripts. Python 3.13 or later also
-  requires the [`pyaudioop`](https://pypi.org/project/pyaudioop/) module.
+  requires the [`audioop-lts`](https://pypi.org/project/audioop-lts/) module.
 - **FFmpeg** – used by the Python scripts for reading and writing audio. Ensure
   `ffmpeg` and `ffprobe` are available on your `PATH`. On macOS or Linux install
   via your package manager (for example `brew install ffmpeg` or `sudo apt install ffmpeg`).
@@ -27,7 +27,7 @@ npm install
 pip install -r requirements.txt  # or: pip install .
 ```
 
-`pyaudioop` is included in the requirements and will be installed automatically on
+`audioop-lts` is included in the requirements and will be installed automatically on
 Python 3.13+ to replace the removed `audioop` module.
 
 ## Running the Tauri app

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ aiohttp>=3.9.0
 TTS>=0.15
 torch>=2.0
 vosk>=0.3.45
-pyaudioop ; python_version >= "3.13"  # audioop module for Python 3.13+
+audioop-lts ; python_version >= "3.13"  # audioop module for Python 3.13+

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(
         'numpy>=1.21.0',
         'pydub>=0.25.0',
         'gTTS>=2.5.1',
-        'pyaudioop; python_version >= "3.13"',
+        'audioop-lts; python_version >= "3.13"',
     ],
 )


### PR DESCRIPTION
## Summary
- replace deprecated pyaudioop with audioop-lts for Python 3.13+
- document audioop-lts requirement in README and setup

## Testing
- `pytest`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aba6d82de483258d53612974a6e309