### PR TITLE
Fix ambience selection to avoid numpy choice error

### DIFF
--- a/src-tauri/python/lofi/renderer.py
+++ b/src-tauri/python/lofi/renderer.py
@@ -1165,7 +1165,7 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60, chords=None
     # --- ambience rotation
     amb_list = motif.get("ambience") or []
     if not amb_list:
-        amb_list = rng.choice(
+        amb_list = random.choice(
             [
                 ["rain"],
                 ["cafe"],


### PR DESCRIPTION
## Summary
- ensure ambience rotation uses Python's `random.choice`

## Testing
- `python -m py_compile src-tauri/python/lofi/renderer.py`
- `python - <<'PY'
import sys, json
sys.path.append('src-tauri/python')
from lofi.renderer import render_from_spec
spec = {"title": "test", "seed": 1, "structure": [{"name":"A","bars":1}], "ambience": []}
print('starting render')
song, bpm = render_from_spec(spec)
print('done', bpm, song.duration_seconds)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ac0841c894832589b96ea7915abba8