### PR TITLE
feat: add RetroTV fallback content

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ Run the test suite to verify the application:
 npm test
 ```
 
+## RetroTV component
+
+The `RetroTV` component renders its children inside a styled television frame when
+the active theme is set to `retro`. If no children are provided, the component
+automatically displays `/assets/logo.png` as a fallback.
+
 ## Configuration and optional features
 
 - **Alpha Vantage API key:** Set the `ALPHAVANTAGE_API_KEY` environment variable (or add

--- a/src/components/RetroTV.tsx
+++ b/src/components/RetroTV.tsx
@@ -8,11 +8,18 @@ interface RetroTVProps {
 export default function RetroTV({ children }: RetroTVProps) {
   const { theme } = useTheme();
   if (theme !== "retro") return null;
+  const content = children ? (
+    <div className="retro-tv-content">{children}</div>
+  ) : (
+    <img
+      src="/assets/logo.png"
+      className="retro-tv-content"
+      alt="Blossom logo"
+    />
+  );
   return (
     <div className="retro-tv-container">
-      <div className="retro-tv-screen">
-        <div className="retro-tv-content">{children}</div>
-      </div>
+      <div className="retro-tv-screen">{content}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show a logo placeholder when RetroTV has no children
- document RetroTV fallback usage in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae34633a3083258961b4e7df477f00