### PR TITLE
Add Acoustic Grand Piano SFZ option

### DIFF
--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -529,6 +529,12 @@ export default function SongForm() {
     }
   }
 
+  function loadAcousticGrand() {
+    setInstruments([]);
+    setLeadInstrument("");
+    setSfzInstrument("/sfz_sounds/UprightPianoKW-20220221.sfz");
+  }
+
   async function generateAlbumArtPrompt(name: string) {
     try {
       const reply: string = await invoke("general_chat", {
@@ -1282,6 +1288,9 @@ export default function SongForm() {
           <div className="mt-2 flex items-center gap-2">
             <button className={styles.btn} onClick={pickSfzInstrument}>
               Choose SFZ
+            </button>
+            <button className={styles.btn} onClick={loadAcousticGrand}>
+              Acoustic Grand Piano
             </button>
             <span className={styles.small}>
               {sfzInstrument ? sfzInstrument.split(/[\\/]/).pop() : "none selected"}

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -2159,6 +2159,11 @@ exports[`SongForm > renders default form 1`] = `
           >
             Choose SFZ
           </button>
+          <button
+            class="_btn_913096"
+          >
+            Acoustic Grand Piano
+          </button>
           <span
             class="_small_913096"
           >


### PR DESCRIPTION
## Summary
- add `loadAcousticGrand` helper and UI button to load Upright Piano SFZ
- update SongForm snapshot

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae2ce4aa888325b9bd7ce62983e0d7