### PR TITLE
feat: randomize lofi title suggestions

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -136,25 +136,33 @@ describe('SongForm', () => {
   it('generates a title with ollama', async () => {
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === 'start_ollama') return Promise.resolve();
-      if (cmd === 'general_chat') return Promise.resolve('Morning Chill');
+      if (cmd === 'general_chat')
+        return Promise.resolve(
+          'Morning Chill\nEvening Jazz\nMidnight Coffee\nSunset Vibes\nRainy Day'
+        );
       return Promise.resolve('');
     });
 
-    render(<SongForm />);
+    const rand = vi.spyOn(Math, 'random').mockReturnValue(0);
+    try {
+      render(<SongForm />);
 
-    fireEvent.click(screen.getByText(/generate title/i));
+      fireEvent.click(screen.getByText(/generate title/i));
 
-    await waitFor(() => {
-      const calls = (invoke as any).mock.calls.map(([c]: any) => c);
-      expect(calls).toContain('start_ollama');
-      expect(calls).toContain('general_chat');
-    });
+      await waitFor(() => {
+        const calls = (invoke as any).mock.calls.map(([c]: any) => c);
+        expect(calls).toContain('start_ollama');
+        expect(calls).toContain('general_chat');
+      });
 
-    await waitFor(() =>
-      expect(
-        (screen.getByPlaceholderText(/song title base/i) as HTMLInputElement).value
-      ).toBe('Morning Chill')
-    );
+      await waitFor(() =>
+        expect(
+          (screen.getByPlaceholderText(/song title base/i) as HTMLInputElement).value
+        ).toBe('Morning Chill')
+      );
+    } finally {
+      rand.mockRestore();
+    }
   });
 
   it('remembers last used template', () => {

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -589,16 +589,29 @@ export default function SongForm() {
             {
               role: "system",
               content:
-                "You are a creative assistant that suggests short, catchy lofi song titles. Respond with only the title.",
+                "You are a creative assistant that suggests short, catchy lofi song titles. Respond with a list of titles, one per line.",
             },
-            { role: "user", content: "Give me a lofi song title." },
+            {
+              role: "user",
+              content: "Give me five different lofi song titles.",
+            },
           ],
+          // If the backend supports it, a higher temperature encourages variety
+          temperature: 1.2,
         });
-        const line = reply
-          .split("\n")[0]
-          .replace(/^['\"]|['\"]$/g, "")
-          .trim();
-        if (line) setTitleBase(line);
+        const lines = reply
+          .split("\n")
+          .map((l) =>
+            l
+              .replace(/^[\s*\-\d\.]+/, "")
+              .replace(/^['\"]|['\"]$/g, "")
+              .trim()
+          )
+          .filter(Boolean);
+        if (lines.length) {
+          const choice = lines[Math.floor(Math.random() * lines.length)];
+          setTitleBase(choice);
+        }
       }
     } catch (e: any) {
       setErr(e?.message || String(e));


### PR DESCRIPTION
## Summary
- ask general chat for multiple lofi song title ideas and pick one at random
- update song title generation test for new multi-suggestion behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aca7fbbf748325af25cc462aff5c2f