### PR TITLE
Handle failed rule PDF upload

### DIFF
--- a/src/features/dnd/RulePdfUpload.tsx
+++ b/src/features/dnd/RulePdfUpload.tsx
@@ -27,7 +27,9 @@ export default function RulePdfUpload() {
   const [taskId, setTaskId] = useState<number | null>(null);
 
   async function handleUpload() {
-    const selected = await open({ filters: [{ name: "PDF", extensions: ["pdf"] }] });
+    const selected = await open({
+      filters: [{ name: "PDF", extensions: ["pdf"] }],
+    });
     if (typeof selected === "string") {
       const id = await enqueueTask("Import Rule PDF", {
         ParseRulePdf: { path: selected },
@@ -60,15 +62,17 @@ export default function RulePdfUpload() {
           );
           let overwrite = true;
           if (dup) {
-            overwrite = window.confirm(
-              `Rule ${rule.name} exists. Overwrite?`,
-            );
+            overwrite = window.confirm(`Rule ${rule.name} exists. Overwrite?`);
           }
           if (overwrite) {
             await invoke("save_rule", { rule, overwrite });
           }
         }
       })();
+    } else if (task && task.status === "failed") {
+      const message = (task.error as any)?.message ?? String(task.error ?? "");
+      window.alert(`Failed to import Rule PDF: ${message}`);
+      setTaskId(null);
     }
   }, [taskId, tasks]);
 
@@ -80,4 +84,3 @@ export default function RulePdfUpload() {
     </div>
   );
 }
-

--- a/src/features/dnd/tests/RulePdfUpload.test.tsx
+++ b/src/features/dnd/tests/RulePdfUpload.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import React from "react";
 import {
   render,
@@ -23,6 +23,9 @@ import { invoke } from "@tauri-apps/api/core";
 import RulePdfUpload from "../RulePdfUpload";
 
 describe("RulePdfUpload", () => {
+  beforeEach(() => {
+    enqueueTask.mockResolvedValue(1);
+  });
   afterEach(() => {
     cleanup();
     vi.resetAllMocks();
@@ -65,4 +68,3 @@ describe("RulePdfUpload", () => {
     );
   });
 });
-


### PR DESCRIPTION
## Summary
- alert user when rule PDF parsing task fails and reset task id for retry
- stabilise RulePdfUpload test by restoring enqueueTask mock for each run

## Testing
- `npx vitest run src/features/dnd/tests/RulePdfUpload.test.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aca1e257708325bbbfc899b9b180d4