### PR TITLE
Ensure all modules default to enabled for existing users

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -562,7 +562,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
       <Typography variant="subtitle1" sx={{ mt: 3 }}>
         Modules
       </Typography>
-      {(Object.keys(modules) as ModuleKey[]).map((key) => (
+      {(Object.keys(MODULE_LABELS) as ModuleKey[]).map((key) => (
         <Box id={`module-${key}`} key={key}>
           <FormControlLabel
             control={<Switch checked={modules[key]} onChange={() => toggleModule(key)} />}

--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -5,7 +5,7 @@ import { useUsers, defaultModules, type ModuleKey } from "../users/useUsers";
 export function useSettings() {
   const modules = useUsers((state) => {
     const id = state.currentUserId;
-    return id ? state.users[id].modules : defaultModules;
+    return { ...defaultModules, ...(id ? state.users[id].modules : {}) };
   });
   const toggleModule = useUsers((state) => state.toggleModule);
   const cpuLimit = useUsers((state) => {


### PR DESCRIPTION
## Summary
- Merge default modules with user settings so new module keys default to enabled
- List module toggles using all known module labels to show missing keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aca89f9bc48325a5d3f1acb52a3f70