### PR TITLE
Respect explicit instrument selection in lofi renderer

### DIFF
--- a/src-tauri/python/tests/test_determinism.py
+++ b/src-tauri/python/tests/test_determinism.py
@@ -8,7 +8,7 @@ import lofi.renderer as renderer  # noqa: E402
 
 
 EXPECTED_RMS = 0.165903
-EXPECTED_HASH = "f29a48bd8e5d4273903e7f537259d012f3890209d45c08b7d3ea73d600c37a56"
+EXPECTED_HASH = "82fdd90872a6d191afc972db5890d113a419fa53c9239d7970063d64d1e3ad90"
 
 
 def test_deterministic_render(caplog):


### PR DESCRIPTION
## Summary
- honor lead instrument when no other instruments are specified
- disable auto Rhodes and bass when instrument list is empty
- update deterministic render test hash after renderer change

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acf4fa16388325bfd6760d11356f70