### PR TITLE
Manage media stream lifecycle in transcription hook

### DIFF
--- a/src/features/transcription/useTranscription.ts
+++ b/src/features/transcription/useTranscription.ts
@@ -6,10 +6,21 @@ export function useTranscription() {
   const [transcript, setTranscript] = useState("");
   const media = useRef<MediaRecorder | null>(null);
   const chunks = useRef<Blob[]>([]);
+  const stream = useRef<MediaStream | null>(null);
 
   async function start() {
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    media.current = new MediaRecorder(stream);
+    try {
+      stream.current = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (err: any) {
+      const message =
+        err?.name === "NotAllowedError"
+          ? "Microphone permission denied."
+          : `Error accessing microphone: ${err?.message ?? err}`;
+      setTranscript(message);
+      return;
+    }
+
+    media.current = new MediaRecorder(stream.current);
     chunks.current = [];
     media.current.ondataavailable = (e) => chunks.current.push(e.data);
     media.current.onstop = async () => {
@@ -21,6 +32,10 @@ export function useTranscription() {
         setTranscript(text.trim());
       } catch (err: any) {
         setTranscript(`Error: ${err}`);
+      } finally {
+        chunks.current = [];
+        stream.current = null;
+        media.current = null;
       }
     };
     media.current.start();
@@ -28,7 +43,10 @@ export function useTranscription() {
   }
 
   function stop() {
+    stream.current?.getTracks().forEach((track) => track.stop());
     media.current?.stop();
+    media.current = null;
+    stream.current = null;
     setRecording(false);
   }
 


### PR DESCRIPTION
## Summary
- handle microphone permission errors in `useTranscription`
- track and clean up `MediaStream` alongside `MediaRecorder`
- stop tracks and clear buffers when recording stops

## Testing
- `npm test -- --run` *(fails: 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1f148ee88325be01ef31d0f7a874