### PR TITLE
Queue album generation tasks

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,6 +13,11 @@ fn main() {
     let queue = TaskQueue::new(1, 90.0, 90.0);
     tauri::Builder::default()
         .manage(queue)
+        .setup(|app| {
+            let handle = app.handle();
+            app.state::<TaskQueue>().set_app_handle(handle);
+            Ok(())
+        })
         .plugin(tauri_plugin_dialog::init())
         .plugin(
             SqlBuilder::default()

--- a/src/components/HomeChat.tsx
+++ b/src/components/HomeChat.tsx
@@ -6,6 +6,7 @@ import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import Draggable from "react-draggable";
 import { nanoid } from "nanoid";
 import { invoke } from "@tauri-apps/api/core";
+import { useTasks } from "../store/tasks";
 import { PRESET_TEMPLATES } from "./songTemplates";
 import { SystemInfo } from "../features/system/useSystemInfo";
 
@@ -22,6 +23,7 @@ export default function HomeChat() {
   const [minimized, setMinimized] = useState(false);
   const nodeRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const enqueueTask = useTasks((s) => s.enqueueTask);
 
   useEffect(() => {
     if (scrollRef.current) {
@@ -66,8 +68,10 @@ export default function HomeChat() {
             `Templates: ${templates}\n` +
             `Example: /music My Song template="Classic Lofi" tracks=3`;
         } else {
-          await invoke("generate_album", {
-            meta: { track_count: trackCount, title_base: title, template },
+          await enqueueTask("Music Generation", {
+            GenerateAlbum: {
+              meta: { track_count: trackCount, title_base: title, template },
+            },
           });
           const plural = trackCount === 1 ? "track" : "tracks";
           reply = `Started music generation for "${title}" using "${template}" with ${trackCount} ${plural}.`;

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -397,6 +397,7 @@ export default function SongForm() {
 
   const tasks = useTasks((s) => s.tasks);
   const fetchStatus = useTasks((s) => s.fetchStatus);
+  const enqueueTask = useTasks((s) => s.enqueueTask);
 
   useEffect(() => {
     const running = Object.values(tasks).find((t) =>
@@ -745,17 +746,19 @@ export default function SongForm() {
       const specs = Array.from({ length: trackCount }, (_, i) =>
         makeSpecForIndex(i)
       );
-      const res: { album_dir: string } = await invoke("generate_album", {
-        meta: {
-          track_count: trackCount,
-          title_base: titleBase,
-          album_name: albumName,
-          track_names: trackNames,
-          out_dir: outDir,
-          specs,
+      await enqueueTask("Music Generation", {
+        GenerateAlbum: {
+          meta: {
+            track_count: trackCount,
+            title_base: titleBase,
+            album_name: albumName,
+            track_names: trackNames,
+            out_dir: outDir,
+            specs,
+          },
         },
       });
-      setOutDir(res.album_dir);
+      setOutDir(outDir);
     } catch (e: any) {
       const message = e?.message || String(e);
       setErr(message);

--- a/src/pages/GeneralChat.tsx
+++ b/src/pages/GeneralChat.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useTasks } from "../store/tasks";
 import { listen } from "@tauri-apps/api/event";
 import {
   Box,
@@ -44,6 +45,7 @@ export default function GeneralChat() {
   const [status, setStatus] = useState<"init" | "starting" | "ready" | "error">("init");
   const [error, setError] = useState<string>("");
   const [logs, setLogs] = useState<string[]>([]);
+  const enqueueTask = useTasks((s) => s.enqueueTask);
 
   const userName = useUsers((state) =>
     state.currentUserId ? state.users[state.currentUserId]?.name : undefined
@@ -188,8 +190,8 @@ export default function GeneralChat() {
             `Templates: ${templates}\n` +
             `Example: /music My Song template="Classic Lofi" tracks=3`;
         } else {
-          await invoke("generate_album", {
-            meta: { track_count: trackCount, title_base: title, template },
+          await enqueueTask("Music Generation", {
+            GenerateAlbum: { meta: { track_count: trackCount, title_base: title, template } },
           });
           const plural = trackCount === 1 ? "track" : "tracks";
           reply = `Started music generation for "${title}" using "${template}" with ${trackCount} ${plural}.`;


### PR DESCRIPTION
## Summary
- add `GenerateAlbum` to task queue and route progress via `task_updated`
- enqueue album generation from chat and forms through the task queue
- update tests to expect task-queue based album generation

## Testing
- `npm test -- --run`
- `cargo check` *(fails: system library `javascriptcoregtk-4.1` / `libsoup-3.0` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aca49efdfc8325af3bd4e5b4db441c