### PR TITLE
feat: persist song jobs across SongForm unmounts

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -6,6 +6,7 @@ import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { open as openOpener } from '@tauri-apps/plugin-opener';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
+import { useSongJobs } from '../store/songJobs';
 
 vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
 vi.mock('@tauri-apps/plugin-opener', () => ({ open: vi.fn() }));
@@ -58,6 +59,7 @@ describe('SongForm', () => {
   beforeEach(() => {
     localStorage.clear();
     vi.resetAllMocks();
+    useSongJobs.setState({ jobs: [] });
     Object.defineProperty(global.HTMLMediaElement.prototype, 'play', {
       configurable: true,
       value: vi.fn(),

--- a/src/store/songJobs.ts
+++ b/src/store/songJobs.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+
+export type Job = {
+  id: string;
+  title: string;
+  spec: any;
+  status: string;
+  outPath?: string;
+  error?: string;
+  progress?: number;
+};
+
+interface SongJobsState {
+  jobs: Job[];
+  setJobs: (updater: Job[] | ((prev: Job[]) => Job[])) => void;
+  updateJob: (id: string, update: Partial<Job>) => void;
+}
+
+export const useSongJobs = create<SongJobsState>((set) => ({
+  jobs: [],
+  setJobs: (updater) =>
+    set((state) => ({
+      jobs:
+        typeof updater === 'function'
+          ? (updater as (prev: Job[]) => Job[])(state.jobs)
+          : updater,
+    })),
+  updateJob: (id, update) =>
+    set((state) => ({
+      jobs: state.jobs.map((j) => (j.id === id ? { ...j, ...update } : j)),
+    })),
+}));
+
+export type { SongJobsState };


### PR DESCRIPTION
## Summary
- add Zustand-powered song job store
- wire SongForm to global jobs store and refresh active tasks on mount
- reset shared job store in SongForm tests

## Testing
- `npm test` *(fails: Failed to resolve entry for package "@react-three/cannon")*
- `npm test src/components/SongForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68abf484c65c832599b09ddbea4729aa