### PR TITLE
feat: add dialog for new world

### DIFF
--- a/src/components/NewWorldDialog.tsx
+++ b/src/components/NewWorldDialog.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, TextField } from '@mui/material';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (name: string) => void;
+}
+
+export default function NewWorldDialog({ open, onClose, onSubmit }: Props) {
+  const [name, setName] = useState('');
+
+  const handleClose = () => {
+    setName('');
+    onClose();
+  };
+
+  const handleSubmit = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+    handleClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth>
+      <DialogTitle>Create New World</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          margin="dense"
+          label="World Name"
+          fullWidth
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button onClick={handleSubmit} variant="contained" disabled={!name.trim()}>
+          Create
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/pages/DND.test.tsx
+++ b/src/pages/DND.test.tsx
@@ -17,13 +17,16 @@ describe("DND world selector", () => {
     vi.restoreAllMocks();
   });
 
-    it.skip("allows creating and saving a new world", async () => {
-      vi.spyOn(window, "prompt").mockReturnValue("Eberron");
-      render(<DND />);
-      const select = screen.getByRole("combobox", { name: "World" });
-      await userEvent.selectOptions(select, "__new__");
-      expect(screen.getByDisplayValue("Eberron")).toBeInTheDocument();
-      expect(useWorlds.getState().worlds).toContain("Eberron");
-      expect(useWorlds.getState().currentWorld).toBe("Eberron");
-    });
+  it("allows creating and saving a new world", async () => {
+    render(<DND />);
+    const select = screen.getByRole("combobox", { name: "World" });
+    await userEvent.click(select);
+    await userEvent.click(screen.getByRole("option", { name: "Create New World" }));
+    const input = await screen.findByLabelText("World Name");
+    await userEvent.type(input, "Eberron");
+    await userEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(screen.getByDisplayValue("Eberron")).toBeInTheDocument();
+    expect(useWorlds.getState().worlds).toContain("Eberron");
+    expect(useWorlds.getState().currentWorld).toBe("Eberron");
+  });
 });

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -24,6 +24,7 @@ import DiceRoller from "../features/dnd/DiceRoller";
 import TabletopMap from "../features/dnd/TabletopMap";
 import WarTable from "../features/dnd/WarTable";
 import { useWorlds } from "../store/worlds";
+import NewWorldDialog from "../components/NewWorldDialog";
 
 export default function DND() {
   const [tab, setTab] = useState(0);
@@ -31,18 +32,19 @@ export default function DND() {
   const world = useWorlds((s) => s.currentWorld);
   const addWorld = useWorlds((s) => s.addWorld);
   const setCurrentWorld = useWorlds((s) => s.setCurrentWorld);
+  const [newWorldOpen, setNewWorldOpen] = useState(false);
   const handleChange = (_e: SyntheticEvent, v: number) => setTab(v);
   const handleWorldChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     if (value === "__new__") {
-      const name = window.prompt("Enter world name")?.trim();
-      if (name) {
-        addWorld(name);
-        setCurrentWorld(name);
-      }
+      setNewWorldOpen(true);
     } else {
       setCurrentWorld(value);
     }
+  };
+  const handleCreateWorld = (name: string) => {
+    addWorld(name);
+    setCurrentWorld(name);
   };
   return (
     <Box sx={{ p: 2 }}>
@@ -62,6 +64,11 @@ export default function DND() {
           <MenuItem value="__new__">Create New World</MenuItem>
         </TextField>
       </Box>
+      <NewWorldDialog
+        open={newWorldOpen}
+        onClose={() => setNewWorldOpen(false)}
+        onSubmit={handleCreateWorld}
+      />
       {world && (
         <>
           <Tabs


### PR DESCRIPTION
## Summary
- replace prompt-based world creation with stateful dialog
- add reusable `NewWorldDialog` component
- test creating and selecting a new world

## Testing
- `npm test src/pages/DND.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68accf55fb74832597aa1ea9f66b7358