### PR TITLE
feat(blender): allow selecting output folder

### DIFF
--- a/src/pages/Blender.tsx
+++ b/src/pages/Blender.tsx
@@ -2,15 +2,28 @@ import { useState } from "react";
 import { TextField, Button, Stack } from "@mui/material";
 import Center from "./_Center";
 import { invoke } from "@tauri-apps/api/core";
+import { open } from "@tauri-apps/api/dialog";
 
 export default function Blender() {
   const [code, setCode] = useState("import bpy\n\n# example cube\nbpy.ops.mesh.primitive_cube_add()");
   const [status, setStatus] = useState<string | null>(null);
+  const [outputDir, setOutputDir] = useState<string | null>(null);
+
+  const selectOutput = async () => {
+    const selected = await open({ directory: true });
+    if (typeof selected === "string") {
+      setOutputDir(selected);
+    }
+  };
 
   const run = async () => {
     setStatus("Running...");
     try {
-      await invoke("blender_run_script", { code });
+      const script =
+        outputDir
+          ? `${code}\n\nbpy.ops.wm.save_mainfile(filepath='${outputDir.replace(/\\/g, "/")}/output.blend')`
+          : code;
+      await invoke("blender_run_script", { code: script });
       setStatus("Blender finished running");
     } catch (e) {
       setStatus("Error: " + e);
@@ -27,7 +40,11 @@ export default function Blender() {
           value={code}
           onChange={(e) => setCode(e.target.value)}
         />
+        <Button variant="outlined" onClick={selectOutput}>
+          Select Output Folder
+        </Button>
         <Button variant="contained" onClick={run}>Run in Blender</Button>
+        {outputDir && <div>Selected Output Folder: {outputDir}</div>}
         {status && <div>{status}</div>}
       </Stack>
     </Center>


### PR DESCRIPTION
## Summary
- allow choosing an output directory in Blender page and save blend file there

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acfd0a0a688325858439c4a367a701