### PR TITLE
Add ambience generation command

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -47,6 +47,7 @@ fn main() {
             commands::generate_album,
             commands::cancel_album,
             commands::dj_mix,
+            commands::generate_ambience,
             // ComfyUI:
             commands::comfy_status,
             commands::comfy_start,


### PR DESCRIPTION
## Summary
- add `generate_ambience` command to run Python ambience generator
- register `generate_ambience` with Tauri invoke handler

## Testing
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `npm test` *(fails: Failed to resolve entry for package `@react-three/cannon`)*

------
https://chatgpt.com/codex/tasks/task_e_68abf827b6748325bd00e779e98ddbdf