### PR TITLE
feat: add voice store and settings UI

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -28,6 +28,7 @@ import { useAudioDefaults } from "../features/audioDefaults/useAudioDefaults";
 import { useTheme, type Theme } from "../features/theme/ThemeContext";
 import { useComfyTutorial } from "../features/comfyTutorial/useComfyTutorial";
 import { useUsers } from "../features/users/useUsers";
+import VoiceSettings from "../features/settings/VoiceSettings";
 import HelpIcon from "./HelpIcon";
 import CreateUserDialog from "./CreateUserDialog";
 
@@ -242,13 +243,20 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   useEffect(() => setComfyDraft(comfyPath), [comfyPath]);
   useEffect(() => setFolderDraft(folder), [folder]);
   useEffect(() => setThemeDraft(theme), [theme]);
-  type Section = "user" | "environment" | "editor" | "appearance" | "integrations";
+  type Section =
+    | "user"
+    | "environment"
+    | "editor"
+    | "appearance"
+    | "integrations"
+    | "voices";
   const sectionLabels: Record<Section, string> = {
     user: "User",
     environment: "Environment",
     editor: "Editor",
     appearance: "Appearance",
     integrations: "Integrations",
+    voices: "Voices",
   };
   const [section, setSection] = useState<Section>("environment");
   const [searchValue, setSearchValue] = useState("");
@@ -271,6 +279,11 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
       label: "Show ComfyUI Tutorial",
       section: "integrations" as Section,
       elementId: "show-tutorial",
