### PR TITLE
Add SEO assistant page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Calendar from "./pages/Calendar";
 import Comfy from "./pages/Comfy";
 import Assistant from "./pages/Assistant";
 import GeneralChat from "./pages/GeneralChat";
+import Seo from "./pages/Seo";
 import WorldBuilder from "./pages/WorldBuilder";
 import NPCMaker from "./pages/NPCMaker";
 import NPCList from "./pages/NPCList";
@@ -61,6 +62,7 @@ export default function App() {
         <Route path="/comfy" element={<Comfy />} />
         <Route path="/assistant" element={<Assistant />} />
         <Route path="/assistant/general-chat" element={<GeneralChat />} />
+        <Route path="/assistant/seo" element={<Seo />} />
         <Route path="/dnd/world-builder" element={<WorldBuilder />} />
         <Route path="/dnd/npcs-maker" element={<NPCMaker />} />
         <Route path="/dnd/npcs-library" element={<NPCList />} />

--- a/src/pages/Assistant.tsx
+++ b/src/pages/Assistant.tsx
@@ -11,7 +11,7 @@ const features: Feature[] = [
   { label: "Prompt Factory" },
   { label: "Script" },
   { label: "Music" },
-  { label: "SEO" },
+  { label: "SEO", path: "/assistant/seo" },
   { label: "Orchestration" },
   { label: "RAG" },
   { label: "General Chat", path: "/assistant/general-chat" },

--- a/src/pages/Seo.tsx
+++ b/src/pages/Seo.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { Box, Button, Stack, TextField, Typography } from "@mui/material";
+import Center from "./_Center";
+import { generatePrompt } from "../utils/promptGenerator";
+
+function generateMetaTags(keywords: string[], content: string) {
+  const description = content.trim().slice(0, 160);
+  const keywordStr = keywords.join(", ");
+  return `<meta name="description" content="${description}" />\n<meta name="keywords" content="${keywordStr}" />`;
+}
+
+function suggestKeywords(content: string) {
+  const words = (content.toLowerCase().match(/\b\w+\b/g) || []).filter(
+    (w) => w.length > 3
+  );
+  const freq: Record<string, number> = {};
+  words.forEach((w) => {
+    freq[w] = (freq[w] || 0) + 1;
+  });
+  return Object.entries(freq)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([w]) => w);
+}
+
+function seoScore(keywords: string[], content: string) {
+  if (!keywords.length || !content.trim()) return 0;
+  const lower = content.toLowerCase();
+  const totalWords = lower.split(/\s+/).length;
+  let matches = 0;
+  keywords.forEach((k) => {
+    const regex = new RegExp(`\\b${k.toLowerCase()}\\b`, "g");
+    matches += (lower.match(regex) || []).length;
+  });
+  return Math.round((matches / totalWords) * 100);
+}
+
+export default function Seo() {
+  const [keywords, setKeywords] = useState("");
+  const [content, setContent] = useState("");
+  const [meta, setMeta] = useState("");
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [score, setScore] = useState<number | null>(null);
+  const [copySuggestion, setCopySuggestion] = useState("");
+
+  const analyze = () => {
+    const kw = keywords
+      .split(",")
+      .map((k) => k.trim())
+      .filter(Boolean);
+    setMeta(generateMetaTags(kw, content));
+    setSuggestions(suggestKeywords(content));
+    setScore(seoScore(kw, content));
+  };
+
+  const suggestCopy = () => {
+    const base = content || keywords;
+    setCopySuggestion(generatePrompt(base, "seo"));
+  };
+
+  return (
+    <Center>
+      <Stack spacing={2} sx={{ width: "100%", maxWidth: 600 }}>
+        <TextField
+          label="Target Keywords"
+          value={keywords}
+          onChange={(e) => setKeywords(e.target.value)}
+        />
+        <TextField
+          label="Content"
+          multiline
+          minRows={4}
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <Stack direction="row" spacing={2}>
+          <Button variant="contained" onClick={analyze}>
+            Analyze
+          </Button>
+          <Button variant="outlined" onClick={suggestCopy}>
+            Suggest Copy
+          </Button>
+        </Stack>
+        {meta && (
+          <Box>
+            <Typography variant="h6">Meta Tags</Typography>
+            <pre>{meta}</pre>
+          </Box>
+        )}
+        {suggestions.length > 0 && (
+          <Box>
+            <Typography variant="h6">Keyword Suggestions</Typography>
+            <Typography>{suggestions.join(", ")}</Typography>
+          </Box>
+        )}
+        {score !== null && (
+          <Typography variant="h6">SEO Score: {score}</Typography>
+        )}
+        {copySuggestion && (
+          <Box>
+            <Typography variant="h6">Copy Suggestion</Typography>
+            <Typography>{copySuggestion}</Typography>
+          </Box>
+        )}
+      </Stack>
+    </Center>
+  );
+}

--- a/src/utils/promptGenerator.test.ts
+++ b/src/utils/promptGenerator.test.ts
@@ -24,6 +24,12 @@ describe('generatePrompt', () => {
     );
   });
 
+  it('creates an SEO prompt', () => {
+    expect(generatePrompt('blogs', 'seo')).toBe(
+      'Create SEO optimized copy about blogs.'
+    );
+  });
+
   it('returns empty string for empty input', () => {
     expect(generatePrompt('   ', 'video')).toBe('');
   });

--- a/src/utils/promptGenerator.ts
+++ b/src/utils/promptGenerator.ts
@@ -1,4 +1,4 @@
-export type PromptType = 'video' | 'image' | 'music' | 'dnd';
+export type PromptType = 'video' | 'image' | 'music' | 'dnd' | 'seo';
 
 export function generatePrompt(text: string, type: PromptType): string {
   const cleaned = text.trim();
@@ -13,6 +13,8 @@ export function generatePrompt(text: string, type: PromptType): string {
       return `Compose a short piece of music about ${cleaned}.`;
     case 'dnd':
       return `Create a DND campaign idea involving ${cleaned}.`;
+    case 'seo':
+      return `Create SEO optimized copy about ${cleaned}.`;
     default:
       return '';
   }


### PR DESCRIPTION
## Summary
- Link SEO feature button to `/assistant/seo`
- Add SEO page with meta tag generation, keyword suggestions, SEO scoring, and copy suggestions
- Extend prompt generator to support SEO prompts

## Testing
- `npm test` *(fails: TypeError: Right-hand side of 'instanceof' is not an object)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2fd810448325ab9f708c36763003