### PR TITLE
Handle pdf_tools path from src-tauri cwd

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -399,6 +399,11 @@ fn pdf_tools_path<R: Runtime>(app: &AppHandle<R>) -> PathBuf {
         if dev.exists() {
             return dev;
         }
+
+        let dev = cwd.join("python").join("pdf_tools.py");
+        if dev.exists() {
+            return dev;
+        }
     }
     app.path()
         .resource_dir()
@@ -410,6 +415,11 @@ fn pdf_tools_path<R: Runtime>(app: &AppHandle<R>) -> PathBuf {
 pub fn pdf_tools_path_default() -> PathBuf {
     if let Ok(cwd) = std::env::current_dir() {
         let dev = cwd.join("src-tauri").join("python").join("pdf_tools.py");
+        if dev.exists() {
+            return dev;
+        }
+
+        let dev = cwd.join("python").join("pdf_tools.py");
         if dev.exists() {
             return dev;
         }


### PR DESCRIPTION
## Summary
- search for `src-tauri/python/pdf_tools.py` when cwd is project root or `src-tauri`

## Testing
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ace660f21c8325aa3103dc65df798c