### PR TITLE
Handle stale ComfyUI processes and add test coverage

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,3 +44,6 @@ sysinfo = "0.37"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
 png = "0.17"
 
+[dev-dependencies]
+tauri = { version = "2", features = ["protocol-asset", "test"] }
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,9 @@ fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+pub mod commands;
 mod stocks;
+mod task_queue;
 pub use stocks::stocks_fetch;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]

--- a/src-tauri/tests/comfy_status.rs
+++ b/src-tauri/tests/comfy_status.rs
@@ -1,0 +1,18 @@
+use blossom_lib::commands::{comfy_status, __has_comfy_child, __set_comfy_child};
+
+#[tokio::test]
+async fn comfy_status_clears_finished_process() {
+    let _rt = tauri::test::mock_runtime();
+
+    let child = std::process::Command::new("sh")
+        .arg("-c")
+        .arg("exit 0")
+        .spawn()
+        .expect("failed to spawn test process");
+
+    __set_comfy_child(child);
+    assert!(__has_comfy_child());
+
+    assert!(!comfy_status().await.unwrap());
+    assert!(!__has_comfy_child());
+}


### PR DESCRIPTION
## Summary
- reset ComfyUI child handle after process exit and report accurate status
- expose commands for testing and add dev tauri test runtime
- ensure comfy_status drops stale handles via integration test

## Testing
- `npm test` *(passes; watch mode canceled)*
- `cargo test --test comfy_status -- --nocapture` *(failed: could not complete due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0337c6508325bd7ecbb26b67e7f0