### PR TITLE
feat: include PDF error codes in task status

### DIFF
--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -16,12 +16,13 @@ export interface Task {
   progress: number;
   result?: unknown;
   error?: string;
+  errorCode?: string;
 }
 
 interface RawTask {
   id: number;
   label: string;
-  status: string | { Failed: string };
+  status: string | { Failed: { code: string; message: string } };
   progress: number;
   result?: unknown;
 }
@@ -42,7 +43,8 @@ function normalize(raw: RawTask): Task {
     status: 'failed',
     progress: raw.progress,
     result: raw.result,
-    error: raw.status.Failed,
+    error: raw.status.Failed.message,
+    errorCode: raw.status.Failed.code,
   };
 }
 


### PR DESCRIPTION
## Summary
- add `PdfErrorCode` enum and carry structured errors in task queue
- surface task error codes through API and state store
- show specific NPC PDF upload failures in snackbar

## Testing
- `cargo test` *(fails: tauri::test::mock_runtime not a function, etc.)*
- `npm test` *(fails: RulePdfUpload.test.tsx expecting 2 saves)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8b54f1bc8325a4a7b3bc54837855