### PR TITLE
fix: use standard window in lofi song tasks

### DIFF
--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -453,7 +453,7 @@ impl TaskQueue {
                                             message: "no app handle".into(),
                                         })?;
                                     let window = app
-                                        .get_webview_window("main")
+                                        .get_window("main")
                                         .ok_or_else(|| TaskError {
                                             code: PdfErrorCode::Unknown,
                                             message: "no main window".into(),


### PR DESCRIPTION
## Summary
- fix type mismatch by using `get_window` when running lofi songs

## Testing
- `cargo check` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc7fed06c83259f72631f8e336578