### PR TITLE
Install lofi package in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='blossom-audio',
     version='0.1.8',
+    packages=find_packages(where="src-tauri/python"),
+    package_dir={"": "src-tauri/python"},
     install_requires=[
         'scipy>=1.9.0',
         'pyloudnorm>=0.1.0',


### PR DESCRIPTION
## Summary
- ensure lofi Python package under src-tauri/python is included when installing the project
- add find_packages and package_dir to setup.py

## Testing
- `pip install .`
- `python -c "import lofi; print(lofi.__file__)"`


------
https://chatgpt.com/codex/tasks/task_e_68abd73f6d84832590f246bd00ac6448