### PR TITLE
chore: update tauri dialog import

### DIFF
--- a/src/pages/Blender.tsx
+++ b/src/pages/Blender.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { TextField, Button, Stack } from "@mui/material";
 import Center from "./_Center";
 import { invoke } from "@tauri-apps/api/core";
-import { open } from "@tauri-apps/api/dialog";
+import { open } from "@tauri-apps/plugin-dialog";
 
 export default function Blender() {
   const [code, setCode] = useState("import bpy\n\n# example cube\nbpy.ops.mesh.primitive_cube_add()");


### PR DESCRIPTION
## Summary
- replace deprecated dialog import with plugin

## Testing
- `npx vite dev`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68adfcd9f21c832589d453b4ee541883