### PR TITLE
feat: verify persistence before updating Blender templates

### DIFF
--- a/src/utils/persist.ts
+++ b/src/utils/persist.ts
@@ -7,7 +7,7 @@ export async function saveState<T>(
   key: string,
   state: T,
   backendUrl?: string
-): Promise<void> {
+): Promise<boolean> {
   const serialized = JSON.stringify(state);
   if (backendUrl) {
     try {
@@ -17,17 +17,24 @@ export async function saveState<T>(
         body: JSON.stringify({ key, state }),
       });
       if (!response.ok) {
-        throw new Error(`Failed to save state: ${response.status} ${response.statusText}`);
+        console.error(
+          `Failed to save state: ${response.status} ${response.statusText}`
+        );
+        return false;
       }
+      return true;
     } catch (err) {
       console.error("Failed to save state", err);
-      throw err;
+      return false;
     }
   } else {
     try {
       window.localStorage.setItem(key, serialized);
-    } catch {
-      // ignore write errors
+      const stored = window.localStorage.getItem(key);
+      return stored === serialized;
+    } catch (err) {
+      console.error("Failed to save state", err);
+      return false;
     }
   }
 }


### PR DESCRIPTION
## Summary
- add persistence verification to saveState and return success flag
- load Blender templates asynchronously and persist output directory with error handling
- validate template save/delete before updating local state

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68ae1ed346448325863f3f95acac1715