### PR TITLE
Fix NPC loading and add image uploads

### DIFF
--- a/src/features/dnd/NpcPdfUpload.tsx
+++ b/src/features/dnd/NpcPdfUpload.tsx
@@ -9,9 +9,10 @@ import NpcLog from "./NpcLog";
 
 interface Props {
   world: string;
+  onImported?: (npcs: NpcData[]) => void;
 }
 
-export default function NpcPdfUpload({ world }: Props) {
+export default function NpcPdfUpload({ world, onImported }: Props) {
   const enqueueTask = useTasks((s) => s.enqueueTask);
   const tasks = useTasks((s) => s.tasks);
   const loadNPCs = useNPCs((s) => s.loadNPCs);
@@ -23,6 +24,7 @@ export default function NpcPdfUpload({ world }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [errorCode, setErrorCode] = useState<string | null>(null);
   const [showLog, setShowLog] = useState(false);
+  const [imported, setImported] = useState<NpcData[] | null>(null);
 
   async function handleUpload() {
     const selected = await open({ filters: [{ name: "PDF", extensions: ["pdf"] }] });
@@ -60,7 +62,9 @@ export default function NpcPdfUpload({ world }: Props) {
             });
           }
         }
-        await loadNPCs();
+        await loadNPCs(world);
+        setImported(parsed);
+        onImported?.(parsed);
         setStatus("completed");
         setSnackbarOpen(true);
         setTaskId(null);
@@ -83,7 +87,7 @@ export default function NpcPdfUpload({ world }: Props) {
       setTaskId(null);
       setShowLog(true);
     }
-  }, [taskId, tasks, world, loadNPCs]);
+  }, [taskId, tasks, world, loadNPCs, onImported]);
 
   const task = taskId ? tasks[taskId] : null;
 
