### PR TITLE
Use mock_app for tests

### DIFF
--- a/src-tauri/tests/comfy_start_stop.rs
+++ b/src-tauri/tests/comfy_start_stop.rs
@@ -1,12 +1,10 @@
 use blossom_lib::commands::{comfy_start, comfy_stop, __has_comfy_child};
 use std::{env, fs};
+use tauri::test::mock_app;
 
 #[tokio::test]
 async fn start_and_stop_comfy() {
-    let _rt = tauri::test::mock_runtime();
-    let app = tauri::test::mock_builder()
-        .build(tauri::test::mock_context(tauri::test::noop_assets()))
-        .unwrap();
+    let app = mock_app();
     let window = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
         .build()
         .unwrap();

--- a/src-tauri/tests/npc_log.rs
+++ b/src-tauri/tests/npc_log.rs
@@ -4,9 +4,8 @@ use tauri::{test::mock_app, Manager};
 
 #[tokio::test]
 async fn append_npc_log_includes_errors() {
-    let _rt = tauri::test::mock_runtime();
     let app = mock_app();
-    let handle = app.app_handle();
+    let handle = app.app_handle().clone();
 
     append_npc_log(
         handle.clone(),

--- a/src-tauri/tests/save_paths.rs
+++ b/src-tauri/tests/save_paths.rs
@@ -4,7 +4,6 @@ use std::{env, fs};
 
 #[tokio::test]
 async fn save_paths_writes_config() {
-    let _rt = tauri::test::mock_runtime();
     let dir = tempfile::tempdir().unwrap();
     env::set_var("HOME", dir.path());
 


### PR DESCRIPTION
## Summary
- remove standalone mock runtime in tests
- initialize test apps with `tauri::test::mock_app`

## Testing
- `cargo test --tests` *(fails: expected `Window<_>` found `WebviewWindow<MockRuntime>` and missing `__cmd__general_chat`)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3cbb2a44832589c8375915c35ac7