### PR TITLE
test: use window handle for comfy start

### DIFF
--- a/src-tauri/tests/comfy_start_stop.rs
+++ b/src-tauri/tests/comfy_start_stop.rs
@@ -1,5 +1,6 @@
 use blossom_lib::commands::{comfy_start, comfy_stop, __has_comfy_child};
 use std::{env, fs};
+use tauri::Manager;
 
 #[tokio::test]
 async fn start_and_stop_comfy() {
@@ -7,9 +8,10 @@ async fn start_and_stop_comfy() {
     let app = tauri::test::mock_builder()
         .build(tauri::test::mock_context(tauri::test::noop_assets()))
         .unwrap();
-    let window = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
+    let _webview = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
         .build()
         .unwrap();
+    let window = app.get_window("main").unwrap();
 
     let dir = tempfile::tempdir().unwrap();
     fs::write(


### PR DESCRIPTION
## Summary
- add Manager trait import
- build WebviewWindow and fetch window handle for comfy test

## Testing
- `cargo test` *(fails: no method named `get_window` for struct `tauri::App`; `tauri::test::mock_runtime` not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3cbad9a88325967dd9f99849157a