### PR TITLE
Add optional lofi filter toggle

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,7 +27,7 @@ tauri-plugin-sql = { version = "2", features = ["sqlite"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 reqwest = { version = "0.11", features = ["json"] }
 rss = "2"
 once_cell = "1"

--- a/src-tauri/python/lofi/renderer.py
+++ b/src-tauri/python/lofi/renderer.py
@@ -1571,13 +1571,14 @@ def render_from_spec(spec: Dict[str, Any]) -> Tuple[AudioSegment, int]:
     logger.info({"stage": "post", "message": "cleaning audio"})
     post_rng = np.random.default_rng((seed ^ 0x5A5A5A5A) & 0xFFFFFFFF)
     wow_cfg = spec.get("wow_flutter")
-    song = enhanced_post_process_chain(
-        song,
-        rng=post_rng,
-        drive=limiter_drive,
-        dither_amount=dither_amt,
-        wow_flutter=wow_cfg,
-    )
+    if spec.get("lofi_filter", True):
+        song = enhanced_post_process_chain(
+            song,
+            rng=post_rng,
+            drive=limiter_drive,
+            dither_amount=dither_amt,
+            wow_flutter=wow_cfg,
+        )
     return song, bpm
 
 # ---------- Main ----------

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -644,9 +644,11 @@ pub struct SongSpec {
     pub hq_chorus: Option<bool>,
     #[serde(alias = "limiterDrive", skip_serializing_if = "Option::is_none")]
     pub limiter_drive: Option<f32>,
+    #[serde(alias = "lofiFilter", skip_serializing_if = "Option::is_none")]
+    pub lofi_filter: Option<bool>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct AlbumRequest {
     pub track_count: u32,
@@ -705,6 +707,7 @@ mod tests {
             hq_sidechain: None,
             hq_chorus: None,
             limiter_drive: None,
+            lofi_filter: None,
         };
         let v = serde_json::to_value(&spec).unwrap();
         assert!(v.get("ambience_level").is_some());

--- a/src/components/PolishControls.tsx
+++ b/src/components/PolishControls.tsx
@@ -16,6 +16,8 @@ interface Props {
   setLimiterDrive: (val: number) => void;
   dither: boolean;
   setDither: (val: boolean) => void;
+  lofiFilter: boolean;
+  setLofiFilter: (val: boolean) => void;
 }
 
 export default function PolishControls({
@@ -31,6 +33,8 @@ export default function PolishControls({
   setLimiterDrive,
   dither,
   setDither,
+  lofiFilter,
+  setLofiFilter,
 }: Props) {
   return (
     <div className={clsx(styles.panel, "mt-3")}>
@@ -82,6 +86,17 @@ export default function PolishControls({
                 type="checkbox"
                 checked={hqChorus}
                 onChange={(e) => setHqChorus(e.target.checked)}
+              />
+            </label>
+            <label className={styles.optionCard}>
+              <span>
+                Lofi Filter
+                <HelpIcon text="Applies lofi low-pass filter (default on)" />
+              </span>
+              <input
+                type="checkbox"
+                checked={lofiFilter}
+                onChange={(e) => setLofiFilter(e.target.checked)}
               />
             </label>
           </div>

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -48,6 +48,7 @@ type SongSpec = {
   hq_chorus?: boolean;
   limiter_drive?: number;
   dither_amount?: number;
+  lofi_filter?: boolean;
 };
 
 export type TemplateSpec = {
@@ -329,6 +330,10 @@ export default function SongForm() {
     const stored = localStorage.getItem("dither");
     return stored === null ? true : stored === "true";
   });
+  const [lofiFilter, setLofiFilter] = useState(() => {
+    const stored = localStorage.getItem("lofiFilter");
+    return stored === null ? true : stored === "true";
+  });
 
   // UI state
   const [busy, setBusy] = useState(false);
@@ -389,6 +394,10 @@ export default function SongForm() {
   useEffect(() => {
     localStorage.setItem("dither", String(dither));
   }, [dither]);
+
+  useEffect(() => {
+    localStorage.setItem("lofiFilter", String(lofiFilter));
+  }, [lofiFilter]);
 
   const runningJobId = useMemo(
     () => jobs.find((j) => !j.error && !j.outPath)?.id,
@@ -683,6 +692,7 @@ export default function SongForm() {
       hq_chorus: hqChorus,
       limiter_drive: Math.max(0.5, Math.min(2, limiterDrive)),
       dither_amount: dither ? 1 : 0,
+      lofi_filter: lofiFilter,
     };
   }
 
@@ -1278,6 +1288,8 @@ export default function SongForm() {
           setLimiterDrive={setLimiterDrive}
           dither={dither}
           setDither={setDither}
+          lofiFilter={lofiFilter}
+          setLofiFilter={setLofiFilter}
         />
         {/* album mode toggle */}
         <div className={styles.panel}>

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -2509,6 +2509,39 @@ exports[`SongForm > renders default form 1`] = `
                   type="checkbox"
                 />
               </label>
+              <label
+                class="_optionCard_62bdff"
+              >
+                <span>
+                  Lofi Filter
+                  <button
+                    aria-label="help"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-155wbr6-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    style="margin-left: 4px; padding: 2px; cursor: help; opacity: 0.6;"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <svg
+                      fill="currentColor"
+                      height="1em"
+                      stroke="currentColor"
+                      stroke-width="0"
+                      viewBox="0 0 512 512"
+                      width="1em"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+                      />
+                    </svg>
+                  </button>
+                </span>
+                <input
+                  checked=""
+                  type="checkbox"
+                />
+              </label>
             </div>
             <details
               class="mt-2"


### PR DESCRIPTION
## Summary
- add lofi filter toggle persisted to localStorage and sent to backend
- expose "Lofi Filter" checkbox in Polish controls
- conditionally run post-process chain in renderer when lofi filter is enabled

## Testing
- `npm test`
- `cargo test` *(fails: type annotations needed in task_queue.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68acb90532408325ac6a5ec619d6d710