### PR TITLE
feat: persist retro tv media

### DIFF
--- a/src/components/RetroTV.tsx
+++ b/src/components/RetroTV.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useTheme } from "../features/theme/ThemeContext";
+import { useUsers } from "../features/users/useUsers";
 import BouncingIcons from "./BouncingIcons";
 
 interface RetroTVProps {
@@ -8,26 +9,71 @@ interface RetroTVProps {
 
 export default function RetroTV({ children }: RetroTVProps) {
   const { theme } = useTheme();
+  const { currentUserId, users, setRetroTvMedia } = useUsers();
   const [mediaUrl, setMediaUrl] = useState<string | null>(null);
   const [mediaType, setMediaType] = useState<"image" | "video" | null>(null);
+  const [mediaWidth, setMediaWidth] = useState<number | null>(null);
+  const [mediaHeight, setMediaHeight] = useState<number | null>(null);
   const fileInput = useRef<HTMLInputElement>(null);
-
   const handleFileChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    if (mediaUrl) URL.revokeObjectURL(mediaUrl);
-    const url = URL.createObjectURL(file);
-    setMediaUrl(url);
-    setMediaType(file.type.startsWith("video") ? "video" : "image");
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      const result = event.target?.result;
+      if (typeof result !== "string") return;
+      const type = file.type.startsWith("video") ? "video" : "image";
+      setMediaUrl(result);
+      setMediaType(type);
+      if (type === "image") {
+        const img = new Image();
+        img.onload = () => {
+          const width = img.width;
+          const height = img.height;
+          setMediaWidth(width);
+          setMediaHeight(height);
+          setRetroTvMedia({ data: result, type, width, height });
+        };
+        img.src = result;
+      } else {
+        const videoEl = document.createElement("video");
+        videoEl.onloadedmetadata = () => {
+          const width = videoEl.videoWidth;
+          const height = videoEl.videoHeight;
+          setMediaWidth(width);
+          setMediaHeight(height);
+          setRetroTvMedia({ data: result, type, width, height });
+        };
+        videoEl.src = result;
+      }
+    };
+    reader.readAsDataURL(file);
   };
 
   useEffect(() => {
-    return () => {
-      if (mediaUrl) URL.revokeObjectURL(mediaUrl);
-    };
-  }, [mediaUrl]);
+    if (!currentUserId) {
+      setMediaUrl(null);
+      setMediaType(null);
+      setMediaWidth(null);
+      setMediaHeight(null);
+      return;
+    }
+    const stored = users[currentUserId]?.retroTvMedia;
+    if (stored) {
+      setMediaUrl(stored.data);
+      setMediaType(stored.type);
+      setMediaWidth(stored.width);
+      setMediaHeight(stored.height);
+    } else {
+      setMediaUrl(null);
+      setMediaType(null);
+      setMediaWidth(null);
+      setMediaHeight(null);
+    }
+  }, [currentUserId, users]);
 
   if (theme !== "retro") return null;
 

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -37,15 +37,23 @@ const defaultModules: ModulesState = {
   construction: true,
 };
 
-  interface User {
-    id: string;
-    name: string;
-    theme: Theme;
-    money: number;
-    modules: ModulesState;
-    cpuLimit: number;
-    memLimit: number;
-  }
+interface RetroTvMedia {
+  data: string;
+  type: 'image' | 'video';
+  width: number;
+  height: number;
+}
+
+interface User {
+  id: string;
+  name: string;
+  theme: Theme;
+  money: number;
+  modules: ModulesState;
+  cpuLimit: number;
+  memLimit: number;
+  retroTvMedia: RetroTvMedia | null;
+}
 
 interface UsersState {
   users: Record<string, User>;
@@ -56,8 +64,10 @@ interface UsersState {
   setTheme: (theme: Theme) => void;
   toggleModule: (key: ModuleKey) => void;
   setCpuLimit: (limit: number) => void;
-    setMemLimit: (limit: number) => void;
-  }
+  setMemLimit: (limit: number) => void;
+  setRetroTvMedia: (media: RetroTvMedia) => void;
+  clearRetroTvMedia: () => void;
+}
 
 export const useUsers = create<UsersState>()(
   persist(
@@ -78,6 +88,7 @@ export const useUsers = create<UsersState>()(
               modules: { ...defaultModules },
               cpuLimit: 90,
               memLimit: 90,
+              retroTvMedia: null,
             },
           },
           currentUserId: id,
@@ -116,13 +127,13 @@ export const useUsers = create<UsersState>()(
         setCpuLimit: (limit) => {
           const id = get().currentUserId;
           if (!id) return;
-          set((state) => ({
-            users: {
-              ...state.users,
-              [id]: { ...state.users[id], cpuLimit: limit },
-            },
-          }));
-        },
+        set((state) => ({
+          users: {
+            ...state.users,
+            [id]: { ...state.users[id], cpuLimit: limit },
+          },
+        }));
+      },
         setMemLimit: (limit) => {
           const id = get().currentUserId;
           if (!id) return;
@@ -130,6 +141,26 @@ export const useUsers = create<UsersState>()(
             users: {
               ...state.users,
               [id]: { ...state.users[id], memLimit: limit },
+            },
+          }));
+        },
+        setRetroTvMedia: (media) => {
+          const id = get().currentUserId;
+          if (!id) return;
+          set((state) => ({
+            users: {
+              ...state.users,
+              [id]: { ...state.users[id], retroTvMedia: media },
+            },
+          }));
+        },
+        clearRetroTvMedia: () => {
+          const id = get().currentUserId;
+          if (!id) return;
+          set((state) => ({
+            users: {
+              ...state.users,
+              [id]: { ...state.users[id], retroTvMedia: null },
             },
           }));
         },


### PR DESCRIPTION
## Summary
- extend user model with retroTvMedia and setters
- load saved RetroTV media for current user on mount
- persist uploaded RetroTV media as data URLs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae4f8fa6d48325b5c28c4d6a13896a