### PR TITLE
feat: add sfz instrument loading

### DIFF
--- a/src/features/lofi/types.ts
+++ b/src/features/lofi/types.ts
@@ -7,4 +7,5 @@ export type LofiState = {
   key: string;
   weatherPreset: WeatherPreset | null;
   weatherEnabled: boolean;
+  sfzInstrument?: string;
 };

--- a/src/utils/AGENTS.md
+++ b/src/utils/AGENTS.md
@@ -1,0 +1,19 @@
+# Agent Instructions
+
+## SFZ Loader
+
+The `sfzLoader` utility parses a minimal subset of the SFZ format and
+creates a `Tone.Sampler` mapping from region definitions.
+
+### Supported opcodes
+- `sample` – path to the audio file. Paths are resolved relative to the SFZ file.
+- `lokey`, `hikey`, `key` – MIDI note range or single key for the region.
+- `pitch_keycenter` – used to derive the sample's root note.
+
+Other opcodes are ignored. Only `<region>` blocks are handled; `<group>`,
+`<control>`, and more advanced features such as velocity layers, envelopes,
+and modulators are currently unsupported.
+
+`loadSfz(path)` fetches the file, parses regions, and returns a ready
+`Tone.Sampler`. Samples must be accessible from the browser environment.
+

--- a/src/utils/sfzLoader.ts
+++ b/src/utils/sfzLoader.ts
@@ -36,7 +36,15 @@ export function parseSfz(text: string, basePath = ''): SfzRegion[] {
       const key = match[1].trim();
       const value = match[2].trim();
       if (key === 'sample') {
-        current.sample = basePath ? basePath + value : value;
+        if (basePath) {
+          try {
+            current.sample = new URL(value, basePath).toString();
+          } catch {
+            current.sample = basePath + value;
+          }
+        } else {
+          current.sample = value;
+        }
       } else {
         const num = Number(value);
         current[key] = isNaN(num) ? value : num;


### PR DESCRIPTION
## Summary
- support SFZ instrument paths in lofi engine and replace lead voice with loaded sampler
- document supported SFZ opcodes and limitations
- improve sample path resolution in SFZ loader

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1350e9248325990e00251f3305e9