### PR TITLE
Specify AppHandle type in TaskQueue

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use serde_yaml;
 use sysinfo::System;
-use tauri::{AppHandle, Emitter, Manager, Runtime, State, Window};
+use tauri::{AppHandle, Emitter, Manager, Runtime, State, WebviewWindow, Window};
 use tokio::{
     io::{AsyncBufReadExt, BufReader as TokioBufReader},
     process::Child,
@@ -802,7 +802,7 @@ pub async fn lofi_generate_gpu<R: Runtime>(
 /// Run full-song generation based on a structured spec (typed, camelCase-friendly).
 #[tauri::command]
 pub async fn run_lofi_song<R: Runtime>(
-    window: Window<R>,
+    window: WebviewWindow<R>,
     app: AppHandle<R>,
     spec: SongSpec,
 ) -> Result<String, String> {
@@ -885,7 +885,7 @@ pub async fn run_lofi_song<R: Runtime>(
 
 #[tauri::command]
 pub async fn generate_album<R: Runtime>(
-    window: Window<R>,
+    window: WebviewWindow<R>,
     app: AppHandle<R>,
     meta: AlbumRequest,
 ) -> Result<AlbumMeta, String> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ mod task_queue;
 
 use task_queue::TaskQueue;
 use tauri_plugin_sql::{Builder as SqlBuilder, Migration, MigrationKind};
+use tauri::Manager;
 
 fn main() {
     env_logger::init();
@@ -15,7 +16,7 @@ fn main() {
         .manage(queue)
         .setup(|app| {
             let handle = app.handle();
-            app.state::<TaskQueue>().set_app_handle(handle);
+            app.state::<TaskQueue>().set_app_handle(handle.clone());
             Ok(())
         })
         .plugin(tauri_plugin_dialog::init())

--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -14,7 +14,8 @@ use tauri::{AppHandle, Manager, Wry};
 use tokio::sync::{mpsc, Mutex, Semaphore};
 use tokio::time::sleep;
 
-use crate::commands::{run_lofi_song, AlbumRequest, ShortSpec, SongSpec};
+use crate::commands::{run_lofi_song, AlbumRequest, ShortSpec};
+use tauri::Emitter;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TaskCommand {
@@ -140,7 +141,7 @@ impl TaskQueue {
             cpu: cpu_limit,
             memory: memory_limit,
         }));
-        let app = Arc::new(StdMutex::new(None));
+        let app = Arc::new(StdMutex::new(None::<AppHandle<Wry>>));
         let tasks_worker = tasks.clone();
         let _handles_worker = _handles.clone();
         let _cancelled_worker = _cancelled.clone();
@@ -202,7 +203,7 @@ impl TaskQueue {
                             };
                             if let Some(task) = snapshot {
                                 if let Some(app) = app_handle.lock().unwrap().clone() {
-                                    let _ = app.emit_all("task_updated", task);
+                                    let _ = app.emit("task_updated", task);
                                 }
                             }
                             let res: Result<Value, TaskError> = match command {
@@ -492,7 +493,7 @@ impl TaskQueue {
                                             }
                                         }
                                         if let Some(task) = snapshot {
-                                            let _ = app.emit_all("task_updated", task);
+                                            let _ = app.emit("task_updated", task);
                                         }
                                         if _cancelled_clone.lock().await.contains(&id) {
                                             return Err(TaskError {
@@ -531,7 +532,7 @@ impl TaskQueue {
                             };
                             if let Some(task) = snapshot {
                                 if let Some(app) = app_handle.lock().unwrap().clone() {
-                                    let _ = app.emit_all("task_updated", task);
+                                    let _ = app.emit("task_updated", task);
                                 }
                             }
                             drop(permit);


### PR DESCRIPTION
## Summary
- explicitly type TaskQueue's app handle mutex as `AppHandle<Wry>`
- update event emission and command signatures for Tauri 2 (`emit`, `WebviewWindow`)
- ensure main imports `Manager` and clones handle during setup

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68acc253d7308325a874a1de8a9b59a6