### PR TITLE
feat(songform): include specs in album generation

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -382,6 +382,11 @@ describe('SongForm', () => {
       );
       expect(call[1].meta.album_name).toBe('My Album');
       expect(call[1].meta.track_names).toEqual(['T1', 'T2', 'T3']);
+      expect(call[1].meta.specs).toHaveLength(3);
+      expect(call[1].meta.specs[0]).toMatchObject({
+        title: 'Test Song 1',
+        album: 'My Album',
+      });
     });
   });
 

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -748,6 +748,9 @@ export default function SongForm() {
 
     try {
       setBusy(true);
+      const specs = Array.from({ length: trackCount }, (_, i) =>
+        makeSpecForIndex(i)
+      );
       const res: { album_dir: string } = await invoke("generate_album", {
         meta: {
           track_count: trackCount,
@@ -755,6 +758,7 @@ export default function SongForm() {
           album_name: albumName,
           track_names: trackNames,
           out_dir: outDir,
+          specs,
         },
       });
       setOutDir(res.album_dir);


### PR DESCRIPTION
## Summary
- build song specs for each track when creating albums
- send track specs array in album generation metadata
- test album mode to ensure specs are transmitted

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abee693b7c832580b405a26320f579