### PR TITLE
feat: allow RetroTV to render children

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,9 +49,9 @@ export default function App() {
 
   return (
     <ErrorBoundary>
-      <TopBar />
-      <RetroTV />
-      <CreateUserDialog open={showUserDialog} onClose={() => setShowUserDialog(false)} />
+        <TopBar />
+        <RetroTV>NO SIGNAL</RetroTV>
+        <CreateUserDialog open={showUserDialog} onClose={() => setShowUserDialog(false)} />
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/objects" element={<Objects />} />

--- a/src/components/RetroTV.tsx
+++ b/src/components/RetroTV.tsx
@@ -1,12 +1,18 @@
 import React from "react";
 import { useTheme } from "../features/theme/ThemeContext";
 
-export default function RetroTV() {
+interface RetroTVProps {
+  children?: React.ReactNode;
+}
+
+export default function RetroTV({ children }: RetroTVProps) {
   const { theme } = useTheme();
   if (theme !== "retro") return null;
   return (
     <div className="retro-tv-container">
-      <div className="retro-tv-screen" />
+      <div className="retro-tv-screen">
+        <div className="retro-tv-content">{children}</div>
+      </div>
     </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -282,6 +282,11 @@ body.theme-studio input[type="range"]::-moz-range-thumb {
   overflow: hidden;
 }
 
+.retro-tv-content {
+  position: relative;
+  z-index: 1;
+}
+
 .retro-tv-screen::before {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Summary
- enable RetroTV component to accept children rendered inside the TV screen
- add `.retro-tv-content` styling so nested content sits under scan lines
- update App to showcase RetroTV with inner text content

## Testing
- `npm test` *(fails: ReferenceError window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3289dd508325af62271c78763982