@@ -137,7 +141,9 @@ export default function NpcPdfUpload({ world }: Props) {
           sx={{ width: "100%" }}
         >
           {status === "completed"
-            ? "NPCs imported successfully!"
+            ? `NPCs imported successfully: ${
+                imported?.map((n) => n.name).join(", ") ?? ""
+              }`
             : status === "failed"
             ? `Failed to import NPC PDF (${errorCode ?? "unknown"}): ${
                 error ?? ""

--- a/src/features/dnd/tests/NpcPdfUpload.test.tsx
+++ b/src/features/dnd/tests/NpcPdfUpload.test.tsx
@@ -50,8 +50,9 @@ describe("NpcPdfUpload logging", () => {
         world: "w",
         id: "1",
         name: "Bob",
-      }),
+      })
     );
+    expect(loadNPCs).toHaveBeenCalledWith("w");
   });
 
   it("logs failed imports", async () => {

--- a/src/pages/NPCDetail.tsx
+++ b/src/pages/NPCDetail.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import Center from './_Center';
 import { useNPCs } from '../store/npcs';
+import { useWorlds } from '../store/worlds';
 import { generateAudio } from '../features/voice/bark';
 import * as Tone from 'tone';
 
@@ -18,10 +19,11 @@ export default function NPCDetail() {
   const { id } = useParams<{ id: string }>();
   const npcs = useNPCs((s) => s.npcs);
   const loadNPCs = useNPCs((s) => s.loadNPCs);
+  const world = useWorlds((s) => s.currentWorld);
 
   useEffect(() => {
-    loadNPCs();
-  }, [loadNPCs]);
+    if (world) loadNPCs(world);
+  }, [loadNPCs, world]);
 
   const npc = npcs.find((n) => n.id === id);
 

--- a/src/pages/NPCList.tsx
+++ b/src/pages/NPCList.tsx
@@ -12,11 +12,13 @@ import AddIcon from '@mui/icons-material/Add';
 import Center from './_Center';
 import GenerateNPCModal from '../components/GenerateNPCModal';
 import { useNPCs } from '../store/npcs';
+import { useWorlds } from '../store/worlds';
 import { Link } from 'react-router-dom';
 
 export default function NPCList() {
   const npcs = useNPCs((s) => s.npcs);
   const loadNPCs = useNPCs((s) => s.loadNPCs);
+  const world = useWorlds((s) => s.currentWorld);
 
   const [tagFilter, setTagFilter] = useState('');
   const [roleFilter, setRoleFilter] = useState('');
@@ -24,8 +26,8 @@ export default function NPCList() {
   const [modalOpen, setModalOpen] = useState(false);
 
   useEffect(() => {
-    loadNPCs();
-  }, [loadNPCs]);
+    if (world) loadNPCs(world);
+  }, [loadNPCs, world]);
 
   const filtered = useMemo(() => {
     return npcs.filter((n) => {

--- a/src/pages/NPCMaker.tsx
+++ b/src/pages/NPCMaker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { open } from '@tauri-apps/plugin-dialog';
 import { Button, Stack, TextField, Typography, Alert, CircularProgress, Snackbar, FormControlLabel, Checkbox } from '@mui/material';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import ErrorIcon from '@mui/icons-material/Error';
@@ -108,6 +109,16 @@ export default function NPCMaker() {
     setNpc((prev) => ({ ...prev, [field]: value }));
   }
 
+  async function selectImage(field: 'portrait' | 'icon') {
+    const selected = await open({
+      multiple: false,
+      filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp'] }],
+    });
+    if (typeof selected === 'string') {
+      handleChange(field, selected);
+    }
+  }
+
   async function save() {
     setError('');
     const required: (keyof Omit<Npc, 'id'>)[] = [
@@ -115,8 +126,6 @@ export default function NPCMaker() {
       'species',
       'role',
       'backstory',
-      'portrait',
-      'icon',
     ];
     for (const field of required) {
       const value = npc[field];
@@ -124,6 +133,13 @@ export default function NPCMaker() {
         setError('Please fill in all fields before saving.');
         return;
       }
+    }
+    if (
+      npc.portrait === 'placeholder.png' ||
+      npc.icon === 'placeholder-icon.png'
+    ) {
+      setError('Please upload a portrait and icon before saving.');
+      return;
     }
     if (!world) {
       setError('Please select a world before saving.');
@@ -211,18 +227,14 @@ export default function NPCMaker() {
           }
           label="Player Character"
         />
-        <TextField
-          label="Portrait URL"
-          value={npc.portrait}
-          onChange={(e) => handleChange('portrait', e.target.value)}
-          fullWidth
-        />
-        <TextField
-          label="Icon URL"
-          value={npc.icon}
-          onChange={(e) => handleChange('icon', e.target.value)}
-          fullWidth
-        />
+        <Button variant="outlined" onClick={() => selectImage('portrait')}>
+          Upload Portrait
+        </Button>
+        {npc.portrait && <Typography>{npc.portrait}</Typography>}
+        <Button variant="outlined" onClick={() => selectImage('icon')}>
+          Upload Icon
+        </Button>
+        {npc.icon && <Typography>{npc.icon}</Typography>}
         <Button variant="contained" onClick={save} disabled={loading}>
           Save NPC
         </Button>

--- a/src/store/npcs.ts
+++ b/src/store/npcs.ts
@@ -7,7 +7,7 @@ interface NpcState {
   npcs: Npc[];
   addNPC: (npc: Omit<Npc, 'id'>) => void;
   removeNPC: (id: string) => void;
-  loadNPCs: () => Promise<void>;
+  loadNPCs: (world: string) => Promise<void>;
 }
 
 export const useNPCs = create<NpcState>()(
@@ -20,8 +20,8 @@ export const useNPCs = create<NpcState>()(
         })),
       removeNPC: (id) =>
         set((state) => ({ npcs: state.npcs.filter((npc) => npc.id !== id) })),
-      loadNPCs: async () => {
-        const npcs = await invoke<Npc[]>('list_npcs');
+      loadNPCs: async (world: string) => {
+        const npcs = await invoke<Npc[]>('list_npcs', { world });
         set({ npcs });
       },
     }),


### PR DESCRIPTION
## Summary
- scope NPC loading to selected world
- allow uploading portrait and icon files for NPCs
- surface imported NPC details after PDF import

## Testing
- `npm test` *(fails: Maximum update depth exceeded)*
- `cargo check` *(fails: gobject-2.0.pc missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae508dc9c08325a9221b7a52224364