### PR TITLE
Specify AppHandle type for TaskQueue app mutex

### DIFF
--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -140,7 +140,8 @@ impl TaskQueue {
             cpu: cpu_limit,
             memory: memory_limit,
         }));
-        let app: Arc<StdMutex<Option<AppHandle<Wry>>>> = Arc::new(StdMutex::new(None));
+        let app: Arc<StdMutex<Option<AppHandle<Wry>>>> =
+            Arc::new(StdMutex::new(None::<AppHandle<Wry>>));
         let tasks_worker = tasks.clone();
         let _handles_worker = _handles.clone();
         let _cancelled_worker = _cancelled.clone();


### PR DESCRIPTION
## Summary
- Specify `AppHandle<Wry>` type when initializing `TaskQueue`'s `app` mutex to avoid inference issues

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68acda70d6a48325a1a017f2337d9ff8