### PR TITLE
fix: enable render songs button

### DIFF
--- a/src/components/BatchActions.tsx
+++ b/src/components/BatchActions.tsx
@@ -15,7 +15,6 @@ interface Props {
   busy: boolean;
   outDir: string;
   titleBase: string;
-  hasInvalidBars: boolean;
   albumMode: boolean;
   albumReady: boolean;
   onRender: () => void;
@@ -37,7 +36,6 @@ export default function BatchActions({
   busy,
   outDir,
   titleBase,
-  hasInvalidBars,
   albumMode,
   albumReady,
   onRender,
@@ -113,7 +111,6 @@ export default function BatchActions({
             busy ||
             !outDir ||
             !titleBase ||
-            hasInvalidBars ||
             (albumMode && !albumReady)
           }
           onClick={onRender}

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -479,15 +479,6 @@ export default function SongForm() {
     };
   }, [runningJobId, updateJob]);
 
-  const hasInvalidBars = useMemo(
-    () =>
-      structure.some((s) => {
-        const val = s.barsStr ?? String(s.bars);
-        const n = parseInt(val, 10);
-        return !(val && /^\d+$/.test(val) && n >= 1);
-      }),
-    [structure]
-  );
 
   const totalBars = useMemo(
     () =>
@@ -1377,7 +1368,6 @@ export default function SongForm() {
           busy={busy}
           outDir={outDir}
           titleBase={titleBase}
-          hasInvalidBars={hasInvalidBars}
           albumMode={albumMode}
           albumReady={albumReady}
           onRender={handleRender}


### PR DESCRIPTION
## Summary
- remove invalid bar check from batch render button
- stop passing unused hasInvalidBars flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acfcf855948325b16360a6de5f08bc