### PR TITLE
Use absolute imports in lofi renderer

### DIFF
--- a/src-tauri/python/lofi/renderer.py
+++ b/src-tauri/python/lofi/renderer.py
@@ -37,7 +37,7 @@ import numpy as np
 from pydub import AudioSegment
 from pydub.exceptions import CouldntDecodeError
 
-from .dsp import (
+from lofi.dsp import (
     SR,
     _butter_lowpass,
     _butter_highpass,
@@ -50,7 +50,7 @@ from .dsp import (
     _apply_duck_envelope,
     _schroeder_room,
 )
-from .io_utils import ensure_wav_bitdepth
+from lofi.io_utils import ensure_wav_bitdepth
 
 
 class _JsonFormatter(logging.Formatter):


### PR DESCRIPTION
## Summary
- refactor lofi renderer to use absolute imports for dsp and io_utils

## Testing
- `python -m lofi.renderer`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abbdd20d7483259cecc1fd65edc00e