### PR TITLE
feat: track task start times

### DIFF
--- a/src/components/TaskQueue/TaskList.tsx
+++ b/src/components/TaskQueue/TaskList.tsx
@@ -51,11 +51,18 @@ export default function TaskList() {
             <Typography variant="body2" sx={{ fontWeight: 500 }}>
               {task.label}
             </Typography>
-            <LinearProgress
-              variant="determinate"
-              value={Math.max(0, Math.min(100, task.progress * 100))}
-              sx={{ my: 0.5 }}
-            />
+            <Box sx={{ display: "flex", alignItems: "center" }}>
+              <LinearProgress
+                variant="determinate"
+                value={Math.max(0, Math.min(100, task.progress * 100))}
+                sx={{ my: 0.5, flexGrow: 1, mr: 1 }}
+              />
+              {task.started_at && (
+                <Typography variant="caption" sx={{ minWidth: 48, textAlign: "right" }}>
+                  {formatElapsed(task.started_at)}
+                </Typography>
+              )}
+            </Box>
             <Box sx={{ display: "flex", justifyContent: "space-between" }}>
               <Typography variant="caption">{task.status}</Typography>
               {task.status === "queued" || task.status === "running" ? (
@@ -69,5 +76,13 @@ export default function TaskList() {
       )}
     </Box>
   );
+}
+
+function formatElapsed(started_at: string) {
+  const diff = Date.now() - new Date(started_at).getTime();
+  const sec = Math.max(0, Math.floor(diff / 1000));
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return `${m}:${s.toString().padStart(2, "0")}`;
 }
 

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -17,6 +17,7 @@ export interface Task {
   result?: unknown;
   error?: string;
   errorCode?: string;
+  started_at?: string;
 }
 
 interface RawTask {
@@ -25,6 +26,7 @@ interface RawTask {
   status: string | { Failed: { code: string; message: string } };
   progress: number;
   result?: unknown;
+  started_at?: string;
 }
 
 function normalize(raw: RawTask): Task {
@@ -35,6 +37,7 @@ function normalize(raw: RawTask): Task {
       status: raw.status.toLowerCase() as TaskStatus,
       progress: raw.progress,
       result: raw.result,
+      started_at: raw.started_at,
     };
   }
   return {
@@ -45,6 +48,7 @@ function normalize(raw: RawTask): Task {
     result: raw.result,
     error: raw.status.Failed.message,
     errorCode: raw.status.Failed.code,
+    started_at: raw.started_at,
   };
 }
 
@@ -68,7 +72,7 @@ export const useTasks = create<TasksState>((set, get) => ({
       set((state) => ({
         tasks: {
           ...state.tasks,
-          [id]: { id, label, status: 'queued', progress: 0 },
+          [id]: { id, label, status: 'queued', progress: 0, started_at: new Date().toISOString() },
         },
       }));
       get().startPolling(id);


### PR DESCRIPTION
## Summary
- track when tasks are queued and running
- show elapsed runtime beside task progress bars

## Testing
- `npm test`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found.)*


------
https://chatgpt.com/codex/tasks/task_e_68acabb855a48325966a69ac4b800c84