### PR TITLE
Randomize SongForm default seed

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -77,9 +77,16 @@ describe('SongForm', () => {
   });
 
   it('renders default form', () => {
-    const { asFragment } = render(<SongForm />);
-    expect(screen.getByText('Song Builder')).toBeInTheDocument();
-    expect(asFragment()).toMatchSnapshot();
+    const rand = vi
+      .spyOn(Math, 'random')
+      .mockReturnValue(0.000012345);
+    try {
+      const { asFragment } = render(<SongForm />);
+      expect(screen.getByText('Song Builder')).toBeInTheDocument();
+      expect(asFragment()).toMatchSnapshot();
+    } finally {
+      rand.mockRestore();
+    }
   });
 
   it('adds a job and shows progress', async () => {

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -308,7 +308,9 @@ export default function SongForm() {
   // VARIATION / BATCH
   const [numSongs, setNumSongs] = useState(1);
   const [titleSuffixMode, setTitleSuffixMode] = useState<"number" | "timestamp">("number");
-  const [seedBase, setSeedBase] = useState(12345);
+  const [seedBase, setSeedBase] = useState(() =>
+    Math.floor(Math.random() * 1_000_000_000)
+  );
   const [seedMode, setSeedMode] = useState<"increment" | "random">("random");
   const [autoKeyPerSong, setAutoKeyPerSong] = useState(false);
   const [bpmJitterPct, setBpmJitterPct] = useState(5);


### PR DESCRIPTION
## Summary
- seedBase now initializes with a random value
- Ensure SongForm snapshot test mocks Math.random for reproducibility

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68acf50ced08832580cee6d6e28cd8ea