### PR TITLE
Guard lofi progress logs in SongForm

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -471,7 +471,9 @@ export default function SongForm() {
           } else {
             setGlobalStatus(pretty);
           }
-          console.log("lofi_progress:", raw);
+          if (import.meta.env.DEV) {
+            console.log("lofi_progress:", raw);
+          }
         } catch {}
       });
       unlisten = off;


### PR DESCRIPTION
## Summary
- Guard lofi progress logging so it only runs in development

## Testing
- `npm test src/components/SongForm.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ae1f29266083259e91b9568da6b62b