### PR TITLE
Add retro TV screen animation for retro theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import TopBar from "./components/TopBar";
 import ErrorBoundary from "./components/ErrorBoundary";
 import CreateUserDialog from "./components/CreateUserDialog";
+import RetroTV from "./components/RetroTV";
 import { useUsers } from "./features/users/useUsers";
 import Home from "./pages/Home";
 import Objects from "./pages/Objects";
@@ -49,6 +50,7 @@ export default function App() {
   return (
     <ErrorBoundary>
       <TopBar />
+      <RetroTV />
       <CreateUserDialog open={showUserDialog} onClose={() => setShowUserDialog(false)} />
       <Routes>
         <Route path="/" element={<Home />} />

--- a/src/components/RetroTV.tsx
+++ b/src/components/RetroTV.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { useTheme } from "../features/theme/ThemeContext";
+
+export default function RetroTV() {
+  const { theme } = useTheme();
+  if (theme !== "retro") return null;
+  return (
+    <div className="retro-tv-container">
+      <div className="retro-tv-screen" />
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -258,3 +258,52 @@ body.theme-studio input[type="range"]::-moz-range-thumb {
     transform: translate(-50%, -50%) scale(1) rotate(0deg);
   }
 }
+.retro-tv-container {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 260px;
+  height: 200px;
+  padding: 15px;
+  background: #111;
+  border: 4px solid #0f0;
+  border-radius: 20px;
+  box-shadow: 0 0 15px rgba(0, 255, 0, 0.5);
+  pointer-events: none;
+}
+
+.retro-tv-screen {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: #000;
+  border-radius: 15px;
+  overflow: hidden;
+}
+
+.retro-tv-screen::before {
+  content: "";
+  position: absolute;
+  top: -100%;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 255, 0, 0.15) 0px,
+    rgba(0, 255, 0, 0.15) 2px,
+    transparent 2px,
+    transparent 4px
+  );
+  animation: retro-scan 2s linear infinite;
+}
+
+@keyframes retro-scan {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(100%);
+  }
+}


### PR DESCRIPTION
## Summary
- add RetroTV component and styles to display center-screen animation when Retro theme active
- integrate RetroTV component at app root so animation appears across routes

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae2d6ecb9c83259e76bfcde5159015