### PR TITLE
Handle Blender template persistence errors

### DIFF
--- a/src/utils/persist.ts
+++ b/src/utils/persist.ts
@@ -7,7 +7,7 @@ export async function saveState<T>(
   key: string,
   state: T,
   backendUrl?: string
-): Promise<void> {
+): Promise<boolean> {
   const serialized = JSON.stringify(state);
   if (backendUrl) {
     try {
@@ -17,17 +17,23 @@ export async function saveState<T>(
         body: JSON.stringify({ key, state }),
       });
       if (!response.ok) {
-        throw new Error(`Failed to save state: ${response.status} ${response.statusText}`);
+        console.error(
+          `Failed to save state: ${response.status} ${response.statusText}`
+        );
+        return false;
       }
+      return true;
     } catch (err) {
       console.error("Failed to save state", err);
-      throw err;
+      return false;
     }
   } else {
     try {
       window.localStorage.setItem(key, serialized);
-    } catch {
-      // ignore write errors
+      return window.localStorage.getItem(key) === serialized;
+    } catch (err) {
+      console.error("Failed to save state", err);
+      return false;
     }
   }
 }


### PR DESCRIPTION
## Summary
- load Blender templates with async handling
- ensure saveState verifies persistence and returns success
- update template operations to check save results before mutating state

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae17d18eac83258b6c2ce964a79061