### PR TITLE
test: cover all dice types in DiceRoller

### DIFF
--- a/src/features/dnd/tests/DiceRoller.test.tsx
+++ b/src/features/dnd/tests/DiceRoller.test.tsx
@@ -1,36 +1,81 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 vi.mock("../../../dnd/rules", () => ({
-  rollDiceExpression: vi.fn(() => ({
-    total: 7,
-    rolls: [
-      { sides: 8, value: 3 },
-      { sides: 8, value: 4 },
-    ],
-  })),
+  rollDiceExpression: vi.fn(),
 }));
 
 import { rollDiceExpression } from "../../../dnd/rules";
 import DiceRoller from "../DiceRoller";
 
-describe("DiceRoller", () => {
+const mockedRollDiceExpression = vi.mocked(rollDiceExpression);
+
+describe.sequential("DiceRoller", () => {
+  beforeEach(() => {
+    mockedRollDiceExpression.mockReset();
+  });
+
   it("builds expression from toggles and rolls dice", async () => {
+    mockedRollDiceExpression.mockReturnValue({
+      total: 7,
+      rolls: [
+        { sides: 8, value: 3 },
+        { sides: 8, value: 4 },
+      ],
+    });
+
     render(<DiceRoller />);
     const user = userEvent.setup();
 
-    const countInput = screen.getByRole("spinbutton", { name: /count/i });
+    const countInput = screen.getAllByRole("spinbutton", { name: /count/i })[0];
     await user.clear(countInput);
     await user.type(countInput, "2");
 
-    await user.click(screen.getByRole("button", { name: /d8/i }));
+    await user.click(
+      screen.getAllByRole("button", { name: /d8/i })[0]
+    );
 
     expect(screen.getByRole("textbox", { name: /dice/i })).toHaveValue("2d8");
 
     await user.click(screen.getByRole("button", { name: /roll/i }));
 
-    expect(rollDiceExpression).toHaveBeenCalledWith("2d8");
+    expect(mockedRollDiceExpression).toHaveBeenCalledWith("2d8");
     await screen.findByText("Result: 7 ( 3, 4 )");
   });
+
+  it.each([4, 8, 10, 12, 20])(
+    "selects d% and renders dice",
+    async (sides) => {
+      mockedRollDiceExpression.mockReturnValue({
+        total: sides + 1,
+        rolls: [
+          { sides, value: 1 },
+          { sides, value: sides },
+        ],
+      });
+
+      render(<DiceRoller />);
+      const user = userEvent.setup();
+
+      const countInput = screen.getAllByRole("spinbutton", { name: /count/i })[0];
+      await user.clear(countInput);
+      await user.type(countInput, "2");
+
+      const toggle = screen.getAllByRole("button", {
+        name: new RegExp(`d${sides}`, "i"),
+      })[0];
+      await user.click(toggle);
+
+      expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+      await user.click(screen.getAllByRole("button", { name: /roll/i })[0]);
+
+      expect(mockedRollDiceExpression).toHaveBeenCalledWith(`2d${sides}`);
+      await screen.findByText(`Result: ${sides + 1} ( 1, ${sides} )`);
+
+      const canvas = document.querySelector("canvas");
+      expect(canvas).toBeInTheDocument();
+    }
+  );
 });


### PR DESCRIPTION
## Summary
- expand DiceRoller tests to verify selecting and rolling d4, d8, d10, d12, and d20
- ensure toggle state, roll expression, and canvas rendering match the selected die type

## Testing
- `npm test -- --run src/features/dnd/tests/DiceRoller.test.tsx`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68acf44b712c83258a80538bdbdc035a