### PR TITLE
Refactor album generation to drop unused Manager import

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -802,10 +802,12 @@ pub async fn lofi_generate_gpu<R: Runtime>(
 /// Run full-song generation based on a structured spec (typed, camelCase-friendly).
 #[tauri::command]
 pub async fn run_lofi_song<R: Runtime>(
-    window: Window<R>,
     app: AppHandle<R>,
     spec: SongSpec,
 ) -> Result<String, String> {
+    let window = app
+        .get_webview_window("main")
+        .ok_or_else(|| "no main window".to_string())?;
     let py = conda_python();
     if !py.exists() {
         return Err(format!("Python not found at {}", py.display()));
@@ -885,7 +887,6 @@ pub async fn run_lofi_song<R: Runtime>(
 
 #[tauri::command]
 pub async fn generate_album<R: Runtime>(
-    window: Window<R>,
     app: AppHandle<R>,
     meta: AlbumRequest,
 ) -> Result<AlbumMeta, String> {
@@ -907,7 +908,7 @@ pub async fn generate_album<R: Runtime>(
         spec.title = name.clone();
         spec.out_dir = album_dir.to_string_lossy().to_string();
         spec.album = Some(album_name.clone());
-        let path = run_lofi_song(window.clone(), app.clone(), spec).await?;
+        let path = run_lofi_song(app.clone(), spec).await?;
         tracks.push(TrackMeta { name, path });
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ mod task_queue;
 
 use task_queue::TaskQueue;
 use tauri_plugin_sql::{Builder as SqlBuilder, Migration, MigrationKind};
+use tauri::Manager;
 
 fn main() {
     env_logger::init();
@@ -15,7 +16,7 @@ fn main() {
         .manage(queue)
         .setup(|app| {
             let handle = app.handle();
-            app.state::<TaskQueue>().set_app_handle(handle);
+            app.state::<TaskQueue>().set_app_handle(handle.clone());
             Ok(())
         })
         .plugin(tauri_plugin_dialog::init())

--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -452,12 +452,6 @@ impl TaskQueue {
                                             code: PdfErrorCode::Unknown,
                                             message: "no app handle".into(),
                                         })?;
-                                    let window = app
-                                        .get_webview_window("main")
-                                        .ok_or_else(|| TaskError {
-                                            code: PdfErrorCode::Unknown,
-                                            message: "no main window".into(),
-                                        })?;
                                     let specs = meta.specs.ok_or_else(|| TaskError {
                                         code: PdfErrorCode::Unknown,
                                         message: "missing specs".into(),
@@ -476,7 +470,7 @@ impl TaskQueue {
                                         if let Some(dir) = &meta.out_dir {
                                             spec.out_dir = dir.clone();
                                         }
-                                        let path = run_lofi_song(window.clone(), app.clone(), spec)
+                                        let path = run_lofi_song(app.clone(), spec)
                                             .await
                                             .map_err(|e| TaskError {
                                                 code: PdfErrorCode::ExecutionFailed,


### PR DESCRIPTION
## Summary
- Drop `Manager` from task queue and fetch main window inside commands
- Simplify album generation helpers to use only `AppHandle`
- Ensure main app initialization clones handle before storing

## Testing
- `cargo check`
- `grep -n 'warning' /tmp/check.log | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68acccde7f3c8325b0fb54429f6e3333