### PR TITLE
Consider all instruments for melody timbre

### DIFF
--- a/src-tauri/python/lofi/renderer.py
+++ b/src-tauri/python/lofi/renderer.py
@@ -1170,7 +1170,8 @@ def _render_section(bars, bpm, section_name, motif, rng, variety=60, chords=None
             section_name=section_name,
             motif_store=motif,
         )
-        melody = _apply_melody_timbre(melody, [lead] if lead else instrs)
+        instrs_for_timbre = instrs + ([lead] if lead else [])
+        melody = _apply_melody_timbre(melody, instrs_for_timbre)
     else:
         melody = np.zeros(n, dtype=np.float32)
 

--- a/src-tauri/python/tests/test_french_horn_timbre.py
+++ b/src-tauri/python/tests/test_french_horn_timbre.py
@@ -13,3 +13,13 @@ def test_french_horn_timbre_bandpass():
     rms_in = np.sqrt(np.mean(x**2))
     rms_out = np.sqrt(np.mean(y**2))
     assert 0 < rms_out < rms_in
+
+
+def test_french_horn_influences_when_not_lead():
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal(44100).astype(np.float32)
+    lead_only = _apply_melody_timbre(x, ["piano"])
+    with_horn = _apply_melody_timbre(x, ["french horn", "piano"])
+    rms_lead = np.sqrt(np.mean(lead_only**2))
+    rms_horn = np.sqrt(np.mean(with_horn**2))
+    assert rms_horn < rms_lead


### PR DESCRIPTION
## Summary
- Ensure melody timbre considers the full instrument list even when a lead is specified
- Add regression test confirming French horn timbre applies when it's not the lead instrument

## Testing
- `pytest src-tauri/python/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68acfa4de4b08325a4e414ae8bc34acb