### PR TITLE
feat(tv): animate idle icons

### DIFF
--- a/src/components/BouncingIcons.tsx
+++ b/src/components/BouncingIcons.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from "react";
+import { ITEMS } from "./FeatureNav";
+
+export default function BouncingIcons() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const iconRefs = useRef<HTMLDivElement[]>([]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const icons = iconRefs.current;
+    const positions = icons.map((el) => ({
+      x: Math.random() * (container.clientWidth - el.offsetWidth),
+      y: Math.random() * (container.clientHeight - el.offsetHeight),
+    }));
+    const velocities = icons.map(() => ({
+      vx: (Math.random() * 2 - 1) * 1.5,
+      vy: (Math.random() * 2 - 1) * 1.5,
+    }));
+
+    let frame: number;
+    const animate = () => {
+      icons.forEach((el, i) => {
+        const { offsetWidth, offsetHeight } = el;
+        let { x, y } = positions[i];
+        let { vx, vy } = velocities[i];
+        x += vx;
+        y += vy;
+        const w = container.clientWidth;
+        const h = container.clientHeight;
+        if (x <= 0 || x + offsetWidth >= w) {
+          vx = -vx;
+          x = Math.max(0, Math.min(w - offsetWidth, x));
+        }
+        if (y <= 0 || y + offsetHeight >= h) {
+          vy = -vy;
+          y = Math.max(0, Math.min(h - offsetHeight, y));
+        }
+        positions[i] = { x, y };
+        velocities[i] = { vx, vy };
+        el.style.transform = `translate(${x}px, ${y}px)`;
+      });
+      frame = requestAnimationFrame(animate);
+    };
+    frame = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="retro-tv-content"
+      style={{ position: "relative", overflow: "hidden" }}
+    >
+      {ITEMS.map((it, idx) => (
+        <div
+          key={idx}
+          ref={(el) => {
+            if (el) iconRefs.current[idx] = el;
+          }}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            fontSize: 40,
+            color: it.color.replace("0.55", "1"),
+          }}
+        >
+          {it.icon}
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/components/FeatureNav.tsx
+++ b/src/components/FeatureNav.tsx
@@ -36,7 +36,7 @@ type Item = {
   color: string;
 };
 
-const ITEMS: Item[] = [
+export const ITEMS: Item[] = [
   { key: "objects", icon: <FaCubes />, label: "3D Object", path: "/objects", color: "rgba(165,216,255,0.55)" },
   { key: "music", icon: <FaMusic />, label: "Music", path: "/music", color: "rgba(245,176,194,0.55)" },
   { key: "calendar", icon: <FaCalendarAlt />, label: "Calendar", path: "/calendar", color: "rgba(211,200,255,0.55)" },

--- a/src/components/RetroTV.tsx
+++ b/src/components/RetroTV.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useTheme } from "../features/theme/ThemeContext";
+import BouncingIcons from "./BouncingIcons";
 
 interface RetroTVProps {
   children?: React.ReactNode;
@@ -47,13 +48,7 @@ export default function RetroTV({ children }: RetroTVProps) {
   } else if (children) {
     content = <div className="retro-tv-content">{children}</div>;
   } else {
-    content = (
-      <img
-        src="/assets/logo.png"
-        className="retro-tv-content"
-        alt="Blossom logo"
-      />
-    );
+    content = <BouncingIcons />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- export FeatureNav item list for reuse
- show bouncing app icons in RetroTV when idle
- animate icons within TV bounds

## Testing
- `npm test` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4b45da448325bedd20ed7dfca01f