### PR TITLE
feat: add SFZ loader utility

### DIFF
--- a/src/utils/sfzLoader.test.ts
+++ b/src/utils/sfzLoader.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('tone', () => ({
+  Frequency: (midi: number) => ({ toNote: () => `midi-${midi}` }),
+  Sampler: class {
+    constructor() {}
+  },
+  loaded: () => Promise.resolve(),
+}));
+
+import { parseSfz } from './sfzLoader';
+
+describe('parseSfz', () => {
+  it('parses regions and opcodes', () => {
+    const sfz = `
+<region>
+sample=kick.wav
+lokey=36
+hikey=36
+pitch_keycenter=36
+`;
+    const regions = parseSfz(sfz);
+    expect(regions).toHaveLength(1);
+    expect(regions[0].sample).toBe('kick.wav');
+    expect(regions[0].lokey).toBe(36);
+    expect(regions[0].hikey).toBe(36);
+    expect(regions[0].pitch_keycenter).toBe(36);
+  });
+});

--- a/src/utils/sfzLoader.ts
+++ b/src/utils/sfzLoader.ts
@@ -1,0 +1,82 @@
+import * as Tone from 'tone';
+
+export interface SfzRegion {
+  sample: string;
+  lokey?: number;
+  hikey?: number;
+  key?: number;
+  pitch_keycenter?: number;
+  [opcode: string]: string | number | undefined;
+}
+
+export interface SfzInstrument {
+  regions: SfzRegion[];
+  sampler: Tone.Sampler;
+}
+
+export function parseSfz(text: string, basePath = ''): SfzRegion[] {
+  const lines = text.split(/\r?\n/);
+  const regions: SfzRegion[] = [];
+  let current: SfzRegion | null = null;
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith('//') || line.startsWith('#')) continue;
+    if (line.startsWith('<region')) {
+      current = { sample: '' };
+      regions.push(current);
+      continue;
+    }
+    if (line.startsWith('<group')) {
+      current = null;
+      continue;
+    }
+    const match = line.match(/^([^=]+)=(.+)$/);
+    if (match && current) {
+      const key = match[1].trim();
+      const value = match[2].trim();
+      if (key === 'sample') {
+        current.sample = basePath ? basePath + value : value;
+      } else {
+        const num = Number(value);
+        current[key] = isNaN(num) ? value : num;
+      }
+    }
+  }
+
+  return regions.filter((r) => r.sample);
+}
+
+export async function loadSfz(path: string): Promise<SfzInstrument> {
+  const res = await fetch(path);
+  if (!res.ok) {
+    throw new Error(`Unable to load SFZ: ${path}`);
+  }
+  const text = await res.text();
+  const basePath = path.includes('/')
+    ? path.substring(0, path.lastIndexOf('/') + 1)
+    : '';
+  const regions = parseSfz(text, basePath);
+
+  const urls: Record<string, string> = {};
+  for (const region of regions) {
+    const midi =
+      typeof region.pitch_keycenter === 'number'
+        ? region.pitch_keycenter
+        : typeof region.key === 'number'
+          ? region.key
+          : typeof region.lokey === 'number'
+            ? region.lokey
+            : undefined;
+    if (midi !== undefined) {
+      const note = Tone.Frequency(midi, 'midi').toNote();
+      urls[note] = region.sample;
+    }
+  }
+
+  const sampler = new Tone.Sampler({ urls });
+  await Tone.loaded();
+
+  return { regions, sampler };
+}
+


### PR DESCRIPTION
## Summary
- add `loadSfz` utility to parse SFZ files and load samples into a Tone.js sampler
- include unit test for SFZ parser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adfcf566d883258c118d27a6cc7ab6