### PR TITLE
feat: add error boundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from "react-router-dom";
 import TopBar from "./components/TopBar";
+import ErrorBoundary from "./components/ErrorBoundary";
 import Home from "./pages/Home";
 import Objects from "./pages/Objects";
 import Blender from "./pages/Blender";
@@ -29,7 +30,7 @@ import BigBrother from "./pages/BigBrother";
 
 export default function App() {
   return (
-    <>
+    <ErrorBoundary>
       <TopBar />
       <Routes>
         <Route path="/" element={<Home />} />
@@ -59,6 +60,6 @@ export default function App() {
         <Route path="/user" element={<User />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
-    </>
+    </ErrorBoundary>
   );
 }

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import { Component, ReactNode, ErrorInfo } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(_: Error): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // You could log the error to an error reporting service
+    console.error("ErrorBoundary caught an error", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>Something went wrong.</div>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -6,6 +6,7 @@ import MenuBookIcon from "@mui/icons-material/MenuBook";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useState, useEffect } from "react";
 import SettingsDrawer from "./SettingsDrawer";
+import ErrorBoundary from "./ErrorBoundary";
 import TaskDrawer from "./TaskDrawer";
 import { useTasks } from "../store/tasks";
 
@@ -119,7 +120,9 @@ export default function TopBar() {
           <FaWrench />
         </IconButton>
       </Tooltip>
-      <SettingsDrawer open={open} onClose={() => setOpen(false)} />
+      <ErrorBoundary>
+        <SettingsDrawer open={open} onClose={() => setOpen(false)} />
+      </ErrorBoundary>
       <TaskDrawer open={taskOpen} onClose={() => setTaskOpen(false)} />
     </>
   );


### PR DESCRIPTION
## Summary
- add an ErrorBoundary component to catch rendering errors
- wrap the app layout and SettingsDrawer with the new boundary

## Testing
- `npm test` *(fails: snapshots out of date)*

------
https://chatgpt.com/codex/tasks/task_e_68acddb35bb4832592d462f3ded63393