### PR TITLE
feat: enable world creation in DND selector

### DIFF
--- a/src/pages/DND.test.tsx
+++ b/src/pages/DND.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import DND from "./DND";
+import { useWorlds } from "../store/worlds";
+
+describe("DND world selector", () => {
+  afterEach(() => {
+    cleanup();
+    useWorlds.setState({ worlds: [] });
+    useWorlds.persist.clearStorage();
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("allows creating and saving a new world", () => {
+    vi.spyOn(window, "prompt").mockReturnValue("Eberron");
+    render(<DND />);
+    fireEvent.change(screen.getByLabelText("World"), {
+      target: { value: "__new__" },
+    });
+    expect(screen.getByDisplayValue("Eberron")).toBeInTheDocument();
+    expect(useWorlds.getState().worlds).toContain("Eberron");
+  });
+});

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -10,7 +10,7 @@ import {
   Map,
   MilitaryTech,
 } from "@mui/icons-material";
-import { SyntheticEvent, useState } from "react";
+import { SyntheticEvent, useState, ChangeEvent } from "react";
 import { DndThemeContext, themes } from "../features/dnd/theme";
 import type { DndTheme } from "../features/dnd/types";
 import NpcForm from "../features/dnd/NpcForm";
@@ -29,16 +29,29 @@ export default function DND() {
   const [selectedTheme, setSelectedTheme] = useState<DndTheme>("Parchment");
   const [world, setWorld] = useState("");
   const worlds = useWorlds((s) => s.worlds);
+  const addWorld = useWorlds((s) => s.addWorld);
   const handleChange = (_e: SyntheticEvent, v: number) => setTab(v);
+  const handleWorldChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value === "__new__") {
+      const name = window.prompt("Enter world name")?.trim();
+      if (name) {
+        addWorld(name);
+        setWorld(name);
+      }
+    } else {
+      setWorld(value);
+    }
+  };
   return (
     <DndThemeContext.Provider value={selectedTheme}>
       <Box sx={{ p: 2 }}>
-        <Box sx={{ my: 2, maxWidth: 200 }}>
+        <Box sx={{ my: 2, maxWidth: 200, mx: "auto" }}>
           <TextField
             select
             label="World"
             value={world}
-            onChange={(e) => setWorld(e.target.value)}
+            onChange={handleWorldChange}
             fullWidth
           >
             {worlds.map((w) => (
@@ -46,6 +59,7 @@ export default function DND() {
                 {w}
               </MenuItem>
             ))}
+            <MenuItem value="__new__">Create New World</MenuItem>
           </TextField>
         </Box>
         {world && (


### PR DESCRIPTION
## Summary
- center the DND world selector
- add option to create new worlds and persist them
- test world creation from the selector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abd13250448325871374407bf1fc22