### PR TITLE
feat: make AlbumRequest clonable

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -646,7 +646,7 @@ pub struct SongSpec {
     pub limiter_drive: Option<f32>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct AlbumRequest {
     pub track_count: u32,


### PR DESCRIPTION
## Summary
- derive `Clone` for `AlbumRequest`

## Testing
- `cargo test` *(fails: trait `Serialize` not implemented for `DateTime<Utc>`)*

------
https://chatgpt.com/codex/tasks/task_e_68acbcf3de908325b0636e48ff8ef3bb