### PR TITLE
Add French horn timbre support

### DIFF
--- a/src-tauri/python/lofi/renderer.py
+++ b/src-tauri/python/lofi/renderer.py
@@ -817,6 +817,8 @@ def _apply_melody_timbre(x, instrs):
         return _butter_bandpass(x, 400, 6000)
     if "trumpet" in instrs:
         return _butter_bandpass(x, 500, 7000)
+    if "french horn" in instrs:
+        return _butter_bandpass(x, 200, 3000)
     if "harp" in instrs or "lute" in instrs:
         return _butter_highpass(_butter_lowpass(x, 7000), 400)
     if "pan flute" in instrs:
@@ -1002,6 +1004,7 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60, chords=None
         "synth plucks",
         "wurlitzer",
         "oboe",
+        "french horn",
     }
     add_rhodes_default = not any(src in instrs for src in melodic_sources)
 

--- a/src-tauri/python/tests/test_french_horn_timbre.py
+++ b/src-tauri/python/tests/test_french_horn_timbre.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import numpy as np
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from lofi.renderer import _apply_melody_timbre
+
+
+def test_french_horn_timbre_bandpass():
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal(44100).astype(np.float32)
+    y = _apply_melody_timbre(x, ["french horn"])
+    rms_in = np.sqrt(np.mean(x**2))
+    rms_out = np.sqrt(np.mean(y**2))
+    assert 0 < rms_out < rms_in


### PR DESCRIPTION
## Summary
- add French horn to melodic source set
- apply band-pass timbre for French horn
- test French horn timbre filtering

## Testing
- `python -m pytest src-tauri/python/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68abf69997508325982dbccc227f3867