### PR TITLE
Add tests for bark voice generation error paths

### DIFF
--- a/src-tauri/tests/bark_tts_errors.rs
+++ b/src-tauri/tests/bark_tts_errors.rs
@@ -1,0 +1,33 @@
+use std::{env, path::PathBuf};
+
+use blossom_lib::commands::{bark_tts, save_paths};
+use tempfile::tempdir;
+use which::which;
+
+#[tokio::test]
+async fn bark_tts_reports_missing_python_and_script() {
+    // isolate configuration
+    let temp_home = tempdir().unwrap();
+    env::set_var("HOME", temp_home.path());
+
+    // ensure script exists for first check
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir.parent().unwrap();
+    env::set_current_dir(&repo_root).unwrap();
+
+    // case: python missing
+    let missing = temp_home.path().join("no_python_here");
+    env::set_var("BLOSSOM_PYTHON_PATH", missing.to_string_lossy().to_string());
+    let err = bark_tts("hi".into(), "spk".into()).await.unwrap_err();
+    assert!(err.contains("Python not found"));
+
+    // case: script missing
+    let py = which("python3").unwrap();
+    save_paths(Some(py.to_string_lossy().to_string()), None)
+        .await
+        .unwrap();
+    let temp_dir = tempdir().unwrap();
+    env::set_current_dir(&temp_dir).unwrap();
+    let err = bark_tts("hi".into(), "spk".into()).await.unwrap_err();
+    assert!(err.contains("Script not found"));
+}

--- a/src/features/voice/bark.test.ts
+++ b/src/features/voice/bark.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateAudio } from './bark';
+import { invoke } from '@tauri-apps/api/core';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('tone', () => {
+  return {
+    getContext: () => ({ decodeAudioData: vi.fn().mockResolvedValue('decoded') }),
+    ToneAudioBuffer: class {
+      buffer: unknown;
+      constructor(buffer: unknown) {
+        this.buffer = buffer;
+      }
+    },
+  };
+});
+
+describe('generateAudio', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns ToneAudioBuffer when invoke succeeds', async () => {
+    (invoke as any).mockResolvedValue(new Uint8Array([1, 2, 3]));
+    const tone = await import('tone');
+    const result = await generateAudio('hello', 'speaker');
+    expect(invoke).toHaveBeenCalledWith('bark_tts', { text: 'hello', speaker: 'speaker' });
+    expect(result).toBeInstanceOf(tone.ToneAudioBuffer as any);
+    expect((result as any).buffer).toBe('decoded');
+  });
+
+  it('throws when invoke fails', async () => {
+    (invoke as any).mockRejectedValue(new Error('boom'));
+    await expect(generateAudio('hello', 'speaker')).rejects.toThrow(
+      'Bark TTS invocation failed: boom',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest tests for voice `generateAudio` covering invoke success and failure
- add Rust integration test validating `bark_tts` errors when Python or script are missing

## Testing
- `npm test src/features/voice/bark.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml --test bark_tts_errors`


------
https://chatgpt.com/codex/tasks/task_e_68ae2c20034c8325b7999837e2f9b446