### PR TITLE
feat(dnd): centralize text field styling

### DIFF
--- a/src/features/dnd/EncounterForm.tsx
+++ b/src/features/dnd/EncounterForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { Typography, TextField, Button, Grid, Box } from "@mui/material";
+import { Typography, Button, Grid, Box } from "@mui/material";
+import StyledTextField from "./StyledTextField";
 import FormErrorText from "./FormErrorText";
 import { zEncounter } from "./schemas";
 import { EncounterData } from "./types";
@@ -46,7 +47,7 @@ export default function EncounterForm() {
           <Typography variant="h6">Encounter Form</Typography>
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Name"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -55,7 +56,7 @@ export default function EncounterForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Level"
             type="number"
             value={level ?? ""}
@@ -74,7 +75,7 @@ export default function EncounterForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Creatures (comma separated)"
             value={creatures}
             onChange={(e) => setCreatures(e.target.value)}
@@ -83,7 +84,7 @@ export default function EncounterForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Tactics"
             value={tactics}
             onChange={(e) => setTactics(e.target.value)}
@@ -92,7 +93,7 @@ export default function EncounterForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Terrain"
             value={terrain}
             onChange={(e) => setTerrain(e.target.value)}
@@ -101,7 +102,7 @@ export default function EncounterForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Treasure"
             value={treasure}
             onChange={(e) => setTreasure(e.target.value)}
@@ -110,7 +111,7 @@ export default function EncounterForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Scaling"
             value={scaling}
             onChange={(e) => setScaling(e.target.value)}

--- a/src/features/dnd/LoreForm.tsx
+++ b/src/features/dnd/LoreForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { Typography, TextField, Button, Grid, Box } from "@mui/material";
+import { Typography, Button, Grid, Box } from "@mui/material";
+import StyledTextField from "./StyledTextField";
 import { zLore } from "./schemas";
 import { LoreData } from "./types";
 import LorePdfUpload from "./LorePdfUpload";
@@ -42,7 +43,7 @@ export default function LoreForm({ world }: Props) {
           <LorePdfUpload world={world} />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Name"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -51,7 +52,7 @@ export default function LoreForm({ world }: Props) {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Summary"
             value={summary}
             onChange={(e) => setSummary(e.target.value)}
@@ -60,7 +61,7 @@ export default function LoreForm({ world }: Props) {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Location"
             value={location}
             onChange={(e) => setLocation(e.target.value)}
@@ -69,7 +70,7 @@ export default function LoreForm({ world }: Props) {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Hooks (comma separated)"
             value={hooks}
             onChange={(e) => setHooks(e.target.value)}
@@ -78,7 +79,7 @@ export default function LoreForm({ world }: Props) {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Tags (comma separated)"
             value={tags}
             onChange={(e) => setTags(e.target.value)}

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import {
   Typography,
-  TextField,
   Button,
   Checkbox,
   Grid,
@@ -17,6 +16,7 @@ import { z } from "zod";
 import { zNpc } from "../../dnd/schemas/npc";
 import { NpcData } from "./types";
 import NpcPdfUpload from "./NpcPdfUpload";
+import StyledTextField from "./StyledTextField";
 
 interface Props {
   world: string;
@@ -42,24 +42,6 @@ export default function NpcForm({ world }: Props) {
   const [tags, setTags] = useState("");
   const [errors, setErrors] = useState<Record<string, string | null>>({});
   const [result, setResult] = useState<NpcData | null>(null);
-
-  const textFieldProps = {
-    variant: "outlined" as const,
-    InputLabelProps: { shrink: true },
-    InputProps: {
-      sx: {
-        "::placeholder": {
-          color: "gray",
-        },
-      },
-    },
-    sx: {
-      backgroundColor: "background.paper",
-      color: "text.primary",
-      borderRadius: 1,
-      boxShadow: 1,
-    },
-  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -145,8 +127,7 @@ export default function NpcForm({ world }: Props) {
               </Typography>
             </Grid>
             <Grid item xs={8}>
-              <TextField
-                {...textFieldProps}
+              <StyledTextField
                 id="name"
                 value={name}
                 onChange={(e) => {
@@ -168,8 +149,7 @@ export default function NpcForm({ world }: Props) {
               </Typography>
             </Grid>
             <Grid item xs={8}>
-              <TextField
-                {...textFieldProps}
+              <StyledTextField
                 id="species"
                 value={species}
                 onChange={(e) => {
@@ -193,8 +173,7 @@ export default function NpcForm({ world }: Props) {
               </Typography>
             </Grid>
             <Grid item xs={8}>
-              <TextField
-                {...textFieldProps}
+              <StyledTextField
                 id="role"
                 value={role}
                 onChange={(e) => {
@@ -216,8 +195,7 @@ export default function NpcForm({ world }: Props) {
               </Typography>
             </Grid>
             <Grid item xs={8}>
-              <TextField
-                {...textFieldProps}
+              <StyledTextField
                 id="alignment"
                 value={alignment}
                 onChange={(e) => {
@@ -265,8 +243,7 @@ export default function NpcForm({ world }: Props) {
               </Typography>
             </Grid>
             <Grid item xs={8}>
-              <TextField
-                {...textFieldProps}
+              <StyledTextField
                 id="backstory"
                 value={backstory}
                 onChange={(e) => setBackstory(e.target.value)}
@@ -280,8 +257,7 @@ export default function NpcForm({ world }: Props) {
               </Typography>
             </Grid>
             <Grid item xs={8}>
-              <TextField
-                {...textFieldProps}
+              <StyledTextField
                 id="location"
                 value={location}
                 onChange={(e) => setLocation(e.target.value)}
@@ -295,8 +271,7 @@ export default function NpcForm({ world }: Props) {
               </Typography>
             </Grid>
             <Grid item xs={8}>
-              <TextField
-                {...textFieldProps}
+              <StyledTextField
                 id="hooks"
                 value={hooks}
                 onChange={(e) => {
@@ -318,8 +293,7 @@ export default function NpcForm({ world }: Props) {
               </Typography>
             </Grid>
             <Grid item xs={8}>
-              <TextField
-                {...textFieldProps}
+              <StyledTextField
                 id="quirks"
                 value={quirks}
                 onChange={(e) => setQuirks(e.target.value)}
@@ -333,8 +307,7 @@ export default function NpcForm({ world }: Props) {
               </Typography>
             </Grid>
             <Grid item xs={8}>
-              <TextField
-                {...textFieldProps}
+              <StyledTextField
                 id="tags"
                 value={tags}
                 onChange={(e) => {
@@ -366,8 +339,7 @@ export default function NpcForm({ world }: Props) {
               </Typography>
             </Grid>
             <Grid item xs={8}>
-              <TextField
-                {...textFieldProps}
+              <StyledTextField
                 id="portrait"
                 value={portrait}
                 onChange={(e) => setPortrait(e.target.value)}
@@ -381,8 +353,7 @@ export default function NpcForm({ world }: Props) {
               </Typography>
             </Grid>
             <Grid item xs={8}>
-              <TextField
-                {...textFieldProps}
+              <StyledTextField
                 id="icon"
                 value={icon}
                 onChange={(e) => setIcon(e.target.value)}
@@ -411,8 +382,7 @@ export default function NpcForm({ world }: Props) {
                   </Typography>
                 </Grid>
                 <Grid item xs={8}>
-                  <TextField
-                    {...textFieldProps}
+                  <StyledTextField
                     id="voice-style"
                     value={voiceStyle}
                     onChange={(e) => {
@@ -438,8 +408,7 @@ export default function NpcForm({ world }: Props) {
                   </Typography>
                 </Grid>
                 <Grid item xs={8}>
-                  <TextField
-                    {...textFieldProps}
+                  <StyledTextField
                     id="voice-provider"
                     value={voiceProvider}
                     onChange={(e) => {
@@ -470,8 +439,7 @@ export default function NpcForm({ world }: Props) {
                   </Typography>
                 </Grid>
                 <Grid item xs={8}>
-                  <TextField
-                    {...textFieldProps}
+                  <StyledTextField
                     id="voice-preset"
                     value={voicePreset}
                     onChange={(e) => {
@@ -506,8 +474,7 @@ export default function NpcForm({ world }: Props) {
                   </Typography>
                 </Grid>
                 <Grid item xs={8}>
-                  <TextField
-                    {...textFieldProps}
+                  <StyledTextField
                     id="statblock"
                     value={statblock}
                     onChange={(e) => {
@@ -534,8 +501,7 @@ export default function NpcForm({ world }: Props) {
                   </Typography>
                 </Grid>
                 <Grid item xs={8}>
-                  <TextField
-                    {...textFieldProps}
+                  <StyledTextField
                     id="sections"
                     value={sections}
                     onChange={(e) => {

--- a/src/features/dnd/QuestForm.tsx
+++ b/src/features/dnd/QuestForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { Typography, TextField, Button, Grid, Box } from "@mui/material";
+import { Typography, Button, Grid, Box } from "@mui/material";
+import StyledTextField from "./StyledTextField";
 import FormErrorText from "./FormErrorText";
 import { zQuest } from "./schemas";
 import { QuestData } from "./types";
@@ -56,7 +57,7 @@ export default function QuestForm() {
           <Typography variant="h6">Quest Form</Typography>
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Name"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -65,7 +66,7 @@ export default function QuestForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Tier"
             type="number"
             value={tier ?? ""}
@@ -84,7 +85,7 @@ export default function QuestForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Summary"
             value={summary}
             onChange={(e) => setSummary(e.target.value)}
@@ -93,7 +94,7 @@ export default function QuestForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Beats (comma separated)"
             value={beats}
             onChange={(e) => setBeats(e.target.value)}
@@ -102,7 +103,7 @@ export default function QuestForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Reward GP"
             type="number"
             value={gp ?? ""}
@@ -121,7 +122,7 @@ export default function QuestForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Reward Items"
             value={items}
             onChange={(e) => setItems(e.target.value)}
@@ -130,7 +131,7 @@ export default function QuestForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Reward Favors"
             value={favors}
             onChange={(e) => setFavors(e.target.value)}
@@ -139,7 +140,7 @@ export default function QuestForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Complications (comma separated)"
             value={complications}
             onChange={(e) => setComplications(e.target.value)}

--- a/src/features/dnd/RuleForm.tsx
+++ b/src/features/dnd/RuleForm.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import {
   Typography,
-  TextField,
   Button,
   FormControl,
   InputLabel,
@@ -10,6 +9,7 @@ import {
   Grid,
   Box,
 } from "@mui/material";
+import StyledTextField from "./StyledTextField";
 import { zRule } from "./schemas";
 import type { RuleData } from "./types";
 import rulesIndex from "../../../dnd/rules/index.json";
@@ -95,7 +95,7 @@ export default function RuleForm() {
           </FormControl>
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Name"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -104,7 +104,7 @@ export default function RuleForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
@@ -114,7 +114,7 @@ export default function RuleForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Tags (comma separated)"
             value={tags}
             onChange={(e) => setTags(e.target.value)}

--- a/src/features/dnd/SpellForm.tsx
+++ b/src/features/dnd/SpellForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { Typography, TextField, Button, Grid, Box } from "@mui/material";
+import { Typography, Button, Grid, Box } from "@mui/material";
+import StyledTextField from "./StyledTextField";
 import SpellPdfUpload from "./SpellPdfUpload";
 import { zSpell } from "./schemas";
 import type { SpellData } from "./types";
@@ -44,7 +45,7 @@ export default function SpellForm() {
           <SpellPdfUpload />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Name"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -53,7 +54,7 @@ export default function SpellForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Level"
             value={level}
             onChange={(e) => setLevel(e.target.value)}
@@ -62,7 +63,7 @@ export default function SpellForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="School"
             value={school}
             onChange={(e) => setSchool(e.target.value)}
@@ -71,7 +72,7 @@ export default function SpellForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Casting Time"
             value={castingTime}
             onChange={(e) => setCastingTime(e.target.value)}
@@ -80,7 +81,7 @@ export default function SpellForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Range"
             value={range}
             onChange={(e) => setRange(e.target.value)}
@@ -89,7 +90,7 @@ export default function SpellForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Components (comma separated)"
             value={components}
             onChange={(e) => setComponents(e.target.value)}
@@ -98,7 +99,7 @@ export default function SpellForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Duration"
             value={duration}
             onChange={(e) => setDuration(e.target.value)}
@@ -107,7 +108,7 @@ export default function SpellForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
@@ -117,7 +118,7 @@ export default function SpellForm() {
           />
         </Grid>
         <Grid item xs={12} md={6}>
-          <TextField
+          <StyledTextField
             label="Tags (comma separated)"
             value={tags}
             onChange={(e) => setTags(e.target.value)}

--- a/src/features/dnd/StyledTextField.tsx
+++ b/src/features/dnd/StyledTextField.tsx
@@ -1,0 +1,26 @@
+import { TextField, TextFieldProps } from "@mui/material";
+
+export default function StyledTextField(props: TextFieldProps) {
+  const { InputProps, sx, ...rest } = props;
+  return (
+    <TextField
+      variant="outlined"
+      InputLabelProps={{ shrink: true }}
+      InputProps={{
+        ...InputProps,
+        sx: {
+          "::placeholder": { color: "gray" },
+          ...(InputProps && InputProps.sx),
+        },
+      }}
+      sx={{
+        backgroundColor: "background.paper",
+        color: "text.primary",
+        borderRadius: 1,
+        boxShadow: 1,
+        ...sx,
+      }}
+      {...rest}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- create `StyledTextField` with shared DnD styling
- use `StyledTextField` across DnD forms to replace plain `TextField`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acd7ef9b308325aa3894c780a72300