### PR TITLE
feat: add sfz instrument picker

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -285,6 +285,16 @@ describe('SongForm', () => {
     });
   });
 
+  it('allows selecting an sfz instrument file', async () => {
+    (openDialog as any).mockResolvedValue('/tmp/piano.sfz');
+    render(<SongForm />);
+    openSection('sfz-section');
+    expect(screen.getByText(/none selected/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByText(/choose sfz/i));
+    await screen.findByText('piano.sfz');
+    expect(openDialog).toHaveBeenCalled();
+  });
+
   it('keeps preset templates when loading custom templates', () => {
     localStorage.setItem(
       'songTemplates',

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -173,7 +173,7 @@ export default function SongForm() {
   const [leadInstrument, setLeadInstrument] = useState<string>(() =>
     inferLeadInstrument(defaultInstruments)
   );
-  const [sfzInstrument] = useState<string | undefined>();
+  const [sfzInstrument, setSfzInstrument] = useState<string | null>(null);
   const [ambience, setAmbience] = useState<string[]>(["rain"]);
   const [ambienceLevel, setAmbienceLevel] = useState(0.5);
   const [templates, setTemplates] = useState<Record<string, TemplateSpec>>(() => {
@@ -513,6 +513,20 @@ export default function SongForm() {
     }
   }
 
+  async function pickSfzInstrument() {
+    try {
+      const file = await openDialog({
+        multiple: false,
+        filters: [{ name: "SFZ Instrument", extensions: ["sfz"] }],
+      });
+      if (file) {
+        setSfzInstrument(file as string);
+      }
+    } catch (e: any) {
+      setErr(e?.message || String(e));
+    }
+  }
+
   async function generateAlbumArtPrompt(name: string) {
     try {
       const reply: string = await invoke("general_chat", {
@@ -679,7 +693,7 @@ export default function SongForm() {
       mood,
       instruments: instrs,
       lead_instrument: leadInstrument,
-      sfzInstrument,
+      sfzInstrument: sfzInstrument ?? undefined,
       ambience,
       ambience_level: amb,
       seed: pickSeed(i),
@@ -1256,6 +1270,20 @@ export default function SongForm() {
               ambienceLevel={ambienceLevel}
               setAmbienceLevel={setAmbienceLevel}
             />
+          </div>
+        </details>
+        {/* sfz instrument selector */}
+        <details className="mt-3" data-testid="sfz-section">
+          <summary className="cursor-pointer text-xs opacity-80">
+            Select SFZ instrument
+          </summary>
+          <div className="mt-2 flex items-center gap-2">
+            <button className={styles.btn} onClick={pickSfzInstrument}>
+              Choose SFZ
+            </button>
+            <span className={styles.small}>
+              {sfzInstrument ? sfzInstrument.split(/[\\/]/).pop() : "none selected"}
+            </span>
           </div>
         </details>
 

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -2144,6 +2144,30 @@ exports[`SongForm > renders default form 1`] = `
       </details>
       <details
         class="mt-3"
+        data-testid="sfz-section"
+      >
+        <summary
+          class="cursor-pointer text-xs opacity-80"
+        >
+          Select SFZ instrument
+        </summary>
+        <div
+          class="mt-2 flex items-center gap-2"
+        >
+          <button
+            class="_btn_913096"
+          >
+            Choose SFZ
+          </button>
+          <span
+            class="_small_913096"
+          >
+            none selected
+          </span>
+        </div>
+      </details>
+      <details
+        class="mt-3"
         data-testid="rhythm-section"
       >
         <summary


### PR DESCRIPTION
## Summary
- allow selecting an optional SFZ instrument file in SongForm
- include chosen SFZ instrument in song spec
- test SFZ picker UI

## Testing
- `npm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68ae130eb18883258a55134ef808f3ab