### PR TITLE
Annotate test general_chat as tauri command

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1640,6 +1640,7 @@ pub async fn general_chat<R: Runtime>(
 }
 
 #[cfg(test)]
+#[tauri::command]
 pub async fn general_chat<R: Runtime>(
     _app: AppHandle<R>,
     _messages: Vec<ChatMessage>,


### PR DESCRIPTION
## Summary
- ensure the test variant of `general_chat` is exposed as a Tauri command

## Testing
- `cargo test` *(fails: expected function, found module `tauri::test::mock_runtime`)*

------
https://chatgpt.com/codex/tasks/task_e_68ae35aac6ac83259e13dc3153706704