### PR TITLE
fix: keep task queue updating during music

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -26,8 +26,7 @@ vi.mock('../features/lofi/SongForm', () => ({
   }),
 }));
 vi.mock('../store/tasks', () => ({
-  useTasks: (selector: any) =>
-    selector({ tasks: {}, subscribe: vi.fn().mockResolvedValue(() => {}) }),
+  useTasks: (selector: any) => selector({ tasks: {}, fetchStatus: vi.fn() }),
 }));
 
 function openSection(id: string) {

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -390,7 +390,6 @@ export default function SongForm() {
   );
 
   const tasks = useTasks((s) => s.tasks);
-  const tasksSubscribe = useTasks((s) => s.subscribe);
   const fetchStatus = useTasks((s) => s.fetchStatus);
 
   useEffect(() => {
@@ -401,15 +400,6 @@ export default function SongForm() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    let unlisten: (() => void) | null = null;
-    tasksSubscribe().then((u) => {
-      unlisten = u;
-    });
-    return () => {
-      unlisten?.();
-    };
-  }, [tasksSubscribe]);
 
   const activeTask = useMemo(
     () =>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -4,7 +4,7 @@ import { fixedIconButtonSx } from "./sx";
 import { FaHome, FaWrench, FaUser, FaTasks } from "react-icons/fa";
 import MenuBookIcon from "@mui/icons-material/MenuBook";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import SettingsDrawer from "./SettingsDrawer";
 import TaskDrawer from "./TaskDrawer";
 import { useTasks } from "../store/tasks";
@@ -17,6 +17,21 @@ export default function TopBar() {
   const taskCount = useTasks((s) =>
     Object.values(s.tasks).filter((t) => t.status === "queued" || t.status === "running").length
   );
+  const subscribe = useTasks((s) => s.subscribe);
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    (async () => {
+      try {
+        unlisten = await subscribe();
+      } catch (err) {
+        console.error("Failed to subscribe", err);
+      }
+    })();
+    return () => {
+      unlisten?.();
+    };
+  }, [subscribe]);
   const activeSx = (p: string): SxProps =>
     pathname === p
       ? { color: "#000", backgroundColor: "#fff", borderRadius: 4 }

--- a/src/features/dnd/tests/RulePdfUpload.test.tsx
+++ b/src/features/dnd/tests/RulePdfUpload.test.tsx
@@ -40,8 +40,6 @@ describe("RulePdfUpload", () => {
   });
 
   it("saves parsed rules when task completes", async () => {
-    vi.spyOn(React, "useState").mockImplementationOnce(() => [1, vi.fn()]);
-    vi.spyOn(React, "useEffect").mockImplementation((fn) => fn());
     state.tasks[1] = {
       status: "completed",
       result: {
@@ -51,17 +49,18 @@ describe("RulePdfUpload", () => {
         ],
       },
     };
+    (open as any).mockResolvedValue("/tmp/rules.pdf");
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === "list_rules") return Promise.resolve([]);
       return Promise.resolve();
     });
 
     render(<RulePdfUpload />);
-
+    fireEvent.click(screen.getByText(/upload rule pdf/i));
+    await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
     await waitFor(() =>
       expect(
-        invoke.mock.calls.filter(([cmd]: any[]) => cmd === "save_rule")
-          .length,
+        invoke.mock.calls.filter(([cmd]: any[]) => cmd === "save_rule").length,
       ).toBe(2),
     );
   });


### PR DESCRIPTION
## Summary
- subscribe to task updates in the top bar so queue stays live
- drop redundant task subscription from SongForm
- update related tests

## Testing
- `npm test` *(fails: RulePdfUpload.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ac96fe216c8325a2d0083d37d947f9