### PR TITLE
style: enlarge retro TV container

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -263,13 +263,13 @@ body.theme-studio input[type="range"]::-moz-range-thumb {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 260px;
-  height: 200px;
-  padding: 15px;
+  width: 520px;
+  height: 400px;
+  padding: 30px;
   background: #111;
-  border: 4px solid #0f0;
-  border-radius: 20px;
-  box-shadow: 0 0 15px rgba(0, 255, 0, 0.5);
+  border: 8px solid #0f0;
+  border-radius: 40px;
+  box-shadow: 0 0 30px rgba(0, 255, 0, 0.5);
   pointer-events: none;
 }
 
@@ -278,7 +278,7 @@ body.theme-studio input[type="range"]::-moz-range-thumb {
   width: 100%;
   height: 100%;
   background: #000;
-  border-radius: 15px;
+  border-radius: 30px;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- enlarge retro TV overlay container and screen dimensions
- adjust padding, border, border-radius, and box-shadow for proportional styling

## Testing
- `npm test` *(fails: ReferenceError window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ae310a2480832593d33722ecd1b5a5