### PR TITLE
refactor: use new raw glob syntax for rule files

### DIFF
--- a/src/features/dnd/RuleForm.tsx
+++ b/src/features/dnd/RuleForm.tsx
@@ -16,7 +16,8 @@ import rulesIndex from "../../../dnd/rules/index.json";
 import RulePdfUpload from "./RulePdfUpload";
 
 const ruleFiles = import.meta.glob("../../../dnd/rules/*.md", {
-  as: "raw",
+  query: "?raw",
+  import: "default",
   eager: true,
 });
 


### PR DESCRIPTION
## Summary
- replace deprecated `as: "raw"` with `query: "?raw", import: "default"` in rule loading

## Testing
- `npm run tauri dev` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found.)*

------
https://chatgpt.com/codex/tasks/task_e_68acf194c8ac832582b0f46c8e59ec02