### PR TITLE
feat: accent primary buttons

### DIFF
--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -530,9 +530,22 @@ export default function NpcForm({ world }: Props) {
         </Grid>
 
         <Grid item xs={12}>
-          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
-            Submit
-          </Button>
+          <Box sx={{ display: "flex", justifyContent: "flex-end", width: "100%" }}>
+            <Button
+              type="submit"
+              variant="contained"
+              size="large"
+              sx={{
+                mt: 2,
+                px: 4,
+                py: 1.5,
+                fontWeight: "bold",
+                "&:hover,&:focus": { boxShadow: "0 0 8px #0f0" },
+              }}
+            >
+              Submit
+            </Button>
+          </Box>
         </Grid>
         {result && (
           <Grid item xs={12}>

--- a/src/features/dnd/NpcPdfUpload.tsx
+++ b/src/features/dnd/NpcPdfUpload.tsx
@@ -79,6 +79,13 @@ export default function NpcPdfUpload({ world }: Props) {
         onClick={handleUpload}
         disabled={!world || status === "uploading"}
         variant="contained"
+        size="large"
+        sx={{
+          px: 4,
+          py: 1.5,
+          fontWeight: "bold",
+          "&:hover,&:focus": { boxShadow: "0 0 8px #0f0" },
+        }}
       >
         Upload NPC PDF
       </Button>


### PR DESCRIPTION
## Summary
- emphasize NPC PDF upload and submit actions with larger, bolder buttons
- add hover/focus glow effect to primary buttons
- align form submit button to bottom-right

## Testing
- `npm test` *(fails: Error: Failed to resolve entry for package "@react-three/cannon")*

------
https://chatgpt.com/codex/tasks/task_e_68abfac8ff6883259e670792271c6249