### PR TITLE
Add user creation flow and improve user UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import { Routes, Route } from "react-router-dom";
+import { useEffect, useState } from "react";
 import TopBar from "./components/TopBar";
 import ErrorBoundary from "./components/ErrorBoundary";
+import CreateUserDialog from "./components/CreateUserDialog";
+import { useUsers } from "./features/users/useUsers";
 import Home from "./pages/Home";
 import Objects from "./pages/Objects";
 import Blender from "./pages/Blender";
@@ -29,9 +32,24 @@ import Simulation from "./pages/Simulation";
 import BigBrother from "./pages/BigBrother";
 
 export default function App() {
+  const users = useUsers((s) => s.users);
+  const currentUserId = useUsers((s) => s.currentUserId);
+  const switchUser = useUsers((s) => s.switchUser);
+  const [showUserDialog, setShowUserDialog] = useState(false);
+
+  useEffect(() => {
+    const ids = Object.keys(users);
+    if (!ids.length) {
+      setShowUserDialog(true);
+    } else if (!currentUserId) {
+      switchUser(ids[ids.length - 1]);
+    }
+  }, [users, currentUserId, switchUser]);
+
   return (
     <ErrorBoundary>
       <TopBar />
+      <CreateUserDialog open={showUserDialog} onClose={() => setShowUserDialog(false)} />
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/objects" element={<Objects />} />

--- a/src/components/CreateUserDialog.tsx
+++ b/src/components/CreateUserDialog.tsx
@@ -1,0 +1,43 @@
+import { Dialog, DialogTitle, DialogContent, TextField, DialogActions, Button } from "@mui/material";
+import { useState } from "react";
+import { useUsers } from "../features/users/useUsers";
+
+interface CreateUserDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function CreateUserDialog({ open, onClose }: CreateUserDialogProps) {
+  const addUser = useUsers((s) => s.addUser);
+  const [name, setName] = useState("");
+
+  const handleCreate = () => {
+    if (name.trim()) {
+      addUser(name.trim());
+      setName("");
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>Create New User</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          margin="dense"
+          label="Name"
+          fullWidth
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleCreate} variant="contained" disabled={!name.trim()}>
+          Create
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -29,6 +29,7 @@ import { useTheme, type Theme } from "../features/theme/ThemeContext";
 import { useComfyTutorial } from "../features/comfyTutorial/useComfyTutorial";
 import { useUsers } from "../features/users/useUsers";
 import HelpIcon from "./HelpIcon";
+import CreateUserDialog from "./CreateUserDialog";
 
 const KEY_OPTIONS = [
   "Auto",
@@ -218,7 +219,10 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   } = useAudioDefaults();
   const { theme, setTheme } = useTheme();
   const currentUserId = useUsers((state) => state.currentUserId);
+  const users = useUsers((s) => s.users);
+  const switchUser = useUsers((s) => s.switchUser);
   const hasUser = currentUserId !== null;
+  const [createUserOpen, setCreateUserOpen] = useState(false);
   const { showTutorial, setShowTutorial } = useComfyTutorial();
   const { modules, toggleModule } = useSettings();
   const [audioSaved, setAudioSaved] = useState(false);
@@ -238,8 +242,9 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   useEffect(() => setComfyDraft(comfyPath), [comfyPath]);
   useEffect(() => setFolderDraft(folder), [folder]);
   useEffect(() => setThemeDraft(theme), [theme]);
-  type Section = "environment" | "editor" | "appearance" | "integrations";
+  type Section = "user" | "environment" | "editor" | "appearance" | "integrations";
   const sectionLabels: Record<Section, string> = {
+    user: "User",
     environment: "Environment",
     editor: "Editor",
     appearance: "Appearance",
@@ -249,6 +254,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   const [searchValue, setSearchValue] = useState("");
 
   const baseIndex = [
+    { label: "Current User", section: "user" as Section, elementId: "current-user" },
     { label: "Python Path", section: "environment" as Section, elementId: "python-path" },
     { label: "ComfyUI Folder", section: "environment" as Section, elementId: "comfy-path" },
     { label: "Default Save Folder", section: "environment" as Section, elementId: "output-folder" },
@@ -508,10 +514,36 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
           </Button>
         </>
       ) : (
-        <Typography variant="body2" sx={{ mt: 2 }}>
-          Create a user to customize the theme.
-        </Typography>
+        <Button variant="outlined" sx={{ mt: 2 }} onClick={() => setCreateUserOpen(true)}>
+          Create New User
+        </Button>
       )}
+    </>
+  );
+
+  const UserSection = () => (
+    <>
+      <Typography variant="subtitle1">User</Typography>
+      {Object.keys(users).length > 0 && (
+        <FormControl fullWidth size="small" sx={{ mt: 2 }} id="current-user">
+          <InputLabel id="current-user-label">Current User</InputLabel>
+          <Select
+            labelId="current-user-label"
+            value={currentUserId ?? ""}
+            label="Current User"
+            onChange={(e) => switchUser(e.target.value as string)}
+          >
+            {Object.values(users).map((u) => (
+              <MenuItem key={u.id} value={u.id}>
+                {u.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      )}
+      <Button variant="outlined" sx={{ mt: 2 }} onClick={() => setCreateUserOpen(true)}>
+        Create New User
+      </Button>
     </>
   );
 
@@ -564,6 +596,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
             renderInput={(params) => <TextField {...params} label="Search settings" />}
             sx={{ mb: 2 }}
           />
+          {section === "user" && <UserSection />}
           {section === "environment" && <EnvironmentSection />}
           {section === "editor" && <EditorSection />}
           {section === "appearance" && <AppearanceSection />}
@@ -600,6 +633,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
           />
         </Box>
       </Box>
+      <CreateUserDialog open={createUserOpen} onClose={() => setCreateUserOpen(false)} />
     </Drawer>
   );
 }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -9,6 +9,7 @@ import SettingsDrawer from "./SettingsDrawer";
 import ErrorBoundary from "./ErrorBoundary";
 import TaskDrawer from "./TaskDrawer";
 import { useTasks } from "../store/tasks";
+import { useUsers } from "../features/users/useUsers";
 
 export default function TopBar() {
   const nav = useNavigate();
@@ -19,6 +20,10 @@ export default function TopBar() {
     Object.values(s.tasks).filter((t) => t.status === "queued" || t.status === "running").length
   );
   const subscribe = useTasks((s) => s.subscribe);
+  const userName = useUsers((s) => {
+    const id = s.currentUserId;
+    return id ? s.users[id]?.name : null;
+  });
 
   useEffect(() => {
     let unlisten: (() => void) | null = null;
@@ -55,7 +60,7 @@ export default function TopBar() {
         </IconButton>
       </Tooltip>
 
-      <Tooltip title="User">
+      <Tooltip title={userName ? `User: ${userName}` : "User"}>
         <IconButton
           onClick={() => nav("/user")}
           sx={{

--- a/src/pages/User.tsx
+++ b/src/pages/User.tsx
@@ -1,5 +1,6 @@
 import Center from "./_Center";
 import { useUsers } from "../features/users/useUsers";
+import { Box, Typography, List, ListItem, ListItemText } from "@mui/material";
 
 export default function User() {
   const user = useUsers((state) => {
@@ -13,23 +14,33 @@ export default function User() {
 
   return (
     <Center>
-      <div style={{ textAlign: "left" }}>
-        <h1>User Info</h1>
-        <p><strong>ID:</strong> {user.id}</p>
-        <p><strong>Name:</strong> {user.name}</p>
-        <p><strong>Theme:</strong> {user.theme}</p>
-        <p><strong>Money:</strong> {user.money}</p>
-        <div>
-          <h2>Modules</h2>
-          <ul>
+      <Box sx={{ textAlign: "left", maxWidth: 400 }}>
+        <Typography variant="h4" gutterBottom>
+          User Info
+        </Typography>
+        <Typography>
+          <strong>ID:</strong> {user.id}
+        </Typography>
+        <Typography>
+          <strong>Name:</strong> {user.name}
+        </Typography>
+        <Typography>
+          <strong>Theme:</strong> {user.theme}
+        </Typography>
+        <Typography>
+          <strong>Money:</strong> {user.money}
+        </Typography>
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="h6">Modules</Typography>
+          <List dense>
             {Object.entries(user.modules).map(([key, enabled]) => (
-              <li key={key}>
-                {key}: {enabled ? "on" : "off"}
-              </li>
+              <ListItem key={key}>
+                <ListItemText primary={`${key}: ${enabled ? "on" : "off"}`} />
+              </ListItem>
             ))}
-          </ul>
-        </div>
-      </div>
+          </List>
+        </Box>
+      </Box>
     </Center>
   );
 }


### PR DESCRIPTION
## Summary
- add modal for creating new users
- prompt for user creation on startup and default to last user
- surface user management in settings and enhance user page readability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acfbd944588325a58a47443f32a07a