### PR TITLE
Remove optional TTS dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,3 @@ aiohttp>=3.9.0
 vosk>=0.3.45
 audioop-lts ; python_version >= "3.13"  # audioop module for Python 3.13+
 
-# Optional dependencies for text-to-speech support
-# TTS>=0.15; python_version < "3.12"
-# torch>=2.0

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,5 @@ setup(
         'pydub>=0.25.0',
         'audioop-lts; python_version >= "3.13"',
     ],
-    extras_require={
-        'TTS': [
-            'TTS>=0.15; python_version < "3.12"',
-            'torch>=2.0',
-        ],
-    },
     python_requires='>=3.10,<3.12',
 )


### PR DESCRIPTION
## Summary
- drop optional text-to-speech packages from requirements
- remove TTS extras from setup

## Testing
- `python -m py_compile setup.py`
- `npm test` *(fails: 1 snapshot failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ace713aa1c832594270d8ea58d7aa8