### PR TITLE
fix: guard tags in Chores page

### DIFF
--- a/src/pages/Chores.tsx
+++ b/src/pages/Chores.tsx
@@ -26,14 +26,14 @@ export default function Chores() {
 
   const upcomingTasks = events.filter(
     (e) =>
-      e.tags.includes("task") &&
+      e.tags?.includes("task") &&
       e.status === "scheduled" &&
       new Date(e.date) >= startOfToday
   ).length;
 
   const missedTasks = events.filter(
     (e) =>
-      e.tags.includes("task") &&
+      e.tags?.includes("task") &&
       e.status === "scheduled" &&
       new Date(e.date) < startOfToday
   ).length;


### PR DESCRIPTION
## Summary
- Prevent Chores page from crashing when an event lacks tags by using optional chaining

## Testing
- `npx vitest run --reporter=dot` *(fails: Test Files 2 failed | 35 passed; Tests 1 failed | 159 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ace9755b6883259f1dc6f5f500dc4b