### PR TITLE
Add album field to SongSpec initializations

### DIFF
--- a/src/components/AlbumWizard.tsx
+++ b/src/components/AlbumWizard.tsx
@@ -14,6 +14,7 @@ export type Section = { name: string; bars: number; chords: string[] };
 type SongSpec = {
   title: string;
   outDir: string;
+  album?: string;
   bpm: number;
   key: string;
   structure: Section[];
@@ -130,6 +131,7 @@ export default function AlbumWizard() {
     return {
       title: titleBase,
       outDir,
+      album: undefined,
       bpm,
       key,
       structure: defaultTpl.structure,

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -26,6 +26,7 @@ export type Section = { name: string; bars: number; chords: string[]; barsStr?: 
 type SongSpec = {
   title: string;
   outDir: string;
+  album?: string;
   bpm: number;
   key: string;
   structure?: Section[];
@@ -650,6 +651,7 @@ export default function SongForm() {
     return {
       title: buildTitle(i),
       outDir,
+      album: albumMode ? albumName : undefined,
       bpm: jitterBpm(i),
       key: formatSpecKey(pickKey(i)),
       structure: structure.map(({ name, bars, chords }) => ({ name, bars, chords })),


### PR DESCRIPTION
## Summary
- include optional `album` in `SongSpec` type definitions
- pass along album data when building song specs

## Testing
- `npm test -- --run`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abc9880c5c8325a1e2d07a8ea86919