### PR TITLE
Add Bark dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,19 @@ Install JavaScript and Python dependencies:
 ```bash
 npm install
 # create/activate a Python environment, then
-pip install -r requirements.txt  # base dependencies
+pip install -r requirements.txt  # base dependencies including Bark
 ```
 
 `audioop-lts` is included in the requirements and will be installed automatically on
 Python 3.13+ to replace the removed `audioop` module.
+
+`bark` (>=0.1.5) provides text‑to‑speech support and depends on `torch` (>=2.8.0)
+and `soundfile` (>=0.13.1). These packages are included in `requirements.txt`, or
+install them separately with:
+
+```bash
+pip install bark>=0.1.5 torch>=2.8.0 soundfile>=0.13.1
+```
 
 ## Running the Tauri app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,7 @@ requests>=2.32.0
 aiohttp>=3.9.0
 vosk>=0.3.45
 audioop-lts ; python_version >= "3.13"  # audioop module for Python 3.13+
+bark>=0.1.5
+torch>=2.8.0
+soundfile>=0.13.1
 


### PR DESCRIPTION
## Summary
- include bark, torch, and soundfile with version pins in requirements
- document installing Bark TTS dependencies in README

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68ae2c68d9688325accce15af33e9e40