### PR TITLE
refactor: consolidate tests module

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1431,7 +1431,7 @@ fn extract_intent(content: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
+mod intent_tests {
     use super::*;
 
     #[test]


### PR DESCRIPTION
## Summary
- rename intent tests module to avoid duplicate `tests` modules

## Testing
- `cargo test --no-run` *(fails: missing field `album` in `SongSpec` initializer)*

------
https://chatgpt.com/codex/tasks/task_e_68abc3af045c832585cfdb6e91efb2bd