### PR TITLE
feat: add task drawer

### DIFF
--- a/src/components/TaskDrawer.tsx
+++ b/src/components/TaskDrawer.tsx
@@ -1,0 +1,21 @@
+import { Drawer, Box, Typography } from "@mui/material";
+import TaskList from "./TaskQueue/TaskList";
+
+interface TaskDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function TaskDrawer({ open, onClose }: TaskDrawerProps) {
+  return (
+    <Drawer anchor="right" open={open} onClose={onClose}>
+      <Box sx={{ width: 360, p: 2 }} role="presentation">
+        <Typography variant="h6" sx={{ mb: 1 }}>
+          Task Queue
+        </Typography>
+        <TaskList />
+      </Box>
+    </Drawer>
+  );
+}
+

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,15 +1,21 @@
-import { IconButton, Tooltip } from "@mui/material";
+import { IconButton, Tooltip, Badge } from "@mui/material";
 import type { SxProps } from "@mui/material";
 import { fixedIconButtonSx } from "./sx";
-import { FaHome, FaWrench, FaUser } from "react-icons/fa";
+import { FaHome, FaWrench, FaUser, FaTasks } from "react-icons/fa";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useState } from "react";
 import SettingsDrawer from "./SettingsDrawer";
+import TaskDrawer from "./TaskDrawer";
+import { useTasks } from "../store/tasks";
 
 export default function TopBar() {
   const nav = useNavigate();
   const { pathname } = useLocation();
   const [open, setOpen] = useState(false);
+  const [taskOpen, setTaskOpen] = useState(false);
+  const taskCount = useTasks((s) =>
+    Object.values(s.tasks).filter((t) => t.status === "queued" || t.status === "running").length
+  );
   const activeSx = (p: string): SxProps =>
     pathname === p
       ? { color: "#000", backgroundColor: "#fff", borderRadius: 4 }
@@ -47,6 +53,25 @@ export default function TopBar() {
         </IconButton>
       </Tooltip>
 
+      <Tooltip title="Tasks">
+        <Badge badgeContent={taskCount} color="secondary" invisible={taskCount === 0}>
+          <IconButton
+            onClick={() => setTaskOpen(true)}
+            sx={{
+              ...fixedIconButtonSx,
+              right: { xs: 44, sm: 60 },
+              color: taskOpen ? "#000" : "white",
+              backgroundColor: taskOpen ? "#fff" : "transparent",
+              borderRadius: 4,
+            }}
+            aria-label="Tasks"
+            aria-expanded={taskOpen}
+          >
+            <FaTasks />
+          </IconButton>
+        </Badge>
+      </Tooltip>
+
       <Tooltip title="Settings">
         <IconButton
           onClick={() => setOpen(true)}
@@ -64,6 +89,7 @@ export default function TopBar() {
         </IconButton>
       </Tooltip>
       <SettingsDrawer open={open} onClose={() => setOpen(false)} />
+      <TaskDrawer open={taskOpen} onClose={() => setTaskOpen(false)} />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add TaskDrawer component with TaskList in a right-side drawer
- hook TaskDrawer into top bar with new tasks icon and badge

## Testing
- `npm test` *(passes)*
- `npm test -- --run` *(fails: Failed to resolve entry for package "@react-three/cannon" in dnd DiceRoller)*

------
https://chatgpt.com/codex/tasks/task_e_68abec9bd4c0832591b9f8a99022301f