### PR TITLE
Handle rule parsing from task result

### DIFF
--- a/src/features/dnd/RulePdfUpload.tsx
+++ b/src/features/dnd/RulePdfUpload.tsx
@@ -39,8 +39,13 @@ export default function RulePdfUpload() {
   useEffect(() => {
     if (!taskId) return;
     const task = tasks[taskId];
-    if (task && task.status === "completed" && Array.isArray(task.result)) {
-      const raw = task.result as RuleRecord[];
+    if (
+      task &&
+      task.status === "completed" &&
+      task.result &&
+      Array.isArray((task.result as any).rules)
+    ) {
+      const raw = (task.result as any).rules as RuleRecord[];
       const parsed: RuleData[] = raw.map((r) => ({
         id: `rule_${r.name.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`,
         name: r.name,


### PR DESCRIPTION
## Summary
- handle rule parsing when task result returns `rules` array
- add regression test for rule saving from parsed PDF

## Testing
- `npx vitest run src/features/dnd/tests/RulePdfUpload.test.tsx` *(fails: expected +0 to be 2 // Object.is equality)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0530e1fc832586deba9b5ef4ed78