### PR TITLE
Ensure SongSpec test covers all fields

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -624,6 +624,7 @@ mod tests {
         let spec = SongSpec {
             out_dir: "out".into(),
             title: "t".into(),
+            album: None,
             bpm: 80,
             key: "C".into(),
             form: None,


### PR DESCRIPTION
## Summary
- include `album` field in `SongSpec` test to ensure struct literals specify all fields

## Testing
- `cargo test` *(fails: name `tests` is defined multiple times)*

------
https://chatgpt.com/codex/tasks/task_e_68abc330fbb883259fb93280470ed1d8