### PR TITLE
Persist selected DnD world across reloads

### DIFF
--- a/src/pages/DND.test.tsx
+++ b/src/pages/DND.test.tsx
@@ -6,7 +6,7 @@ import { useWorlds } from "../store/worlds";
 describe("DND world selector", () => {
   afterEach(() => {
     cleanup();
-    useWorlds.setState({ worlds: [] });
+    useWorlds.setState({ worlds: [], currentWorld: '' });
     useWorlds.persist.clearStorage();
     localStorage.clear();
     vi.restoreAllMocks();
@@ -20,5 +20,6 @@ describe("DND world selector", () => {
     });
     expect(screen.getByDisplayValue("Eberron")).toBeInTheDocument();
     expect(useWorlds.getState().worlds).toContain("Eberron");
+    expect(useWorlds.getState().currentWorld).toBe("Eberron");
   });
 });

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -27,9 +27,10 @@ import { useWorlds } from "../store/worlds";
 export default function DND() {
   const [tab, setTab] = useState(0);
   const [selectedTheme, setSelectedTheme] = useState<DndTheme>("Parchment");
-  const [world, setWorld] = useState("");
   const worlds = useWorlds((s) => s.worlds);
+  const world = useWorlds((s) => s.currentWorld);
   const addWorld = useWorlds((s) => s.addWorld);
+  const setCurrentWorld = useWorlds((s) => s.setCurrentWorld);
   const handleChange = (_e: SyntheticEvent, v: number) => setTab(v);
   const handleWorldChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -37,10 +38,10 @@ export default function DND() {
       const name = window.prompt("Enter world name")?.trim();
       if (name) {
         addWorld(name);
-        setWorld(name);
+        setCurrentWorld(name);
       }
     } else {
-      setWorld(value);
+      setCurrentWorld(value);
     }
   };
   return (

--- a/src/pages/WorldBuilder.test.tsx
+++ b/src/pages/WorldBuilder.test.tsx
@@ -6,7 +6,7 @@ import { useWorlds } from "../store/worlds";
 describe("WorldBuilder", () => {
   afterEach(() => {
     cleanup();
-    useWorlds.setState({ worlds: [] });
+    useWorlds.setState({ worlds: [], currentWorld: '' });
     useWorlds.persist.clearStorage();
     localStorage.clear();
   });

--- a/src/store/worlds.ts
+++ b/src/store/worlds.ts
@@ -3,14 +3,17 @@ import { persist } from 'zustand/middleware';
 
 interface WorldState {
   worlds: string[];
+  currentWorld: string;
   addWorld: (world: string) => void;
   removeWorld: (world: string) => void;
+  setCurrentWorld: (world: string) => void;
 }
 
 export const useWorlds = create<WorldState>()(
   persist(
     (set) => ({
       worlds: [],
+      currentWorld: '',
       addWorld: (world) =>
         set((state) => {
           const name = world.trim();
@@ -25,6 +28,7 @@ export const useWorlds = create<WorldState>()(
         set((state) => ({
           worlds: state.worlds.filter((w) => w !== world),
         })),
+      setCurrentWorld: (world) => set({ currentWorld: world }),
     }),
     { name: 'world-store' }
   )


### PR DESCRIPTION
## Summary
- extend world store with currentWorld and setCurrentWorld actions, persisted via zustand
- use stored world selection in DnD page and save new selections
- update tests to reset currentWorld state

## Testing
- `npm test` *(fails: Failed to resolve entry for package "@react-three/cannon")*

------
https://chatgpt.com/codex/tasks/task_e_68abeb5fdd788325a5c94d790d7c2bde