### PR TITLE
Fix Halloween holiday date

### DIFF
--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -37,7 +37,7 @@ function pad(n: number) {
 const HOLIDAYS = [
   { month: 0, day: 1, title: "New Year's Day" },
   { month: 6, day: 4, title: "Independence Day" },
-  { month: 10, day: 31, title: "Halloween" },
+  { month: 9, day: 31, title: "Halloween" },
   { month: 11, day: 25, title: "Christmas Day" },
 ];
 


### PR DESCRIPTION
## Summary
- correct Halloween in the calendar to October 31st

## Testing
- `npx vitest run` *(fails: MUI Grid warnings keep the process running)*

------
https://chatgpt.com/codex/tasks/task_e_68acef44614083258a5c1dc40ebe4343