### PR TITLE
Sync SFZ instrument with preview sampler

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -15,6 +15,8 @@ vi.mock('@tauri-apps/api/core', () => ({
   convertFileSrc: (p: string) => p,
 }));
 vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+const setPreviewSfzInstrument = vi.fn();
+
 vi.mock('../features/lofi/SongForm', () => ({
   useLofi: () => ({
     isPlaying: false,
@@ -23,6 +25,7 @@ vi.mock('../features/lofi/SongForm', () => ({
     setBpm: vi.fn(),
     setKey: vi.fn(),
     setSeed: vi.fn(),
+    setSfzInstrument: setPreviewSfzInstrument,
   }),
 }));
 const enqueueTask = vi.fn(() => Promise.resolve(1));
@@ -60,6 +63,7 @@ describe('SongForm', () => {
   beforeEach(() => {
     localStorage.clear();
     vi.resetAllMocks();
+    setPreviewSfzInstrument.mockReset();
     enqueueTask.mockResolvedValue(1);
     useSongJobs.setState({ jobs: [] });
     Object.defineProperty(global.HTMLMediaElement.prototype, 'play', {
@@ -293,12 +297,16 @@ describe('SongForm', () => {
     fireEvent.click(screen.getByText(/choose sfz/i));
     await screen.findByText('piano.sfz');
     expect(openDialog).toHaveBeenCalled();
+    expect(setPreviewSfzInstrument).toHaveBeenCalledWith('/tmp/piano.sfz');
   });
 
   it('loads acoustic grand piano and clears instruments', () => {
     render(<SongForm />);
     openSection('sfz-section');
     fireEvent.click(screen.getByText(/acoustic grand piano/i));
+    expect(setPreviewSfzInstrument).toHaveBeenCalledWith(
+      '/sfz_sounds/UprightPianoKW-20220221.sfz'
+    );
     expect(
       screen.getByText('UprightPianoKW-20220221.sfz')
     ).toBeInTheDocument();

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -173,7 +173,7 @@ export default function SongForm() {
   const [leadInstrument, setLeadInstrument] = useState<string>(() =>
     inferLeadInstrument(defaultInstruments)
   );
-  const [sfzInstrument, setSfzInstrument] = useState<string | null>(null);
+  const [sfzInstrument, setSfzInstrumentState] = useState<string | null>(null);
   const [ambience, setAmbience] = useState<string[]>(["rain"]);
   const [ambienceLevel, setAmbienceLevel] = useState(0.5);
   const [templates, setTemplates] = useState<Record<string, TemplateSpec>>(() => {
@@ -358,6 +358,7 @@ export default function SongForm() {
     weatherPreset,
     weatherEnabled,
     setWeatherEnabled,
+    setSfzInstrument: setPreviewSfzInstrument,
   } = useLofi();
 
   // one audio element
@@ -522,7 +523,8 @@ export default function SongForm() {
         filters: [{ name: "SFZ Instrument", extensions: ["sfz"] }],
       });
       if (file) {
-        setSfzInstrument(file as string);
+        setSfzInstrumentState(file as string);
+        setPreviewSfzInstrument(file as string);
       }
     } catch (e: any) {
       setErr(e?.message || String(e));
@@ -532,7 +534,9 @@ export default function SongForm() {
   function loadAcousticGrand() {
     setInstruments([]);
     setLeadInstrument("");
-    setSfzInstrument("/sfz_sounds/UprightPianoKW-20220221.sfz");
+    const path = "/sfz_sounds/UprightPianoKW-20220221.sfz";
+    setSfzInstrumentState(path);
+    setPreviewSfzInstrument(path);
   }
 
   async function generateAlbumArtPrompt(name: string) {


### PR DESCRIPTION
## Summary
- import `setSfzInstrument` from `useLofi`
- propagate SFZ selections to preview sampler
- test SFZ file and acoustic grand piano button update the preview sampler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae316fb3308325bb053c3df77ba2cb