### PR TITLE
Use lead instrument fallback when instruments list empty

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -668,6 +668,11 @@ export default function SongForm() {
   function makeSpecForIndex(i: number): SongSpec {
     const amb = Math.max(0, Math.min(1, ambienceLevel));
     const varPct = Math.max(0, Math.min(100, variety));
+    const instrs = instruments.length
+      ? instruments
+      : leadInstrument
+        ? [leadInstrument]
+        : [];
 
     return {
       title: buildTitle(i),
@@ -677,7 +682,7 @@ export default function SongForm() {
       key: formatSpecKey(pickKey(i)),
       structure: structure.map(({ name, bars, chords }) => ({ name, bars, chords })),
       mood,
-      instruments,
+      instruments: instrs,
       lead_instrument: leadInstrument,
       ambience,
       ambience_level: amb,


### PR DESCRIPTION
## Summary
- ensure SongForm's spec always includes a lead instrument by using it when the instruments list is empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acf51a35d88325a4794e854eadad58