### PR TITLE
Remove unused SongSpec import

### DIFF
--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -14,7 +14,7 @@ use tauri::{AppHandle, Manager, Wry};
 use tokio::sync::{mpsc, Mutex, Semaphore};
 use tokio::time::sleep;
 
-use crate::commands::{run_lofi_song, AlbumRequest, ShortSpec, SongSpec};
+use crate::commands::{run_lofi_song, AlbumRequest, ShortSpec};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TaskCommand {
@@ -140,7 +140,7 @@ impl TaskQueue {
             cpu: cpu_limit,
             memory: memory_limit,
         }));
-        let app = Arc::new(StdMutex::new(None));
+        let app: Arc<StdMutex<Option<AppHandle<Wry>>>> = Arc::new(StdMutex::new(None));
         let tasks_worker = tasks.clone();
         let _handles_worker = _handles.clone();
         let _cancelled_worker = _cancelled.clone();


### PR DESCRIPTION
## Summary
- remove unused SongSpec from task queue imports
- annotate TaskQueue's app field initialization with explicit AppHandle type

## Testing
- `cargo check` *(fails: no method named `emit_all` for AppHandle; expected `Window`, found `WebviewWindow`)*

------
https://chatgpt.com/codex/tasks/task_e_68acc083390883258bf0e33668e3b54f