+    },
+    {
+      label: "Voices",
+      section: "voices" as Section,
+      elementId: "voice-settings",
     },
   ];
   const moduleIndex = (Object.entries(MODULE_LABELS) as [ModuleKey, string][]) .map(
@@ -601,6 +614,7 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
           {section === "editor" && <EditorSection />}
           {section === "appearance" && <AppearanceSection />}
           {section === "integrations" && <IntegrationsSection />}
+          {section === "voices" && <VoiceSettings />}
           <Snackbar
             open={!!ambienceMessage}
             autoHideDuration={3000}

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useState } from "react";
+import { useReducer, useState, useEffect } from "react";
 import {
   Typography,
   Button,
@@ -9,6 +9,7 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  Autocomplete,
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import FormErrorText from "./FormErrorText";
@@ -16,6 +17,7 @@ import { zNpc } from "../../dnd/schemas/npc";
 import { NpcData } from "./types";
 import NpcPdfUpload from "./NpcPdfUpload";
 import StyledTextField from "./StyledTextField";
+import { useVoices } from "../../store/voices";
 
 interface FormState {
   name: string;
@@ -78,6 +80,15 @@ interface Props {
 
 export default function NpcForm({ world }: Props) {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const voices = useVoices((s) => s.voices);
+  const loadVoices = useVoices((s) => s.load);
+  useEffect(() => {
+    loadVoices();
+  }, [loadVoices]);
+  const providerOptions = Array.from(new Set(voices.map((v) => v.provider)));
+  const presetOptions = voices
+    .filter((v) => !state.voice.provider || v.provider === state.voice.provider)
+    .map((v) => v.preset);
   const [errors, setErrors] = useState<Record<string, string | null>>({});
   const [result, setResult] = useState<NpcData | null>(null);
 
@@ -462,29 +473,36 @@ export default function NpcForm({ world }: Props) {
                   </Typography>
                 </Grid>
                 <Grid item xs={8}>
-                  <StyledTextField
-                    id="voice-provider"
-                    value={state.voice.provider}
-                    onChange={(e) => {
-                      dispatch({ type: "SET_VOICE", field: "provider", value: e.target.value });
+                  <Autocomplete
+                    freeSolo
+                    options={providerOptions}
+                    inputValue={state.voice.provider}
+                    onInputChange={(_e, v) => {
+                      dispatch({ type: "SET_VOICE", field: "provider", value: v });
                       setErrors((prev) => ({
                         ...prev,
                         ["voice.provider"]: null,
                       }));
                     }}
+                    renderInput={(params) => (
+                      <StyledTextField
+                        {...params}
+                        id="voice-provider"
+                        margin="normal"
+                        error={Boolean(errors["voice.provider"])}
+                        helperText={
+                          <FormErrorText id="voice-provider-error">
+                            {errors["voice.provider"]}
+                          </FormErrorText>
+                        }
+                        aria-describedby={
+                          errors["voice.provider"]
+                            ? "voice-provider-error"
+                            : undefined
+                        }
+                      />
+                    )}
                     fullWidth
-                    margin="normal"
-                    error={Boolean(errors["voice.provider"])}
-                    helperText={
-                      <FormErrorText id="voice-provider-error">
-                        {errors["voice.provider"]}
-                      </FormErrorText>
-                    }
-                    aria-describedby={
-                      errors["voice.provider"]
-                        ? "voice-provider-error"
-                        : undefined
-                    }
                   />
                 </Grid>
                 <Grid item xs={4}>
@@ -493,24 +511,31 @@ export default function NpcForm({ world }: Props) {
                   </Typography>
                 </Grid>
                 <Grid item xs={8}>
-                  <StyledTextField
-                    id="voice-preset"
-                    value={state.voice.preset}
-                    onChange={(e) => {
-                      dispatch({ type: "SET_VOICE", field: "preset", value: e.target.value });
+                  <Autocomplete
+                    freeSolo
+                    options={presetOptions}
+                    inputValue={state.voice.preset}
+                    onInputChange={(_e, v) => {
+                      dispatch({ type: "SET_VOICE", field: "preset", value: v });
                       setErrors((prev) => ({ ...prev, ["voice.preset"]: null }));
                     }}
+                    renderInput={(params) => (
+                      <StyledTextField
+                        {...params}
+                        id="voice-preset"
+                        margin="normal"
+                        error={Boolean(errors["voice.preset"])}
+                        helperText={
+                          <FormErrorText id="voice-preset-error">
+                            {errors["voice.preset"]}
+                          </FormErrorText>
+                        }
+                        aria-describedby={
+                          errors["voice.preset"] ? "voice-preset-error" : undefined
+                        }
+                      />
+                    )}
                     fullWidth
-                    margin="normal"
-                    error={Boolean(errors["voice.preset"])}
-                    helperText={
-                      <FormErrorText id="voice-preset-error">
-                        {errors["voice.preset"]}
-                      </FormErrorText>
-                    }
-                    aria-describedby={
-                      errors["voice.preset"] ? "voice-preset-error" : undefined
-                    }
                   />
                 </Grid>
               </Grid>

--- a/src/features/settings/VoiceSettings.tsx
+++ b/src/features/settings/VoiceSettings.tsx
@@ -1,0 +1,101 @@
+import { useState, useEffect } from "react";
+import { Box, Button, Stack, TextField, Typography } from "@mui/material";
+import { useVoices } from "../../store/voices";
+
+export default function VoiceSettings() {
+  const voices = useVoices((s) => s.voices);
+  const addVoice = useVoices((s) => s.addVoice);
+  const removeVoice = useVoices((s) => s.removeVoice);
+  const setTags = useVoices((s) => s.setTags);
+  const load = useVoices((s) => s.load);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const [id, setId] = useState("");
+  const [provider, setProvider] = useState("bark");
+  const [preset, setPreset] = useState("");
+  const [tagInput, setTagInput] = useState("");
+
+  const handleAdd = () => {
+    const trimmedId = id.trim();
+    const trimmedPreset = preset.trim();
+    if (!trimmedId || !trimmedPreset) return;
+    const tags = tagInput
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    addVoice({ id: trimmedId, provider: provider.trim(), preset: trimmedPreset, tags });
+    setId("");
+    setPreset("");
+    setTagInput("");
+  };
+
+  const handleTagChange = (voiceId: string, value: string) => {
+    const tags = value
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+    setTags(voiceId, tags);
+  };
+
+  return (
+    <Box id="voice-settings">
+      <Typography variant="subtitle1">Bark Voices</Typography>
+      <Stack spacing={2} sx={{ mt: 2 }}>
+        {voices.map((v) => (
+          <Stack key={v.id} direction="row" spacing={1} alignItems="center">
+            <Typography sx={{ flex: 1 }}>{v.id}</Typography>
+            <TextField
+              label="Tags"
+              size="small"
+              value={v.tags.join(", ")}
+              onChange={(e) => handleTagChange(v.id, e.target.value)}
+            />
+            <Button
+              size="small"
+              variant="outlined"
+              color="error"
+              onClick={() => removeVoice(v.id)}
+            >
+              Remove
+            </Button>
+          </Stack>
+        ))}
+      </Stack>
+      <Typography variant="subtitle1" sx={{ mt: 3 }}>
+        Add Voice
+      </Typography>
+      <Stack spacing={2} sx={{ mt: 1 }} direction="row" flexWrap="wrap">
+        <TextField
+          label="ID"
+          size="small"
+          value={id}
+          onChange={(e) => setId(e.target.value)}
+        />
+        <TextField
+          label="Provider"
+          size="small"
+          value={provider}
+          onChange={(e) => setProvider(e.target.value)}
+        />
+        <TextField
+          label="Preset"
+          size="small"
+          value={preset}
+          onChange={(e) => setPreset(e.target.value)}
+        />
+        <TextField
+          label="Tags"
+          size="small"
+          value={tagInput}
+          onChange={(e) => setTagInput(e.target.value)}
+        />
+        <Button variant="contained" onClick={handleAdd}>
+          Add
+        </Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@ import { useCharacter } from "./character";
 import { useEncounterStore } from "./encounter";
 import { useWarTableStore } from "./warTable";
 import { useTabletopStore } from "./tabletop";
+import { useVoices } from "./voices";
 
 // Export individual stores for existing imports elsewhere
 export {
@@ -14,6 +15,7 @@ export {
   useEncounterStore,
   useWarTableStore,
   useTabletopStore,
+  useVoices,
 };
 
 const slices = {

--- a/src/store/voices.ts
+++ b/src/store/voices.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+import { saveState, loadState } from "../utils/persist";
+
+export interface Voice {
+  id: string;
+  provider: string;
+  preset: string;
+  tags: string[];
+}
+
+interface VoiceState {
+  voices: Voice[];
+  addVoice: (voice: Voice) => Promise<void>;
+  removeVoice: (id: string) => Promise<void>;
+  setTags: (id: string, tags: string[]) => Promise<void>;
+  load: () => Promise<void>;
+}
+
+const STORAGE_KEY = "voices";
+
+export const useVoices = create<VoiceState>((set, get) => ({
+  voices: [],
+  addVoice: async (voice) => {
+    const existing = get().voices.filter((v) => v.id !== voice.id);
+    const voices = [...existing, voice];
+    set({ voices });
+    await saveState(STORAGE_KEY, voices);
+  },
+  removeVoice: async (id) => {
+    const voices = get().voices.filter((v) => v.id !== id);
+    set({ voices });
+    await saveState(STORAGE_KEY, voices);
+  },
+  setTags: async (id, tags) => {
+    const voices = get().voices.map((v) => (v.id === id ? { ...v, tags } : v));
+    set({ voices });
+    await saveState(STORAGE_KEY, voices);
+  },
+  load: async () => {
+    const voices = await loadState<Voice[]>(STORAGE_KEY);
+    if (voices) set({ voices });
+  },
+}));
+
+loadState<Voice[]>(STORAGE_KEY).then((voices) => {
+  if (voices) useVoices.setState({ voices }, true);
+});
+
+export type { VoiceState };


### PR DESCRIPTION
## Summary
- add persistent `useVoices` store for provider/preset/tag data
- manage Bark voices and tags through new `VoiceSettings` settings section
- offer voice provider/preset suggestions in NPC form

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68ae142cd3288325a54d708b4e3411a1