### PR TITLE
Improve PDF rule extraction and add tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pydub>=0.25.0
 scipy>=1.9.0
 pdfplumber>=0.10.3
 pytesseract>=0.3.10
+fpdf2>=2.7
 Pillow>=9.0.0
 feedparser>=6.0.0
 requests>=2.32.0


### PR DESCRIPTION
## Summary
- Enhance `extract_rules` to analyze PDF layout for headings using font style and case heuristics
- Add fpdf2 dependency and unit tests covering bold and colon-based rule headings

## Testing
- `pytest src-tauri/python/tests/test_pdf_tools.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca6aa7cf8832592fd5cf402cca442