### PR TITLE
Generate placeholder images for new NPCs

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "log",
  "nyse-holiday-cal",
  "once_cell",
+ "png",
  "reqwest 0.11.27",
  "robotstxt",
  "rss",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,4 +42,5 @@ sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio-rustls"] }
 futures = "0.3"
 sysinfo = "0.37"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
+png = "0.17"
 

--- a/src/pages/NPCMaker.tsx
+++ b/src/pages/NPCMaker.tsx
@@ -5,6 +5,7 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
 import Center from './_Center';
 import { useNPCs, NPC } from '../store/npcs';
+import { useWorlds } from '../store/worlds';
 
 const systemPrompt =
   'You are a creative assistant that generates random D&D NPCs. Respond only with JSON having keys name, race, class, personality, background, appearance.';
@@ -27,6 +28,7 @@ export default function NPCMaker() {
   const [snackbarOpen, setSnackbarOpen] = useState(false);
 
   const addNPC = useNPCs((s) => s.addNPC);
+  const world = useWorlds((s) => s.currentWorld);
 
   useEffect(() => {
     async function start() {
@@ -121,9 +123,13 @@ export default function NPCMaker() {
         return;
       }
     }
+    if (!world) {
+      setError('Please select a world before saving.');
+      return;
+    }
     try {
-      await invoke('save_npc', { npc });
-      addNPC(npc);
+      const saved = await invoke<NPC>('save_npc', { world, npc });
+      addNPC(saved);
       setNpc({
         name: '',
         race: '',


### PR DESCRIPTION
## Summary
- create blank portrait and icon files when saving an NPC
- store paths to generated placeholders and require world selection on NPC save
- add `png` dependency for image encoding

## Testing
- `cargo test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abfc20fcb08325bf99fb18e17ab087