### PR TITLE
Add pdfplumber dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         'numpy>=1.21.0',
         'pydub>=0.25.0',
         'audioop-lts; python_version >= "3.13"',
+        'pdfplumber>=0.10.3',
     ],
     python_requires='>=3.10,<3.12',
 )


### PR DESCRIPTION
## Summary
- include `pdfplumber>=0.10.3` in package dependencies

## Testing
- `pip install -e .`
- `python src-tauri/python/pdf_tools.py --help`
- `pytest` *(fails: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0658f95483258446d9885ab74168