### PR TITLE
refactor: remove tts settings

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -200,14 +200,6 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
     setPythonPath,
     comfyPath,
     setComfyPath,
-    ttsModelPath,
-    setTtsModelPath,
-    ttsConfigPath,
-    setTtsConfigPath,
-    ttsSpeaker,
-    setTtsSpeaker,
-    ttsLanguage,
-    setTtsLanguage,
   } = usePaths();
   const { folder, setFolder } = useOutput();
   const {
@@ -238,20 +230,12 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
 
   const [pythonDraft, setPythonDraft] = useState(pythonPath);
   const [comfyDraft, setComfyDraft] = useState(comfyPath);
-  const [ttsModelDraft, setTtsModelDraft] = useState(ttsModelPath);
-  const [ttsConfigDraft, setTtsConfigDraft] = useState(ttsConfigPath);
-  const [ttsSpeakerDraft, setTtsSpeakerDraft] = useState(ttsSpeaker);
-  const [ttsLanguageDraft, setTtsLanguageDraft] = useState(ttsLanguage);
   const [folderDraft, setFolderDraft] = useState(folder);
   const [themeDraft, setThemeDraft] = useState<Theme>(theme);
   const [editPython, setEditPython] = useState(false);
 
   useEffect(() => setPythonDraft(pythonPath), [pythonPath]);
   useEffect(() => setComfyDraft(comfyPath), [comfyPath]);
-  useEffect(() => setTtsModelDraft(ttsModelPath), [ttsModelPath]);
-  useEffect(() => setTtsConfigDraft(ttsConfigPath), [ttsConfigPath]);
-  useEffect(() => setTtsSpeakerDraft(ttsSpeaker), [ttsSpeaker]);
-  useEffect(() => setTtsLanguageDraft(ttsLanguage), [ttsLanguage]);
   useEffect(() => setFolderDraft(folder), [folder]);
   useEffect(() => setThemeDraft(theme), [theme]);
   type Section = "environment" | "editor" | "appearance" | "integrations";
@@ -267,10 +251,6 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   const baseIndex = [
     { label: "Python Path", section: "environment" as Section, elementId: "python-path" },
     { label: "ComfyUI Folder", section: "environment" as Section, elementId: "comfy-path" },
-    { label: "TTS Model Path", section: "environment" as Section, elementId: "tts-model-path" },
-    { label: "TTS Config Path", section: "environment" as Section, elementId: "tts-config-path" },
-    { label: "TTS Speaker", section: "environment" as Section, elementId: "tts-speaker" },
-    { label: "TTS Language", section: "environment" as Section, elementId: "tts-language" },
     { label: "Default Save Folder", section: "environment" as Section, elementId: "output-folder" },
     { label: "BPM", section: "editor" as Section, elementId: "bpm" },
     { label: "Key", section: "editor" as Section, elementId: "key" },
@@ -341,44 +321,12 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
         onChange={setComfyDraft}
         directory
       />
-      <PathField
-        id="tts-model-path"
-        label="TTS Model Path"
-        value={ttsModelDraft}
-        onChange={setTtsModelDraft}
-      />
-      <PathField
-        id="tts-config-path"
-        label="TTS Config Path"
-        value={ttsConfigDraft}
-        onChange={setTtsConfigDraft}
-      />
-      <Box id="tts-speaker" sx={{ mt: 1 }}>
-        <TextField
-          label="TTS Speaker"
-          value={ttsSpeakerDraft}
-          onChange={(e) => setTtsSpeakerDraft(e.target.value)}
-          fullWidth
-        />
-      </Box>
-      <Box id="tts-language" sx={{ mt: 1 }}>
-        <TextField
-          label="TTS Language"
-          value={ttsLanguageDraft}
-          onChange={(e) => setTtsLanguageDraft(e.target.value)}
-          fullWidth
-        />
-      </Box>
       <Button
         variant="contained"
         sx={{ mt: 2 }}
         onClick={() => {
           setPythonPath(pythonDraft);
           setComfyPath(comfyDraft);
-          setTtsModelPath(ttsModelDraft);
-          setTtsConfigPath(ttsConfigDraft);
-          setTtsSpeaker(ttsSpeakerDraft);
-          setTtsLanguage(ttsLanguageDraft);
           setPathsSaved(true);
           setEditPython(false);
         }}

--- a/src/features/djMix/useDjMix.ts
+++ b/src/features/djMix/useDjMix.ts
@@ -1,17 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
-import { usePaths } from "../paths/usePaths";
-
 export function useDjMix() {
-  const { ttsModelPath, ttsConfigPath, ttsSpeaker, ttsLanguage } = usePaths();
   return async (specs: string[], out: string, host = false) => {
     await invoke("dj_mix", {
       specs,
       out,
       host,
-      tts_model_path: ttsModelPath,
-      tts_config: ttsConfigPath,
-      tts_speaker: ttsSpeaker,
-      tts_language: ttsLanguage,
     });
   };
 }

--- a/src/features/paths/usePaths.test.ts
+++ b/src/features/paths/usePaths.test.ts
@@ -12,10 +12,6 @@ describe('usePaths save_paths error handling', () => {
   const setters: [string, string][] = [
     ['setPythonPath', 'py'],
     ['setComfyPath', 'comfy'],
-    ['setTtsModelPath', 'model'],
-    ['setTtsConfigPath', 'config'],
-    ['setTtsSpeaker', 'speaker'],
-    ['setTtsLanguage', 'lang'],
   ];
 
   it.each(setters)('%s surfaces errors', async (setter, value) => {

--- a/src/features/paths/usePaths.ts
+++ b/src/features/paths/usePaths.ts
@@ -6,17 +6,9 @@ interface PathsState {
   pythonPath: string;
   defaultPythonPath: string;
   comfyPath: string;
-  ttsModelPath: string;
-  ttsConfigPath: string;
-  ttsSpeaker: string;
-  ttsLanguage: string;
   loaded: boolean;
   setPythonPath: (p: string) => void;
   setComfyPath: (p: string) => void;
-  setTtsModelPath: (p: string) => void;
-  setTtsConfigPath: (p: string) => void;
-  setTtsSpeaker: (s: string) => void;
-  setTtsLanguage: (l: string) => void;
   load: () => Promise<void>;
 }
 
@@ -24,20 +16,12 @@ export const usePathsStore = create<PathsState>((set, get) => ({
   pythonPath: "",
   defaultPythonPath: "",
   comfyPath: "",
-  ttsModelPath: "",
-  ttsConfigPath: "",
-  ttsSpeaker: "",
-  ttsLanguage: "",
   loaded: false,
   setPythonPath: (pythonPath: string) => {
     set({ pythonPath });
     invoke("save_paths", {
       python_path: pythonPath,
       comfy_path: get().comfyPath,
-      tts_model_path: get().ttsModelPath,
-      tts_config_path: get().ttsConfigPath,
-      tts_speaker: get().ttsSpeaker,
-      tts_language: get().ttsLanguage,
     }).catch((err) => {
       console.error("Failed to save paths:", err);
     });
@@ -47,62 +31,6 @@ export const usePathsStore = create<PathsState>((set, get) => ({
     invoke("save_paths", {
       python_path: get().pythonPath,
       comfy_path: comfyPath,
-      tts_model_path: get().ttsModelPath,
-      tts_config_path: get().ttsConfigPath,
-      tts_speaker: get().ttsSpeaker,
-      tts_language: get().ttsLanguage,
-    }).catch((err) => {
-      console.error("Failed to save paths:", err);
-    });
-  },
-  setTtsModelPath: (ttsModelPath: string) => {
-    set({ ttsModelPath });
-    invoke("save_paths", {
-      python_path: get().pythonPath,
-      comfy_path: get().comfyPath,
-      tts_model_path: ttsModelPath,
-      tts_config_path: get().ttsConfigPath,
-      tts_speaker: get().ttsSpeaker,
-      tts_language: get().ttsLanguage,
-    }).catch((err) => {
-      console.error("Failed to save paths:", err);
-    });
-  },
-  setTtsConfigPath: (ttsConfigPath: string) => {
-    set({ ttsConfigPath });
-    invoke("save_paths", {
-      python_path: get().pythonPath,
-      comfy_path: get().comfyPath,
-      tts_model_path: get().ttsModelPath,
-      tts_config_path: ttsConfigPath,
-      tts_speaker: get().ttsSpeaker,
-      tts_language: get().ttsLanguage,
-    }).catch((err) => {
-      console.error("Failed to save paths:", err);
-    });
-  },
-  setTtsSpeaker: (ttsSpeaker: string) => {
-    set({ ttsSpeaker });
-    invoke("save_paths", {
-      python_path: get().pythonPath,
-      comfy_path: get().comfyPath,
-      tts_model_path: get().ttsModelPath,
-      tts_config_path: get().ttsConfigPath,
-      tts_speaker: ttsSpeaker,
-      tts_language: get().ttsLanguage,
-    }).catch((err) => {
-      console.error("Failed to save paths:", err);
-    });
-  },
-  setTtsLanguage: (ttsLanguage: string) => {
-    set({ ttsLanguage });
-    invoke("save_paths", {
-      python_path: get().pythonPath,
-      comfy_path: get().comfyPath,
-      tts_model_path: get().ttsModelPath,
-      tts_config_path: get().ttsConfigPath,
-      tts_speaker: get().ttsSpeaker,
-      tts_language: ttsLanguage,
     }).catch((err) => {
       console.error("Failed to save paths:", err);
     });
@@ -113,20 +41,12 @@ export const usePathsStore = create<PathsState>((set, get) => ({
       const res = await invoke<{
         python_path?: string;
         comfy_path?: string;
-        tts_model_path?: string;
-        tts_config_path?: string;
-        tts_speaker?: string;
-        tts_language?: string;
       }>("load_paths");
       const detected = await invoke<string>("detect_python");
       set({
         pythonPath: res.python_path || "",
         defaultPythonPath: detected,
         comfyPath: res.comfy_path || "",
-        ttsModelPath: res.tts_model_path || "",
-        ttsConfigPath: res.tts_config_path || "",
-        ttsSpeaker: res.tts_speaker || "",
-        ttsLanguage: res.tts_language || "",
         loaded: true,
       });
     } catch {


### PR DESCRIPTION
## Summary
- drop TTS path fields from paths store and settings drawer
- update DJ mix hook to no longer pass TTS args
- adjust path error tests for new store

## Testing
- `npm test` *(fails: DiceRoller > builds expression from toggles and rolls dice: This browser does not support ResizeObserver out of the box)*

------
https://chatgpt.com/codex/tasks/task_e_68acf04771548325966068eafa9f71a8