### PR TITLE
Resolve default SFZ path via Tauri asset API

### DIFF
--- a/public/sfz_sounds/README.md
+++ b/public/sfz_sounds/README.md
@@ -1,8 +1,8 @@
 # SFZ Sounds
 
-Static SFZ instrument definitions and their samples live here. The folder is
-served from `/sfz_sounds` at runtime so front-end code can fetch files by
-relative URL.
+Static SFZ instrument definitions and their samples live here. When the app is
+packaged with Tauri, this directory is bundled into the application's resource
+folder and is resolved at runtime via Tauri's asset APIs.
 
 ## Naming and layout
 
@@ -29,11 +29,12 @@ Inside the `.sfz`, reference samples using paths relative to the `.sfz` file:
 
 ## Loading
 
-Future code will load instruments from this directory using relative paths. When
-invoking the loader, pass only the file name:
+At runtime, resolve the path to an instrument using `resolveResource` and then
+convert it to a URL with `convertFileSrc` before handing it to the loader:
 
 ```ts
-loadSfz('piano.sfz'); // resolves to /sfz_sounds/piano.sfz
+const path = await resolveResource('sfz_sounds/piano.sfz');
+loadSfz(convertFileSrc(path));
 ```
 
 Because sample paths are relative, the loader automatically locates files inside

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -15,6 +15,9 @@ vi.mock('@tauri-apps/api/core', () => ({
   convertFileSrc: (p: string) => p,
 }));
 vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+vi.mock('@tauri-apps/api/path', () => ({
+  resolveResource: (p: string) => Promise.resolve(p),
+}));
 vi.mock('../features/lofi/SongForm', () => ({
   useLofi: () => ({
     isPlaying: false,
@@ -295,13 +298,11 @@ describe('SongForm', () => {
     expect(openDialog).toHaveBeenCalled();
   });
 
-  it('loads acoustic grand piano and clears instruments', () => {
+  it('loads acoustic grand piano and clears instruments', async () => {
     render(<SongForm />);
     openSection('sfz-section');
     fireEvent.click(screen.getByText(/acoustic grand piano/i));
-    expect(
-      screen.getByText('UprightPianoKW-20220221.sfz')
-    ).toBeInTheDocument();
+    await screen.findByText('UprightPianoKW-20220221.sfz');
     openSection('vibe-section');
     ['rhodes', 'nylon guitar', 'upright bass'].forEach((name) => {
       expect(screen.getByRole('checkbox', { name })).not.toBeChecked();

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -4,6 +4,7 @@ import { useAudioDefaults } from "../features/audioDefaults/useAudioDefaults";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { openPath } from "@tauri-apps/plugin-opener";
 import { invoke, convertFileSrc } from "@tauri-apps/api/core";
+import { resolveResource } from "@tauri-apps/api/path";
 import { listen } from "@tauri-apps/api/event";
 import { useLofi } from "../features/lofi/SongForm";
 import { WEATHER_PRESETS } from "../features/lofi/weather";
@@ -529,10 +530,17 @@ export default function SongForm() {
     }
   }
 
-  function loadAcousticGrand() {
+  async function loadAcousticGrand() {
     setInstruments([]);
     setLeadInstrument("");
-    setSfzInstrument("/sfz_sounds/UprightPianoKW-20220221.sfz");
+    try {
+      const path = await resolveResource(
+        "sfz_sounds/UprightPianoKW-20220221.sfz"
+      );
+      setSfzInstrument(convertFileSrc(path));
+    } catch (e: any) {
+      setErr(e?.message || String(e));
+    }
   }
 
   async function generateAlbumArtPrompt(name: string) {


### PR DESCRIPTION
## Summary
- replace hardcoded SFZ URL with resolved asset path
- document SFZ bundle location and load steps
- adapt SongForm test for async resource loading

## Testing
- `npm test -- src/components/SongForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae317a5f7483258c40287f678fff86