### PR TITLE
Use Link directly in NPC list items

### DIFF
--- a/src/pages/NPCList.tsx
+++ b/src/pages/NPCList.tsx
@@ -73,13 +73,12 @@ export default function NPCList() {
         ) : (
           <List>
             {filtered.map((npc) => (
-              <ListItemButton key={npc.id}>
-                <Link
-                  to={`/dnd/npcs/${npc.id}`}
-                  style={{ textDecoration: 'none', color: 'inherit', width: '100%' }}
-                >
-                  <ListItemText primary={npc.name} />
-                </Link>
+              <ListItemButton
+                key={npc.id}
+                component={Link}
+                to={`/dnd/npcs/${npc.id}`}
+              >
+                <ListItemText primary={npc.name} />
               </ListItemButton>
             ))}
           </List>


### PR DESCRIPTION
## Summary
- Simplify NPC list item navigation by using `<ListItemButton component={Link}>` with `to` prop
- Remove nested `<Link>` wrapper for cleaner markup

## Testing
- `npm test` *(fails: Snapshots 1 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ace5efeba08325a4c3729afcae5fbf