### PR TITLE
Add D&D theme variant and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700;800&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
     <title>Tauri + React + Typescript</title>
   </head>
 

--- a/src/features/dnd/DiceRoller.tsx
+++ b/src/features/dnd/DiceRoller.tsx
@@ -223,7 +223,14 @@ export default function DiceRoller() {
   };
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 2,
+        fontFamily: "typography.fontFamily",
+      }}
+    >
       <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
         <TextField
           label="Count"
@@ -253,11 +260,19 @@ export default function DiceRoller() {
         onChange={(e) => setExpression(e.target.value)}
         sx={{ maxWidth: 200 }}
       />
-      <Button variant="contained" onClick={handleRoll} sx={{ maxWidth: 200 }}>
+      <Button
+        variant="contained"
+        onClick={handleRoll}
+        sx={{
+          maxWidth: 200,
+          bgcolor: "primary.main",
+          "&:hover": { bgcolor: "primary.dark" },
+        }}
+      >
         Roll
       </Button>
       {result !== null && (
-        <Typography variant="h6">
+        <Typography variant="h6" sx={{ color: "secondary.main" }}>
           Result: {result} {rolls.length > 0 && `( ${rolls.join(", ")} )`}
         </Typography>
       )}

--- a/src/features/dnd/StyledTextField.tsx
+++ b/src/features/dnd/StyledTextField.tsx
@@ -9,7 +9,8 @@ export default function StyledTextField(props: TextFieldProps) {
       InputProps={{
         ...InputProps,
         sx: {
-          "::placeholder": { color: "gray" },
+          "&::placeholder": { color: "secondary.light" },
+          fontFamily: "typography.fontFamily",
           ...(InputProps && InputProps.sx),
         },
       }}
@@ -18,6 +19,15 @@ export default function StyledTextField(props: TextFieldProps) {
         color: "text.primary",
         borderRadius: 1,
         boxShadow: 1,
+        "& .MuiOutlinedInput-notchedOutline": {
+          borderColor: "primary.main",
+        },
+        "&:hover .MuiOutlinedInput-notchedOutline": {
+          borderColor: "primary.light",
+        },
+        "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+          borderColor: "secondary.main",
+        },
         ...sx,
       }}
       {...rest}

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -22,7 +22,8 @@ export type Theme =
   | "rainy"
   | "pastel"
   | "mono"
-  | "eclipse";
+  | "eclipse"
+  | "dnd";
 
 interface ThemeContextType {
   theme: Theme;
@@ -54,6 +55,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       "theme-pastel",
       "theme-mono",
       "theme-eclipse",
+      "theme-dnd",
     ];
     document.body.classList.remove(...classes);
     document.body.classList.add(`theme-${theme}`);

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -1,4 +1,5 @@
 import { Box, Tab, Tabs, TextField, MenuItem } from "@mui/material";
+import { ThemeProvider } from "@mui/material/styles";
 import {
   Person,
   MenuBook,
@@ -12,7 +13,7 @@ import {
   LibraryBooks,
 } from "@mui/icons-material";
 import { SyntheticEvent, useState, ChangeEvent } from "react";
-// Removed custom D&D theming in favor of default MUI styling
+import { createDndTheme } from "../theme";
 import NpcForm from "../features/dnd/NpcForm";
 import LoreForm from "../features/dnd/LoreForm";
 import NPCList from "./NPCList";
@@ -65,7 +66,8 @@ export default function DND() {
     { icon: <MilitaryTech />, label: "War Table", component: <WarTable /> },
   ];
   return (
-    <Box sx={{ p: 2 }}>
+    <ThemeProvider theme={createDndTheme()}>
+      <Box sx={{ p: 2 }}>
       <Box sx={{ my: 2, maxWidth: 200, mx: "auto" }}>
         <TextField
           select
@@ -102,6 +104,7 @@ export default function DND() {
           {tabs[tab]?.component}
         </>
       )}
-    </Box>
+      </Box>
+    </ThemeProvider>
   );
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -15,6 +15,19 @@ export const colors = {
 
 export const spacing = 8;
 
+export const dndColors = {
+  primary: '#8b0000',
+  secondary: '#d4af37',
+  background: '#2a1a1f',
+  surface: '#3e2723',
+};
+
+export const dndTypography = {
+  fontFamily: `'Cinzel', serif`,
+  h1: { fontFamily: `'Cinzel', serif` },
+  h2: { fontFamily: `'Cinzel', serif` },
+};
+
 export const createAppTheme = () =>
   createTheme({
     palette: {
@@ -23,5 +36,20 @@ export const createAppTheme = () =>
       secondary: { main: colors.secondary },
       background: { default: colors.background, paper: colors.surface },
     },
+    spacing,
+  });
+
+export const createDndTheme = () =>
+  createTheme({
+    palette: {
+      mode: 'dark',
+      primary: { main: dndColors.primary },
+      secondary: { main: dndColors.secondary },
+      background: {
+        default: dndColors.background,
+        paper: dndColors.surface,
+      },
+    },
+    typography: dndTypography,
     spacing,
   });


### PR DESCRIPTION
## Summary
- add D&D palette and typography and export `createDndTheme`
- support `dnd` theme option and apply D&D theme to DND page
- style dice roller and form fields with new colors and fonts

## Testing
- `npm test` *(fails: Failed to resolve entry for package "@react-three/cannon" in DiceRoller.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68aced9a110c8325af5492baa2c209e0