### PR TITLE
Add Bark TTS command to Tauri backend

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,8 +6,8 @@ mod stocks;
 mod task_queue;
 
 use task_queue::TaskQueue;
-use tauri_plugin_sql::{Builder as SqlBuilder, Migration, MigrationKind};
 use tauri::Manager;
+use tauri_plugin_sql::{Builder as SqlBuilder, Migration, MigrationKind};
 
 fn main() {
     env_logger::init();
@@ -54,6 +54,7 @@ fn main() {
             commands::cancel_album,
             commands::dj_mix,
             commands::generate_ambience,
+            commands::bark_tts,
             // ComfyUI:
             commands::comfy_status,
             commands::comfy_start,


### PR DESCRIPTION
## Summary
- add bark_tts Tauri command executing bark_tts.py via embedded Python
- expose bark_tts in Tauri invoke handler

## Testing
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae0d5434a88325b38cc8ddc49bac9b