### PR TITLE
feat: auto-update lead instrument

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -309,6 +309,17 @@ describe('SongForm', () => {
     expect(call[1].spec.instruments).toEqual(['harp', 'lute', 'pan flute']);
   });
 
+  it('updates lead instrument when adding a lead-capable instrument', () => {
+    render(<SongForm />);
+    openSection('vibe-section');
+
+    expect(screen.getByRole('radio', { name: 'synth' })).toBeChecked();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'flute' }));
+
+    expect(screen.getByRole('radio', { name: 'flute' })).toBeChecked();
+  });
+
   it('passes lead instrument in spec', async () => {
     (openDialog as any).mockResolvedValue('/tmp/out');
     (invoke as any).mockResolvedValue('');

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -244,6 +244,12 @@ export default function SongForm() {
     localStorage.setItem("lastInstruments", JSON.stringify(instruments));
   }, [instruments]);
 
+  useEffect(() => {
+    if (!instruments.includes(leadInstrument)) {
+      setLeadInstrument(inferLeadInstrument(instruments));
+    }
+  }, [instruments]);
+
   // Album mode
   const storedAlbumMeta = useMemo(() => {
     try {


### PR DESCRIPTION
## Summary
- auto-select new lead instrument when current selection removed from instrument list
- test automatic lead instrument updates on instrument addition

## Testing
- `npm test src/components/SongForm.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ac9002c7a48325b9bc2cd4a9001363