### PR TITLE
Avoid default ambience when none specified

### DIFF
--- a/src-tauri/python/lofi/renderer.py
+++ b/src-tauri/python/lofi/renderer.py
@@ -1166,19 +1166,9 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60, chords=None
     # --- ambience rotation
     amb_list = motif.get("ambience") or []
     if not amb_list:
-        amb_list = random.choice(
-            [
-                ["rain"],
-                ["cafe"],
-                ["rain", "cafe"],
-                ["vinyl"],
-                ["street"],
-                ["forest"],
-                ["train"],
-                ["fireplace"],
-                ["ocean"],
-            ]
-        )
+        # Leave amb_list empty when no ambience is specified so that
+        # no ambience is mixed into the render.
+        amb_list = []
 
     amb_level = float(np.clip(motif.get("ambience_level", 0.5), 0.0, 1.0))
 

--- a/src-tauri/python/tests/test_determinism.py
+++ b/src-tauri/python/tests/test_determinism.py
@@ -8,7 +8,7 @@ import lofi.renderer as renderer  # noqa: E402
 
 
 EXPECTED_RMS = 0.165903
-EXPECTED_HASH = "f29a48bd8e5d4273903e7f537259d012f3890209d45c08b7d3ea73d600c37a56"
+EXPECTED_HASH = "82fdd90872a6d191afc972db5890d113a419fa53c9239d7970063d64d1e3ad90"
 
 
 def test_deterministic_render(caplog):


### PR DESCRIPTION
## Summary
- Remove automatic random ambience assignment in `_render_section` so no ambience is mixed when unspecified
- Update deterministic render test hash

## Testing
- `pytest -q`
- `python - <<'PY'
import os, sys
sys.path.append(os.getcwd()+"/src-tauri/python/lofi")
import renderer as r
spec = {"title":"test_no_amb","bpm":80,"seed":2,"key":"C","structure":[{"name":"A","bars":1}],"instruments":["piano"]}
audio,_ = r.render_from_spec(spec)
print('samples', len(audio.get_array_of_samples()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68acf504fd00832596d03110396b5bda