### PR TITLE
Add unit and integration tests plus CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm test -- --run
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pytest src-tauri/python/tests
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+      - run: cargo test
+        working-directory: src-tauri

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-sql",
+ "tempfile",
  "tokio",
  "url",
  "which",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,4 +46,5 @@ png = "0.17"
 
 [dev-dependencies]
 tauri = { version = "2", features = ["protocol-asset", "test"] }
+tempfile = "3"
 

--- a/src-tauri/python/tests/test_dj_mix.py
+++ b/src-tauri/python/tests/test_dj_mix.py
@@ -1,0 +1,42 @@
+import numpy as np
+from pydub import AudioSegment
+import os
+import sys
+import types
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+dummy_renderer = types.ModuleType("renderer")
+dummy_renderer.render_from_spec = lambda spec: (AudioSegment.silent(duration=1), 120)
+dummy_io = types.ModuleType("io_utils")
+dummy_io.ensure_wav_bitdepth = lambda seg: seg
+lofi_pkg = types.ModuleType("lofi")
+lofi_pkg.renderer = dummy_renderer
+lofi_pkg.io_utils = dummy_io
+sys.modules.setdefault("lofi", lofi_pkg)
+sys.modules.setdefault("lofi.renderer", dummy_renderer)
+sys.modules.setdefault("lofi.io_utils", dummy_io)
+
+import dj_mix
+
+
+def test_tts_audio(monkeypatch):
+    class DummySynth:
+        output_sample_rate = 22050
+
+    class DummyTTS:
+        def __init__(self, model_path, config_path):
+            self.model_path = model_path
+            self.config_path = config_path
+            self.synthesizer = DummySynth()
+
+        def tts(self, text, speaker=None, language=None):
+            assert text == "hi"
+            return np.array([0.0, 0.5, -0.5])
+
+    monkeypatch.setattr(dj_mix, "TTS", DummyTTS)
+    audio = dj_mix.tts_audio("hi", "model", "config", speaker="spk", language="en")
+    assert isinstance(audio, AudioSegment)
+    assert audio.frame_rate == 22050
+    assert audio.channels == 1
+    assert audio.sample_width == 2

--- a/src-tauri/python/tests/test_pdf_tools.py
+++ b/src-tauri/python/tests/test_pdf_tools.py
@@ -1,0 +1,50 @@
+import os
+import subprocess
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pdf_tools
+
+
+def test_add_pdf_and_search(monkeypatch, tmp_path):
+    os.environ["BLOSSOM_OUTPUT_DIR"] = str(tmp_path)
+    dummy_pdf = tmp_path / "doc.pdf"
+    dummy_pdf.write_bytes(b"dummy")
+
+    def fake_extract(pdf_path: Path, doc_dir: Path):
+        pages = ["hello world", "goodbye world"]
+        info = {"title": "Test", "pages": len(pages)}
+        return pages, info
+
+    monkeypatch.setattr(pdf_tools, "extract_pages", fake_extract)
+
+    result = pdf_tools.add_pdf(str(dummy_pdf))
+    assert result["pages"] == 2
+    doc_id = result["doc_id"]
+
+    search_res = pdf_tools.search("hello")
+    assert search_res["results"]
+    first = search_res["results"][0]
+    assert first["doc_id"] == doc_id
+    assert "hello world" in first["text"]
+
+
+def test_validate_entry(monkeypatch):
+    class Dummy:
+        def __init__(self, code):
+            self.returncode = code
+
+    def run_ok(*args, **kwargs):
+        return Dummy(0)
+
+    def run_fail(*args, **kwargs):
+        return Dummy(1)
+
+    monkeypatch.setattr(subprocess, "run", run_ok)
+    assert pdf_tools._validate_entry("npc", {"name": "Bob"})
+
+    monkeypatch.setattr(subprocess, "run", run_fail)
+    assert not pdf_tools._validate_entry("npc", {"name": "Bob"})

--- a/src-tauri/tests/comfy_start_stop.rs
+++ b/src-tauri/tests/comfy_start_stop.rs
@@ -1,0 +1,29 @@
+use blossom_lib::commands::{comfy_start, comfy_stop, __has_comfy_child};
+use std::{env, fs};
+
+#[tokio::test]
+async fn start_and_stop_comfy() {
+    let _rt = tauri::test::mock_runtime();
+    let app = tauri::test::mock_builder()
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .unwrap();
+    let window = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
+        .build()
+        .unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join("main.py"),
+        "import time\nwhile True: time.sleep(0.1)\n",
+    )
+    .unwrap();
+    env::set_var("BLOSSOM_PYTHON_PATH", "python3");
+
+    assert!(!__has_comfy_child());
+    comfy_start(window, dir.path().to_string_lossy().to_string())
+        .await
+        .unwrap();
+    assert!(__has_comfy_child());
+    comfy_stop().await.unwrap();
+    assert!(!__has_comfy_child());
+}

--- a/src-tauri/tests/save_paths.rs
+++ b/src-tauri/tests/save_paths.rs
@@ -1,0 +1,28 @@
+use blossom_lib::commands::save_paths;
+use serde_json::Value;
+use std::{env, fs};
+
+#[tokio::test]
+async fn save_paths_writes_config() {
+    let _rt = tauri::test::mock_runtime();
+    let dir = tempfile::tempdir().unwrap();
+    env::set_var("HOME", dir.path());
+
+    save_paths(
+        Some("python".into()),
+        Some("comfy".into()),
+        Some("model".into()),
+        None,
+        Some("speaker".into()),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let cfg_path = dir.path().join(".blossom").join("config.json");
+    let data: Value = serde_json::from_str(&fs::read_to_string(cfg_path).unwrap()).unwrap();
+    assert_eq!(data["python_path"], "python");
+    assert_eq!(data["comfy_path"], "comfy");
+    assert_eq!(data["tts_model_path"], "model");
+    assert_eq!(data["tts_speaker"], "speaker");
+}


### PR DESCRIPTION
## Summary
- add tests for PDF indexing and search plus validation helper
- cover DJ mix TTS synthesis with a stubbed model
- verify save_paths and ComfyUI start/stop commands
- run Python, frontend, and Rust tests in CI

## Testing
- `pytest src-tauri/python/tests/test_pdf_tools.py src-tauri/python/tests/test_dj_mix.py`
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required)*
- `npm test -- --run` *(fails: RulePdfUpload saves parsed rules)*
- `cargo test` *(fails: glib-2.0.pc missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8b6bcd348325bc723b8e7670261e