### PR TITLE
Allow configuring Blender path via env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Allow configuring the Blender executable via the `BLENDER_PATH` environment variable.
+
 ### Security
 - Require `requests` version 2.32.0 or newer to address security issues.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ npm test
 - **Paths:** Set the ComfyUI directory in the Settings page and edit
   `conda_python()` in `src-tauri/src/commands.rs` so the app can find your Python
   interpreter.
+- **Blender path:** If Blender is not on your system `PATH`, set the
+  `BLENDER_PATH` environment variable to the Blender executable so `/objects/blender`
+  can run scripts.
 - **HQ feature flags:** `lofi/renderer.py` supports `hq_stereo`, `hq_reverb`,
   `hq_sidechain`, and `hq_chorus` flags inside the `motif` object to enable or disable
   high‑quality processing.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -958,6 +958,11 @@ pub async fn blender_run_script(code: String) -> Result<(), String> {
 }
 
 fn blender_path() -> PathBuf {
+    if let Ok(p) = env::var("BLENDER_PATH") {
+        if !p.trim().is_empty() {
+            return PathBuf::from(p);
+        }
+    }
     PathBuf::from("blender")
 }
 


### PR DESCRIPTION
## Summary
- allow setting Blender executable path using BLENDER_PATH environment variable
- document BLENDER_PATH usage and update changelog

## Testing
- `npm test` *(fails: @react-three/cannon entry resolution)*
- `cargo test` *(fails: javascriptcoregtk-4.1 system library missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ace74135b483258ee1c0f99cfa4c66