### PR TITLE
feat: add NPC import log

### DIFF
--- a/npc/log/README.md
+++ b/npc/log/README.md
@@ -1,0 +1,14 @@
+# NPC Import Log
+
+Entries are appended in JSON Lines format to `npc-import.log`. Each line is a JSON object with:
+
+- `timestamp`: ISO 8601 string when the NPC was saved
+- `world`: the world identifier
+- `id`: NPC id
+- `name`: NPC name
+
+Example:
+
+```json
+{"timestamp":"2024-01-01T12:00:00Z","world":"forgotten-realms","id":"abc123","name":"Elminster"}
+```

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -71,6 +71,8 @@ fn main() {
             commands::blender_run_script,
             commands::save_npc,
             commands::list_npcs,
+            commands::append_npc_log,
+            commands::read_npc_log,
             commands::save_rule,
             commands::list_rules,
             commands::save_spell,

--- a/src/features/dnd/NpcLog.tsx
+++ b/src/features/dnd/NpcLog.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Button, List, ListItem, ListItemText, Typography } from "@mui/material";
+
+interface LogEntry {
+  timestamp: string;
+  world: string;
+  id: string;
+  name: string;
+}
+
+export default function NpcLog() {
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+
+  async function load() {
+    try {
+      const data = await invoke<LogEntry[]>("read_npc_log", { limit: 20 });
+      setEntries(data);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <div>
+      <Typography variant="h6" sx={{ mt: 2 }}>
+        NPC Import Log
+      </Typography>
+      <Button size="small" onClick={load} sx={{ mb: 1 }}>
+        Refresh
+      </Button>
+      <List dense>
+        {entries.length === 0 && (
+          <ListItem>
+            <ListItemText primary="No entries" />
+          </ListItem>
+        )}
+        {entries.map((e, i) => (
+          <ListItem key={i}>
+            <ListItemText
+              primary={`${e.name} (${e.world})`}
+              secondary={new Date(e.timestamp).toLocaleString()}
+            />
+          </ListItem>
+        ))}
+      </List>
+    </div>
+  );
+}

--- a/src/features/dnd/NpcPdfUpload.tsx
+++ b/src/features/dnd/NpcPdfUpload.tsx
@@ -5,6 +5,7 @@ import { Button, Snackbar, Alert, LinearProgress } from "@mui/material";
 import { useTasks } from "../../store/tasks";
 import { useNPCs } from "../../store/npcs";
 import type { NpcData } from "./types";
+import NpcLog from "./NpcLog";
 
 interface Props {
   world: string;
@@ -17,6 +18,7 @@ export default function NpcPdfUpload({ world }: Props) {
   const [taskId, setTaskId] = useState<number | null>(null);
   const [status, setStatus] = useState<"idle" | "uploading" | "completed">("idle");
   const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [showLog, setShowLog] = useState(false);
 
   async function handleUpload() {
     const selected = await open({ filters: [{ name: "PDF", extensions: ["pdf"] }] });
@@ -47,12 +49,18 @@ export default function NpcPdfUpload({ world }: Props) {
           }
           if (overwrite) {
             await invoke("save_npc", { world, npc, overwrite });
+            await invoke("append_npc_log", {
+              world,
+              id: npc.id,
+              name: npc.name,
+            });
           }
         }
         await loadNPCs();
         setStatus("completed");
         setSnackbarOpen(true);
         setTaskId(null);
+        setShowLog(true);
       })();
     }
   }, [taskId, tasks, world, loadNPCs]);
@@ -73,6 +81,14 @@ export default function NpcPdfUpload({ world }: Props) {
         variant="contained"
       >
         Upload NPC PDF
+      </Button>
+      <Button
+        type="button"
+        onClick={() => setShowLog((s) => !s)}
+        sx={{ ml: 2 }}
+        size="small"
+      >
+        {showLog ? "Hide Log" : "View Log"}
       </Button>
       {task && task.status === "running" && (
         <LinearProgress
@@ -96,6 +112,7 @@ export default function NpcPdfUpload({ world }: Props) {
             : "Uploading NPC PDF..."}
         </Alert>
       </Snackbar>
+      {showLog && <NpcLog />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add JSON-lines NPC import log directory
- append to log after each NPC PDF import and expose log view component
- enable backend commands to read/write NPC import log

## Testing
- `npm test` *(fails: Failed to resolve entry for package "@react-three/cannon")*

------
https://chatgpt.com/codex/tasks/task_e_68abf006e1f08325ad186ef07535ede2