### PR TITLE
Use emit instead of emit_all for task updates

### DIFF
--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use chrono::{DateTime, Utc};
 use sysinfo::System;
 use tauri::async_runtime::{self, JoinHandle};
-use tauri::{AppHandle, Manager, Wry};
+use tauri::{AppHandle, Emitter, Manager, Wry};
 use tokio::sync::{mpsc, Mutex, Semaphore};
 use tokio::time::sleep;
 
@@ -202,7 +202,7 @@ impl TaskQueue {
                             };
                             if let Some(task) = snapshot {
                                 if let Some(app) = app_handle.lock().unwrap().clone() {
-                                    let _ = app.emit_all("task_updated", task);
+                                    let _ = app.emit("task_updated", task);
                                 }
                             }
                             let res: Result<Value, TaskError> = match command {
@@ -492,7 +492,7 @@ impl TaskQueue {
                                             }
                                         }
                                         if let Some(task) = snapshot {
-                                            let _ = app.emit_all("task_updated", task);
+                                            let _ = app.emit("task_updated", task);
                                         }
                                         if _cancelled_clone.lock().await.contains(&id) {
                                             return Err(TaskError {
@@ -531,7 +531,7 @@ impl TaskQueue {
                             };
                             if let Some(task) = snapshot {
                                 if let Some(app) = app_handle.lock().unwrap().clone() {
-                                    let _ = app.emit_all("task_updated", task);
+                                    let _ = app.emit("task_updated", task);
                                 }
                             }
                             drop(permit);


### PR DESCRIPTION
## Summary
- use `emit` instead of `emit_all` when notifying about task updates
- import `Emitter` to bring `emit` into scope

## Testing
- `cargo build` *(fails: mismatched types for window parameter)*

------
https://chatgpt.com/codex/tasks/task_e_68acc5fe32e48325adc2f23bc9b645c1