### PR TITLE
feat: populate npc spec defaults

### DIFF
--- a/scripts/npc-gen.ts
+++ b/scripts/npc-gen.ts
@@ -34,14 +34,23 @@ async function main() {
     const spec = {
       id,
       name: `${theme} NPC ${i + 1}`,
-      tags: [theme]
+      species: "Unknown",
+      role: "Commoner",
+      alignment: "Neutral",
+      playerCharacter: false,
+      hooks: ["A mysterious opportunity"],
+      statblock: {},
+      tags: [theme],
     };
     const parsed = zNpc.safeParse(spec);
     if (!parsed.success) {
       console.error("Validation failed", parsed.error);
       continue;
     }
-    await fs.writeFile(path.join(specsDir, `${id}.json`), JSON.stringify(spec, null, 2));
+    await fs.writeFile(
+      path.join(specsDir, `${id}.json`),
+      JSON.stringify(spec, null, 2)
+    );
   }
 
   await reindex();


### PR DESCRIPTION
## Summary
- seed new NPC specs with placeholder fields required by zNpc schema

## Testing
- `npm test`
- `npm run npc:gen -- --theme test --count 1`


------
https://chatgpt.com/codex/tasks/task_e_68ac064912f48325a116cff0d7f6b637