### PR TITLE
feat: add favorite voices

### DIFF
--- a/src/features/settings/VoiceSettings.tsx
+++ b/src/features/settings/VoiceSettings.tsx
@@ -1,12 +1,22 @@
 import { useState, useEffect } from "react";
-import { Box, Button, Stack, TextField, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  Stack,
+  TextField,
+  Typography,
+  IconButton,
+} from "@mui/material";
+import StarIcon from "@mui/icons-material/Star";
+import StarBorderIcon from "@mui/icons-material/StarBorder";
 import { useVoices } from "../../store/voices";
 
 export default function VoiceSettings() {
-  const voices = useVoices((s) => s.voices);
+  const voices = useVoices((s) => s.voices.filter(s.filter));
   const addVoice = useVoices((s) => s.addVoice);
   const removeVoice = useVoices((s) => s.removeVoice);
   const setTags = useVoices((s) => s.setTags);
+  const toggleFavorite = useVoices((s) => s.toggleFavorite);
   const load = useVoices((s) => s.load);
 
   useEffect(() => {
@@ -26,7 +36,13 @@ export default function VoiceSettings() {
       .split(",")
       .map((t) => t.trim())
       .filter(Boolean);
-    addVoice({ id: trimmedId, provider: provider.trim(), preset: trimmedPreset, tags });
+    addVoice({
+      id: trimmedId,
+      provider: provider.trim(),
+      preset: trimmedPreset,
+      tags,
+      favorite: false,
+    });
     setId("");
     setPreset("");
     setTagInput("");
@@ -47,6 +63,9 @@ export default function VoiceSettings() {
         {voices.map((v) => (
           <Stack key={v.id} direction="row" spacing={1} alignItems="center">
             <Typography sx={{ flex: 1 }}>{v.id}</Typography>
+            <IconButton onClick={() => toggleFavorite(v.id)} size="small">
+              {v.favorite ? <StarIcon /> : <StarBorderIcon />}
+            </IconButton>
             <TextField
               label="Tags"
               size="small"

--- a/src/pages/GeneralChat.tsx
+++ b/src/pages/GeneralChat.tsx
@@ -12,6 +12,8 @@ import {
   Typography,
   Autocomplete,
 } from "@mui/material";
+import StarIcon from "@mui/icons-material/Star";
+import StarBorderIcon from "@mui/icons-material/StarBorder";
 import type { Theme } from "@mui/material/styles";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -50,7 +52,8 @@ export default function GeneralChat() {
   const [error, setError] = useState<string>("");
   const [logs, setLogs] = useState<string[]>([]);
   const enqueueTask = useTasks((s) => s.enqueueTask);
-  const voices = useVoices((s) => s.voices);
+  const voices = useVoices((s) => s.voices.filter(s.filter));
+  const toggleFavorite = useVoices((s) => s.toggleFavorite);
   const loadVoices = useVoices((s) => s.load);
   const [voiceId, setVoiceId] = useState<string>("");
 
@@ -341,12 +344,33 @@ export default function GeneralChat() {
         <ImagePromptGenerator onGenerate={(prompt) => send(prompt)} />
         <MusicPromptGenerator onGenerate={(prompt) => send(prompt)} />
         <Autocomplete
-          options={voices.map((v) => v.id)}
-          value={voiceId}
-          onChange={(_e, v) => setVoiceId(v || "")}
-          renderInput={(params) => (
-            <TextField {...params} label="Voice" />
+          options={voices}
+          getOptionLabel={(v) => v.id}
+          value={voices.find((v) => v.id === voiceId) || null}
+          onChange={(_e, v) => setVoiceId(v?.id || "")}
+          renderOption={(props, option) => (
+            <Box
+              component="li"
+              {...props}
+              sx={{ display: "flex", justifyContent: "space-between" }}
+            >
+              {option.id}
+              <IconButton
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleFavorite(option.id);
+                }}
+              >
+                {option.favorite ? (
+                  <StarIcon fontSize="small" />
+                ) : (
+                  <StarBorderIcon fontSize="small" />
+                )}
+              </IconButton>
+            </Box>
           )}
+          renderInput={(params) => <TextField {...params} label="Voice" />}
         />
         <Box sx={{ flexGrow: 1, overflowY: "auto", width: "100%" }}>
           {messages.map((m, i) => (


### PR DESCRIPTION
## Summary
- add favorite toggle and filtering to voice store
- expose voice favorites in settings and selectors
- persist voice favorites across reloads

## Testing
- `npm test` *(fails: Maximum update depth exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4e35d0c083258c4890a0b809939e