### PR TITLE
chore: use webview window in task queue

### DIFF
--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 use chrono::{DateTime, Utc};
 use sysinfo::System;
 use tauri::async_runtime::{self, JoinHandle};
-use tauri::{AppHandle, Emitter, Manager, Wry};
+use tauri::{AppHandle, Emitter, Wry};
 use tokio::sync::{mpsc, Mutex, Semaphore};
 use tokio::time::sleep;
 
@@ -453,7 +453,7 @@ impl TaskQueue {
                                             message: "no app handle".into(),
                                         })?;
                                     let window = app
-                                        .get_window("main")
+                                        .get_webview_window("main")
                                         .ok_or_else(|| TaskError {
                                             code: PdfErrorCode::Unknown,
                                             message: "no main window".into(),


### PR DESCRIPTION
## Summary
- swap `get_window` with `get_webview_window` for the main window
- drop unused `Manager` trait import

## Testing
- `npm run tauri build` *(fails: Property 'toBeInTheDocument' does not exist on type 'Assertion<HTMLElement>' etc.)*
- `cargo check` *(fails: The system library `gdk-3.0` required by crate `gdk-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acca706b9c8325bebd55821504e99d