### PR TITLE
fix: use webview window for ambience logs

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1903,7 +1903,7 @@ pub async fn generate_ambience<R: Runtime>(app: AppHandle<R>) -> Result<(), Stri
         .output()
         .map_err(|e| format!("Failed to start python: {e}"))?;
 
-    if let Some(window) = app.get_window("main") {
+    if let Some(window) = app.get_webview_window("main") {
         for line in String::from_utf8_lossy(&output.stdout).lines() {
             let _ = window.emit("ambience_log", format!("[out] {}", line));
         }


### PR DESCRIPTION
## Summary
- use `get_webview_window` when emitting ambience generator logs

## Testing
- `npm run tauri dev` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abfb992b3883259cfe9cdcb12fa306