### PR TITLE
Use shallow selector in settings modules

### DIFF
--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -1,12 +1,16 @@
 import { useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useUsers, defaultModules, type ModuleKey } from "../users/useUsers";
+import { shallow } from "zustand/shallow";
 
 export function useSettings() {
-  const modules = useUsers((state) => {
-    const id = state.currentUserId;
-    return { ...defaultModules, ...(id ? state.users[id].modules : {}) };
-  });
+  const modules = useUsers(
+    (state) => {
+      const id = state.currentUserId;
+      return { ...defaultModules, ...(id ? state.users[id].modules : {}) };
+    },
+    shallow
+  );
   const toggleModule = useUsers((state) => state.toggleModule);
   const cpuLimit = useUsers((state) => {
     const id = state.currentUserId;


### PR DESCRIPTION
## Summary
- use zustand's `shallow` equality to stabilize module selection in settings

## Testing
- `npm test` *(fails: 1 failed snapshot, 34 passed test files)*

------
https://chatgpt.com/codex/tasks/task_e_68acd291d1108325adfc15c665783014