### PR TITLE
refactor: optimize bucketDownsample

### DIFF
--- a/src/utils/downsample.bench.ts
+++ b/src/utils/downsample.bench.ts
@@ -1,0 +1,24 @@
+import { bench } from 'vitest';
+import { bucketDownsample } from './downsample';
+
+function sliceDownsample(data: number[], pixelWidth: number): number[] {
+  if (!data || data.length === 0 || pixelWidth <= 0) return [];
+  const bucketSize = Math.max(1, Math.floor(data.length / pixelWidth));
+  const out: number[] = [];
+  for (let i = 0; i < data.length; i += bucketSize) {
+    const slice = data.slice(i, i + bucketSize);
+    const avg = slice.reduce((a, b) => a + b, 0) / slice.length;
+    out.push(avg);
+  }
+  return out;
+}
+
+const data = Array.from({ length: 10_000 }, (_, i) => i);
+
+bench('slice-based', () => {
+  sliceDownsample(data, 500);
+});
+
+bench('single-pass', () => {
+  bucketDownsample(data, 500);
+});

--- a/src/utils/downsample.ts
+++ b/src/utils/downsample.ts
@@ -2,10 +2,19 @@ export function bucketDownsample(data: number[], pixelWidth: number): number[] {
   if (!data || data.length === 0 || pixelWidth <= 0) return [];
   const bucketSize = Math.max(1, Math.floor(data.length / pixelWidth));
   const out: number[] = [];
-  for (let i = 0; i < data.length; i += bucketSize) {
-    const slice = data.slice(i, i + bucketSize);
-    const avg = slice.reduce((a, b) => a + b, 0) / slice.length;
-    out.push(avg);
+  let sum = 0;
+  let count = 0;
+  for (let i = 0; i < data.length; i++) {
+    sum += data[i];
+    count++;
+    if (count === bucketSize) {
+      out.push(sum / count);
+      sum = 0;
+      count = 0;
+    }
+  }
+  if (count > 0) {
+    out.push(sum / count);
   }
   return out;
 }


### PR DESCRIPTION
## Summary
- avoid per-bucket slicing in `bucketDownsample`
- add benchmark comparing slice-based vs single-pass implementations

## Testing
- `npm test`
- `npx vitest bench src/utils/downsample.bench.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ad2498ce9c83258235e11649d04941