### PR TITLE
chore: simplify song builder heading

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -78,6 +78,7 @@ describe('SongForm', () => {
 
   it('renders default form', () => {
     const { asFragment } = render(<SongForm />);
+    expect(screen.getByText('Song Builder')).toBeInTheDocument();
     expect(asFragment()).toMatchSnapshot();
   });
 

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -853,7 +853,7 @@ export default function SongForm() {
   return (
     <div className={styles.page}>
       <div className={styles.card}>
-        <div className={styles.h1}>Blossom — Song Builder (Batch + Vibes)</div>
+        <div className={styles.h1}>Song Builder</div>
 
         {weatherPreset && (
           <div className={styles.row}>

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`SongForm > renders default form 1`] = `
       <div
         class="_h1_62bdff"
       >
-        Blossom — Song Builder (Batch + Vibes)
+        Song Builder
       </div>
       <div
         class="_panel_62bdff"


### PR DESCRIPTION
## Summary
- Simplify Song Builder page heading
- Update tests and snapshots for new heading text

## Testing
- `npx vitest run src/components/SongForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68acabfed8f48325862aa53fda623fd4