### PR TITLE
test: ensure sfz instrument clears instrument selections

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -295,6 +295,20 @@ describe('SongForm', () => {
     expect(openDialog).toHaveBeenCalled();
   });
 
+  it('loads acoustic grand piano and clears instruments', () => {
+    render(<SongForm />);
+    openSection('sfz-section');
+    fireEvent.click(screen.getByText(/acoustic grand piano/i));
+    expect(
+      screen.getByText('UprightPianoKW-20220221.sfz')
+    ).toBeInTheDocument();
+    openSection('vibe-section');
+    ['rhodes', 'nylon guitar', 'upright bass'].forEach((name) => {
+      expect(screen.getByRole('checkbox', { name })).not.toBeChecked();
+    });
+    expect(screen.getByRole('radio', { name: 'synth' })).not.toBeChecked();
+  });
+
   it('keeps preset templates when loading custom templates', () => {
     localStorage.setItem(
       'songTemplates',

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -248,7 +248,7 @@ export default function SongForm() {
   }, [instruments]);
 
   useEffect(() => {
-    if (!instruments.includes(leadInstrument)) {
+    if (instruments.length && !instruments.includes(leadInstrument)) {
       setLeadInstrument(inferLeadInstrument(instruments));
     }
   }, [instruments]);


### PR DESCRIPTION
## Summary
- add unit test for Acoustic Grand Piano button clearing instruments and lead instrument
- avoid auto-selecting lead instrument when no instruments remain

## Testing
- `npx vitest run src/components/SongForm.test.tsx -u`

------
https://chatgpt.com/codex/tasks/task_e_68ae2e8eb1ac83258fc7105ee9889071