### PR TITLE
Use module invocation for lofi renderer

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -720,6 +720,11 @@ pub async fn run_lofi_song<R: Runtime>(
     if !script.exists() {
         return Err(format!("Script not found at {}", script.display()));
     }
+    let python_dir = script
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| "invalid script path".to_string())?;
 
     // Ensure the output directory exists
     let out_dir = PathBuf::from(&spec.out_dir);
@@ -735,8 +740,10 @@ pub async fn run_lofi_song<R: Runtime>(
 
     // Launch Python
     let mut cmd = PCommand::new(&py);
-    cmd.arg("-u")
-        .arg(&script)
+    cmd.current_dir(python_dir)
+        .arg("-u")
+        .arg("-m")
+        .arg("lofi.renderer")
         .arg("--song-json")
         .arg(json_str)
         .arg("--out")
@@ -1447,7 +1454,6 @@ fn extract_intent(content: &str) -> String {
         _ => "chat".to_string(),
     }
 }
-
 
 #[tauri::command]
 pub async fn stocks_fetch<R: Runtime>(


### PR DESCRIPTION
## Summary
- Spawn Python using `-m lofi.renderer` instead of file paths
- Set working directory so `lofi` module imports succeed

## Testing
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `python -m lofi.renderer --help` *(fails: ffmpeg not found; please install ffmpeg and ensure it is on PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68abd0577a5883259ff30e7c69859e1f