### PR TITLE
Dim quick-add overlay to avoid full-screen blackout

### DIFF
--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -607,7 +607,12 @@ export default function Calendar() {
           <Box
             data-testid="quick-add-overlay"
             onClick={closeQuickAdd}
-            sx={{ position: "fixed", inset: 0, zIndex: 10 }}
+            sx={{
+              position: "fixed",
+              inset: 0,
+              zIndex: 10,
+              bgcolor: "rgba(0,0,0,0.5)",
+            }}
           />
           <Paper
             sx={{ position: "fixed", zIndex: 20, p: 2, width: 224 }}


### PR DESCRIPTION
## Summary
- dim quick-add overlay in calendar so clicking a day no longer blacks out screen

## Testing
- `npm test` *(fails: RulePdfUpload saves parsed rules when task completes)*

------
https://chatgpt.com/codex/tasks/task_e_68aca0cdedf08325b59847f55bac3624