### PR TITLE
Report save path errors

### DIFF
--- a/src/features/paths/usePaths.test.ts
+++ b/src/features/paths/usePaths.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { usePathsStore } from './usePaths';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+describe('usePaths save_paths error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const setters: [string, string][] = [
+    ['setPythonPath', 'py'],
+    ['setComfyPath', 'comfy'],
+    ['setTtsModelPath', 'model'],
+    ['setTtsConfigPath', 'config'],
+    ['setTtsSpeaker', 'speaker'],
+    ['setTtsLanguage', 'lang'],
+  ];
+
+  it.each(setters)('%s surfaces errors', async (setter, value) => {
+    (invoke as any).mockRejectedValue(new Error('fail'));
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    (usePathsStore.getState() as any)[setter](value);
+    await Promise.resolve();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to save paths'),
+      expect.any(Error)
+    );
+    spy.mockRestore();
+  });
+});

--- a/src/features/paths/usePaths.ts
+++ b/src/features/paths/usePaths.ts
@@ -20,7 +20,7 @@ interface PathsState {
   load: () => Promise<void>;
 }
 
-const usePathsStore = create<PathsState>((set, get) => ({
+export const usePathsStore = create<PathsState>((set, get) => ({
   pythonPath: "",
   defaultPythonPath: "",
   comfyPath: "",
@@ -38,7 +38,9 @@ const usePathsStore = create<PathsState>((set, get) => ({
       tts_config_path: get().ttsConfigPath,
       tts_speaker: get().ttsSpeaker,
       tts_language: get().ttsLanguage,
-    }).catch(() => {});
+    }).catch((err) => {
+      console.error("Failed to save paths:", err);
+    });
   },
   setComfyPath: (comfyPath: string) => {
     set({ comfyPath });
@@ -49,7 +51,9 @@ const usePathsStore = create<PathsState>((set, get) => ({
       tts_config_path: get().ttsConfigPath,
       tts_speaker: get().ttsSpeaker,
       tts_language: get().ttsLanguage,
-    }).catch(() => {});
+    }).catch((err) => {
+      console.error("Failed to save paths:", err);
+    });
   },
   setTtsModelPath: (ttsModelPath: string) => {
     set({ ttsModelPath });
@@ -60,7 +64,9 @@ const usePathsStore = create<PathsState>((set, get) => ({
       tts_config_path: get().ttsConfigPath,
       tts_speaker: get().ttsSpeaker,
       tts_language: get().ttsLanguage,
-    }).catch(() => {});
+    }).catch((err) => {
+      console.error("Failed to save paths:", err);
+    });
   },
   setTtsConfigPath: (ttsConfigPath: string) => {
     set({ ttsConfigPath });
@@ -71,7 +77,9 @@ const usePathsStore = create<PathsState>((set, get) => ({
       tts_config_path: ttsConfigPath,
       tts_speaker: get().ttsSpeaker,
       tts_language: get().ttsLanguage,
-    }).catch(() => {});
+    }).catch((err) => {
+      console.error("Failed to save paths:", err);
+    });
   },
   setTtsSpeaker: (ttsSpeaker: string) => {
     set({ ttsSpeaker });
@@ -82,7 +90,9 @@ const usePathsStore = create<PathsState>((set, get) => ({
       tts_config_path: get().ttsConfigPath,
       tts_speaker: ttsSpeaker,
       tts_language: get().ttsLanguage,
-    }).catch(() => {});
+    }).catch((err) => {
+      console.error("Failed to save paths:", err);
+    });
   },
   setTtsLanguage: (ttsLanguage: string) => {
     set({ ttsLanguage });
@@ -93,7 +103,9 @@ const usePathsStore = create<PathsState>((set, get) => ({
       tts_config_path: get().ttsConfigPath,
       tts_speaker: get().ttsSpeaker,
       tts_language: ttsLanguage,
-    }).catch(() => {});
+    }).catch((err) => {
+      console.error("Failed to save paths:", err);
+    });
   },
   load: async () => {
     if (get().loaded) return;


### PR DESCRIPTION
## Summary
- log failures from `save_paths` in path setters so errors aren't swallowed
- add unit tests ensuring failed `save_paths` calls surface errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abfe2eceec8325906b5d359d7aea1e