### PR TITLE
Use async logging for child processes

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,6 @@ nyse-holiday-cal = "0.2.3"
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio-rustls"] }
 futures = "0.3"
 sysinfo = "0.37"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "io-util", "process"] }
 png = "0.17"
 


### PR DESCRIPTION
## Summary
- stream child process output with async tasks instead of threads
- track spawned tasks for cleanup on shutdown
- add regression test ensuring short-lived commands leave no extra threads

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ac01ddcebc8325a54bfaeb491f7379