### PR TITLE
feat(tv): add bouncing icons fallback

### DIFF
--- a/src/components/BouncingIcons.tsx
+++ b/src/components/BouncingIcons.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef } from "react";
+import { ITEMS } from "./FeatureNav";
+
+/**
+ * Displays the FeatureNav icons bouncing around inside the TV screen.
+ */
+export default function BouncingIcons() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const iconRefs = useRef<HTMLDivElement[]>([]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const ICON_SIZE = 48;
+    const positions = ITEMS.map(() => ({
+      x: Math.random() * (container.clientWidth - ICON_SIZE),
+      y: Math.random() * (container.clientHeight - ICON_SIZE),
+      vx: (Math.random() * 1.5 + 0.5) * (Math.random() < 0.5 ? -1 : 1),
+      vy: (Math.random() * 1.5 + 0.5) * (Math.random() < 0.5 ? -1 : 1),
+    }));
+
+    let frame: number;
+
+    const animate = () => {
+      const width = container.clientWidth;
+      const height = container.clientHeight;
+      positions.forEach((p, i) => {
+        p.x += p.vx;
+        p.y += p.vy;
+        if (p.x <= 0 || p.x >= width - ICON_SIZE) p.vx *= -1;
+        if (p.y <= 0 || p.y >= height - ICON_SIZE) p.vy *= -1;
+        const el = iconRefs.current[i];
+        if (el) {
+          el.style.transform = `translate(${p.x}px, ${p.y}px)`;
+        }
+      });
+      frame = requestAnimationFrame(animate);
+    };
+
+    frame = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="retro-tv-content"
+      style={{ width: "100%", height: "100%", position: "relative" }}
+    >
+      {ITEMS.map((it, i) => (
+        <div
+          key={i}
+          ref={(el) => {
+            if (el) iconRefs.current[i] = el;
+          }}
+          style={{
+            position: "absolute",
+            fontSize: "2rem",
+            color: it.color.replace("0.55", "1"),
+          }}
+        >
+          {it.icon}
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/components/FeatureNav.tsx
+++ b/src/components/FeatureNav.tsx
@@ -36,7 +36,7 @@ type Item = {
   color: string;
 };
 
-const ITEMS: Item[] = [
+export const ITEMS: Item[] = [
   { key: "objects", icon: <FaCubes />, label: "3D Object", path: "/objects", color: "rgba(165,216,255,0.55)" },
   { key: "music", icon: <FaMusic />, label: "Music", path: "/music", color: "rgba(245,176,194,0.55)" },
   { key: "calendar", icon: <FaCalendarAlt />, label: "Calendar", path: "/calendar", color: "rgba(211,200,255,0.55)" },

--- a/src/components/RetroTV.tsx
+++ b/src/components/RetroTV.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useTheme } from "../features/theme/ThemeContext";
+import BouncingIcons from "./BouncingIcons";
 
 interface RetroTVProps {
   children?: React.ReactNode;
@@ -47,13 +48,7 @@ export default function RetroTV({ children }: RetroTVProps) {
   } else if (children) {
     content = <div className="retro-tv-content">{children}</div>;
   } else {
-    content = (
-      <img
-        src="/assets/logo.png"
-        className="retro-tv-content"
-        alt="Blossom logo"
-      />
-    );
+    content = <BouncingIcons />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- export FeatureNav icon list for reuse
- add animated BouncingIcons component
- show bouncing icons in RetroTV when no media provided

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae3e3198e48325912bcb322e69bbd0