### PR TITLE
Reuse system info handle in task queue

### DIFF
--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -170,12 +170,12 @@ impl TaskQueue {
                         let permit = semaphore.clone().acquire_owned().await.unwrap();
                         let id = task.id;
                         let handle = async_runtime::spawn(async move {
+                            let mut sys = System::new();
                             loop {
                                 let (cpu_limit, mem_limit) = {
                                     let l = limits_clone.lock().await;
                                     (l.cpu, l.memory)
                                 };
-                                let mut sys = System::new();
                                 sys.refresh_cpu_usage();
                                 tokio::time::sleep(Duration::from_millis(100)).await;
                                 sys.refresh_cpu_usage();


### PR DESCRIPTION
## Summary
- Instantiate `sysinfo::System` once per worker task and refresh CPU/memory stats each loop iteration
- Profile task start latency before and after the change

## Testing
- `cargo test` *(fails: expected function, found module `tauri::test::mock_runtime`)*


------
https://chatgpt.com/codex/tasks/task_e_68acfc5e88308325a546b3721e1edb76