### PR TITLE
feat: add gpu monitor to song form page

### DIFF
--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -1,6 +1,9 @@
 // src/pages/Music.tsx
 import SongForm from "../components/SongForm";
 import VersionBadge from "../components/VersionBadge";
+import SystemInfoWidget from "../components/SystemInfoWidget";
+import { Box } from "@mui/material";
+import { systemInfoWidgetSx } from "./homeStyles";
 
 export default function Music() {
   return (
@@ -30,6 +33,11 @@ export default function Music() {
       <div style={{ maxWidth: 980, margin: "0 auto", padding: "24px 16px" }}>
         <SongForm />
       </div>
+
+      {/* System info widget */}
+      <Box sx={systemInfoWidgetSx}>
+        <SystemInfoWidget />
+      </Box>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show a floating system info widget on the song form page to monitor GPU usage

## Testing
- `npm test` *(fails: Failed to resolve entry for package '@react-three/cannon')*


------
https://chatgpt.com/codex/tasks/task_e_68abeb105f2083258cb7c1e9bb0e8931