### PR TITLE
feat: track task runtime

### DIFF
--- a/src/store/tasks.test.ts
+++ b/src/store/tasks.test.ts
@@ -21,7 +21,7 @@ describe('useTasks error handling', () => {
     vi.useFakeTimers();
     (invoke as any).mockRejectedValue(new Error('boom'));
     useTasks.setState({
-      tasks: { 1: { id: 1, label: 't', status: 'running', progress: 0 } },
+      tasks: { 1: { id: 1, label: 't', status: 'running', progress: 0, started_at: 0 } },
     } as any);
     useTasks.getState().startPolling(1, 1000);
     await expect(useTasks.getState().fetchStatus(1)).rejects.toThrow('boom');
@@ -34,7 +34,7 @@ describe('useTasks error handling', () => {
     vi.useFakeTimers();
     (invoke as any).mockRejectedValue(new Error('nope'));
     useTasks.setState({
-      tasks: { 1: { id: 1, label: 't', status: 'running', progress: 0 } },
+      tasks: { 1: { id: 1, label: 't', status: 'running', progress: 0, started_at: 0 } },
     } as any);
     useTasks.getState().startPolling(1, 1000);
     await expect(useTasks.getState().cancelTask(1)).rejects.toThrow('nope');


### PR DESCRIPTION
## Summary
- add `started_at` timestamp to Task types and backend queue
- track start times when enqueuing and when tasks begin running
- display elapsed runtime next to task progress bars

## Testing
- `npm test`
- `cargo test` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aca89287e883259674bacf160e9a99