### PR TITLE
Replace cube with Blender icon on objects page

### DIFF
--- a/src/pages/Objects.tsx
+++ b/src/pages/Objects.tsx
@@ -1,24 +1,20 @@
-import { Canvas } from "@react-three/fiber";
+import { FaBlender } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 
-function Cube({ onSelect }:{ onSelect:()=>void }){
-  return (
-    <mesh onClick={onSelect} style={{ cursor:"pointer" }}>
-      <boxGeometry args={[1,1,1]} />
-      <meshStandardMaterial color="orange" />
-    </mesh>
-  );
-}
-
-export default function Objects(){
+export default function Objects() {
   const nav = useNavigate();
   return (
-    <div style={{ height:"100vh" }}>
-      <Canvas camera={{ position:[3,3,3] }}>
-        <ambientLight />
-        <pointLight position={[10,10,10]} />
-        <Cube onSelect={()=>nav("/objects/blender")} />
-      </Canvas>
+    <div
+      style={{
+        height: "100vh",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        cursor: "pointer",
+      }}
+      onClick={() => nav("/objects/blender")}
+    >
+      <FaBlender size={64} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace in-canvas cube with a recognizable Blender icon on the Objects page
- Preserve click navigation to `/objects/blender`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae177f879483259ae79949a136892a