### PR TITLE
Propagate SFZ selection to preview sampler

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
 vi.mock('@tauri-apps/api/path', () => ({
   resolveResource: (p: string) => Promise.resolve(p),
 }));
+const setPreviewSfzInstrument = vi.fn();
 vi.mock('../features/lofi/SongForm', () => ({
   useLofi: () => ({
     isPlaying: false,
@@ -26,6 +27,7 @@ vi.mock('../features/lofi/SongForm', () => ({
     setBpm: vi.fn(),
     setKey: vi.fn(),
     setSeed: vi.fn(),
+    setSfzInstrument: setPreviewSfzInstrument,
   }),
 }));
 const enqueueTask = vi.fn(() => Promise.resolve(1));
@@ -65,6 +67,7 @@ describe('SongForm', () => {
     vi.resetAllMocks();
     enqueueTask.mockResolvedValue(1);
     useSongJobs.setState({ jobs: [] });
+    setPreviewSfzInstrument.mockClear();
     Object.defineProperty(global.HTMLMediaElement.prototype, 'play', {
       configurable: true,
       value: vi.fn(),
@@ -296,6 +299,7 @@ describe('SongForm', () => {
     fireEvent.click(screen.getByText(/choose sfz/i));
     await screen.findByText('piano.sfz');
     expect(openDialog).toHaveBeenCalled();
+    expect(setPreviewSfzInstrument).toHaveBeenCalledWith('/tmp/piano.sfz');
   });
 
   it('loads acoustic grand piano and clears instruments', async () => {
@@ -308,6 +312,9 @@ describe('SongForm', () => {
       expect(screen.getByRole('checkbox', { name })).not.toBeChecked();
     });
     expect(screen.getByRole('radio', { name: 'synth' })).not.toBeChecked();
+    expect(setPreviewSfzInstrument).toHaveBeenCalledWith(
+      'sfz_sounds/UprightPianoKW-20220221.sfz'
+    );
   });
 
   it('keeps preset templates when loading custom templates', () => {

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -356,6 +356,7 @@ export default function SongForm() {
     setBpm: setPreviewBpm,
     setKey: setPreviewKey,
     setSeed: setPreviewSeed,
+    setSfzInstrument: setPreviewSfzInstrument,
     weatherPreset,
     weatherEnabled,
     setWeatherEnabled,
@@ -524,6 +525,7 @@ export default function SongForm() {
       });
       if (file) {
         setSfzInstrument(file as string);
+        setPreviewSfzInstrument(file as string);
       }
     } catch (e: any) {
       setErr(e?.message || String(e));
@@ -537,7 +539,9 @@ export default function SongForm() {
       const path = await resolveResource(
         "sfz_sounds/UprightPianoKW-20220221.sfz"
       );
-      setSfzInstrument(convertFileSrc(path));
+      const url = convertFileSrc(path);
+      setSfzInstrument(url);
+      setPreviewSfzInstrument(url);
     } catch (e: any) {
       setErr(e?.message || String(e));
     }


### PR DESCRIPTION
## Summary
- forward SFZ instrument selections to the lofi preview sampler
- adjust acoustic grand piano button to update preview sampler
- test that SFZ file selection and acoustic grand piano update the sampler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae347c62c483258f728bcb8df146c1