### PR TITLE
Add history events dialog to calendar

### DIFF
--- a/src/components/CalendarDay.test.tsx
+++ b/src/components/CalendarDay.test.tsx
@@ -10,6 +10,7 @@ describe('CalendarDay', () => {
     render(
       <CalendarDay
         day={1}
+        month={1}
         events={[] as CalendarEvent[]}
         onDayClick={onDayClick}
         onPrefill={onPrefill}
@@ -23,5 +24,52 @@ describe('CalendarDay', () => {
     expect(onPrefill).toHaveBeenCalledWith(1);
     expect(onDayClick).toHaveBeenCalledTimes(1);
     expect(onDayClick.mock.calls[0][0]).toBe(1);
+  });
+
+  it('shows history events when history button is clicked', async () => {
+    const onDayClick = vi.fn();
+    const onPrefill = vi.fn();
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          events: [
+            {
+              year: 1066,
+              text: 'Battle of Hastings',
+              pages: [
+                {
+                  content_urls: {
+                    desktop: {
+                      page: 'https://en.wikipedia.org/wiki/Battle_of_Hastings',
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+    });
+    // @ts-ignore
+    global.fetch = mockFetch;
+
+    render(
+      <CalendarDay
+        day={7}
+        month={10}
+        events={[] as CalendarEvent[]}
+        onDayClick={onDayClick}
+        onPrefill={onPrefill}
+        isToday={false}
+        isFocused={false}
+        isSelected={false}
+      />
+    );
+    const historyBtn = screen.getByRole('button', { name: /history for day 7/i });
+    fireEvent.click(historyBtn);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.wikimedia.org/feed/v1/wikipedia/en/onthisday/events/10/7',
+      expect.any(Object)
+    );
+    await screen.findByText(/Battle of Hastings/i);
   });
 });

--- a/src/components/HistoryDialog.tsx
+++ b/src/components/HistoryDialog.tsx
@@ -1,0 +1,50 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  List,
+  ListItem,
+  Link,
+  Typography,
+} from '@mui/material';
+
+interface EventItem {
+  year: number;
+  text: string;
+  pages?: { content_urls?: { desktop?: { page?: string } } }[];
+}
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  events: EventItem[];
+}
+
+export default function HistoryDialog({ open, onClose, events }: Props) {
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth>
+      <DialogTitle>On This Day</DialogTitle>
+      <DialogContent>
+        {events.length === 0 ? (
+          <Typography>No events found.</Typography>
+        ) : (
+          <List>
+            {events.map((ev, idx) => (
+              <ListItem key={idx} disableGutters>
+                <Link
+                  href={ev.pages?.[0]?.content_urls?.desktop?.page}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  underline="hover"
+                >
+                  {ev.year}: {ev.text}
+                </Link>
+              </ListItem>
+            ))}
+          </List>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -400,6 +400,7 @@ export default function Calendar() {
                   <CalendarDay
                     key={idx}
                     day={day}
+                    month={month + 1}
                     events={day ? dayEvents(day) : []}
                     onDayClick={handleDayClick}
                     onPrefill={prefillDay}


### PR DESCRIPTION
## Summary
- add history button to calendar day that fetches on-this-day events
- display events in new HistoryDialog component with source links
- test calendar day history button and fetching behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae15b546f083259c3c42e9efb2af23