### PR TITLE
Add optional sfzInstrument to SongSpec

### DIFF
--- a/src-tauri/python/lofi/renderer.py
+++ b/src-tauri/python/lofi/renderer.py
@@ -1540,6 +1540,8 @@ def render_from_spec(spec: Dict[str, Any]) -> Tuple[AudioSegment, int]:
     if lead:
         lead = _normalize_instruments([lead])[0]
 
+    sfz_inst = spec.get("sfz_instrument")
+
     motif = {
         "mood": spec.get("mood") or [],
         "instruments": spec.get("instruments") or [],
@@ -1555,6 +1557,8 @@ def render_from_spec(spec: Dict[str, Any]) -> Tuple[AudioSegment, int]:
         "hq_chorus": spec.get("hq_chorus", True),
         "limiter_drive": limiter_drive,
     }
+    if sfz_inst:
+        motif["sfz_instrument"] = sfz_inst
 
     try:
         chord_span_beats = int(spec.get("chord_span_beats", 4))

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -642,6 +642,8 @@ pub struct SongSpec {
     pub limiter_drive: Option<f32>,
     #[serde(alias = "lofiFilter", skip_serializing_if = "Option::is_none")]
     pub lofi_filter: Option<bool>,
+    #[serde(alias = "sfzInstrument", skip_serializing_if = "Option::is_none")]
+    pub sfz_instrument: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -704,6 +706,7 @@ mod tests {
             hq_chorus: None,
             limiter_drive: None,
             lofi_filter: None,
+            sfz_instrument: None,
         };
         let v = serde_json::to_value(&spec).unwrap();
         assert!(v.get("ambience_level").is_some());

--- a/src/components/AlbumWizard.tsx
+++ b/src/components/AlbumWizard.tsx
@@ -33,6 +33,7 @@ type SongSpec = {
   hq_chorus?: boolean;
   limiter_drive?: number;
   dither_amount?: number;
+  sfzInstrument?: string;
 };
 
 const AMBI = [
@@ -150,6 +151,7 @@ export default function AlbumWizard() {
       hq_chorus: hqChorus,
       limiter_drive: limiterDrive,
       dither_amount: dither ? 1 : 0,
+      sfzInstrument: undefined,
     };
   }
 

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -49,6 +49,7 @@ type SongSpec = {
   limiter_drive?: number;
   dither_amount?: number;
   lofi_filter?: boolean;
+  sfzInstrument?: string;
 };
 
 export type TemplateSpec = {
@@ -172,6 +173,7 @@ export default function SongForm() {
   const [leadInstrument, setLeadInstrument] = useState<string>(() =>
     inferLeadInstrument(defaultInstruments)
   );
+  const [sfzInstrument] = useState<string | undefined>();
   const [ambience, setAmbience] = useState<string[]>(["rain"]);
   const [ambienceLevel, setAmbienceLevel] = useState(0.5);
   const [templates, setTemplates] = useState<Record<string, TemplateSpec>>(() => {
@@ -677,6 +679,7 @@ export default function SongForm() {
       mood,
       instruments: instrs,
       lead_instrument: leadInstrument,
+      sfzInstrument,
       ambience,
       ambience_level: amb,
       seed: pickSeed(i),


### PR DESCRIPTION
## Summary
- add optional `sfzInstrument` field to SongSpec and include it when building specs
- propagate `sfz_instrument` through backend structures and renderer
- update album wizard to acknowledge `sfzInstrument`

## Testing
- `npm test` (fails: TypeError in DiceRoller.test.tsx)
- `cargo test` (fails: expected function, found module `tauri::test::mock_runtime`)


------
https://chatgpt.com/codex/tasks/task_e_68ae059de79483258e31c04c5eb4033d