### PR TITLE
Add debug logging to SFZ path resolver

### DIFF
--- a/src-tauri/python/lofi/renderer.py
+++ b/src-tauri/python/lofi/renderer.py
@@ -345,14 +345,24 @@ class SfzSampler:
 
 def _resolve_sfz_path(p: str) -> Path:
     path = Path(unquote(p))
+    logger.debug({"stage": "sfz_resolve", "original": str(path)})
     if path.is_absolute() and path.exists():
         return path
     root = Path(__file__).resolve().parents[3]
     rel = Path(str(path).lstrip("/\\"))
     candidate = root / rel
+    logger.debug({"stage": "sfz_resolve", "candidate": str(candidate)})
     if candidate.exists():
         return candidate
     alt = root / "public" / rel
+    logger.debug({"stage": "sfz_resolve", "fallback": str(alt)})
+    if not alt.exists():
+        logger.warning({
+            "stage": "sfz_resolve_missing",
+            "original": str(path),
+            "candidate": str(candidate),
+            "fallback": str(alt),
+        })
     return alt
 
 def _sine(freq, ms, amp=0.5):


### PR DESCRIPTION
## Summary
- log original, candidate, and fallback paths when resolving SFZ files
- warn when no SFZ path exists so missing instruments are visible

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae50b5c09c8325962606fe24335ae7