### PR TITLE
feat: gate TTS dependencies behind optional extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Install JavaScript and Python dependencies:
 ```bash
 npm install
 # create/activate a Python environment, then
-pip install -r requirements.txt  # or: pip install .
+pip install -r requirements.txt  # base dependencies
+# optional: enable text-to-speech features
+# pip install .[TTS]
 ```
 
 `audioop-lts` is included in the requirements and will be installed automatically on
@@ -94,7 +96,9 @@ Blossom can announce track titles or host voice‑overs using the
    Coqui TTS requires Python 3.9–3.11.
 
    ```bash
-   pip install TTS
+   pip install blossom-audio[TTS]
+   # or, from a clone:
+   pip install .[TTS]
    ```
 
 2. **Download a model** – use `tts --list_models` to view available voices and

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,9 @@ Pillow>=9.0.0
 feedparser>=6.0.0
 requests>=2.31.0
 aiohttp>=3.9.0
-TTS>=0.15; python_version < "3.12"
-torch>=2.0
 vosk>=0.3.45
 audioop-lts ; python_version >= "3.13"  # audioop module for Python 3.13+
+
+# Optional dependencies for text-to-speech support
+# TTS>=0.15; python_version < "3.12"
+# torch>=2.0

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,13 @@ setup(
         'pyloudnorm>=0.1.0',
         'numpy>=1.21.0',
         'pydub>=0.25.0',
-        'gTTS>=2.5.1',
         'audioop-lts; python_version >= "3.13"',
     ],
+    extras_require={
+        'TTS': [
+            'TTS>=0.15; python_version < "3.12"',
+            'torch>=2.0',
+        ],
+    },
     python_requires='>=3.10,<3.12',
 )


### PR DESCRIPTION
## Summary
- remove unused gTTS dependency and add optional `TTS` extras with Torch
- mark TTS and Torch as optional in requirements
- document how to enable TTS features using the new extras

## Testing
- `npm test` *(fails: saves parsed rules when task completes)*
- `pytest` *(fails: RuntimeError: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac084c893883259f7b589241bc2a37