### PR TITLE
Add Bark voice presets and reloadable Voices page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import Transcription from "./pages/Transcription";
 import Construction from "./pages/Construction";
 import Simulation from "./pages/Simulation";
 import BigBrother from "./pages/BigBrother";
+import Voices from "./pages/Voices";
 
 export default function App() {
   const users = useUsers((s) => s.users);
@@ -71,6 +72,7 @@ export default function App() {
         <Route path="/fusion" element={<Fusion />} />
         <Route path="/construction" element={<Construction />} />
         <Route path="/lofi" element={<Lofi />} />
+        <Route path="/voices" element={<Voices />} />
         <Route path="/stocks" element={<Stocks />} />
         <Route path="/shorts" element={<Shorts />} />
         <Route path="/chores" element={<Chores />} />

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useState, useEffect } from "react";
+import { useReducer, useState, useEffect, useMemo } from "react";
 import {
   Typography,
   Button,
@@ -79,7 +79,9 @@ interface Props {
 
 export default function NpcForm({ world }: Props) {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const voices = useVoices((s) => s.voices.filter(s.filter));
+  const allVoices = useVoices((s) => s.voices);
+  const voiceFilter = useVoices((s) => s.filter);
+  const voices = useMemo(() => allVoices.filter(voiceFilter), [allVoices, voiceFilter]);
   const toggleFavorite = useVoices((s) => s.toggleFavorite);
   const loadVoices = useVoices((s) => s.load);
   useEffect(() => {

--- a/src/features/settings/VoiceSettings.tsx
+++ b/src/features/settings/VoiceSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import {
   Box,
   Button,
@@ -12,7 +12,9 @@ import StarBorderIcon from "@mui/icons-material/StarBorder";
 import { useVoices } from "../../store/voices";
 
 export default function VoiceSettings() {
-  const voices = useVoices((s) => s.voices.filter(s.filter));
+  const allVoices = useVoices((s) => s.voices);
+  const voiceFilter = useVoices((s) => s.filter);
+  const voices = useMemo(() => allVoices.filter(voiceFilter), [allVoices, voiceFilter]);
   const addVoice = useVoices((s) => s.addVoice);
   const removeVoice = useVoices((s) => s.removeVoice);
   const setTags = useVoices((s) => s.setTags);

--- a/src/features/voice/fetchVoices.ts
+++ b/src/features/voice/fetchVoices.ts
@@ -1,0 +1,23 @@
+import presets from "./presets.json";
+
+/**
+ * Retrieve available Bark preset identifiers.
+ * Attempts to fetch from Bark's online presets list, falling back to
+ * a static JSON bundle when offline.
+ */
+export async function fetchVoices(): Promise<string[]> {
+  try {
+    const res = await fetch(
+      "https://huggingface.co/suno/bark/raw/main/assets/presets.json"
+    );
+    if (res.ok) {
+      const data = (await res.json()) as Record<string, unknown>;
+      return Object.keys(data);
+    }
+  } catch {
+    // ignore network errors and fall back to static list
+  }
+  return presets;
+}
+
+export default fetchVoices;

--- a/src/features/voice/presets.json
+++ b/src/features/voice/presets.json
@@ -1,0 +1,12 @@
+[
+  "v2/en_speaker_0",
+  "v2/en_speaker_1",
+  "v2/en_speaker_2",
+  "v2/en_speaker_3",
+  "v2/en_speaker_4",
+  "v2/en_speaker_5",
+  "v2/en_speaker_6",
+  "v2/en_speaker_7",
+  "v2/en_speaker_8",
+  "v2/en_speaker_9"
+]

--- a/src/pages/GeneralChat.tsx
+++ b/src/pages/GeneralChat.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useTasks } from "../store/tasks";
 import { listen } from "@tauri-apps/api/event";
@@ -52,7 +52,9 @@ export default function GeneralChat() {
   const [error, setError] = useState<string>("");
   const [logs, setLogs] = useState<string[]>([]);
   const enqueueTask = useTasks((s) => s.enqueueTask);
-  const voices = useVoices((s) => s.voices.filter(s.filter));
+  const allVoices = useVoices((s) => s.voices);
+  const voiceFilter = useVoices((s) => s.filter);
+  const voices = useMemo(() => allVoices.filter(voiceFilter), [allVoices, voiceFilter]);
   const toggleFavorite = useVoices((s) => s.toggleFavorite);
   const loadVoices = useVoices((s) => s.load);
   const [voiceId, setVoiceId] = useState<string>("");

--- a/src/pages/Voices.tsx
+++ b/src/pages/Voices.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { Box, Button, List, ListItem, ListItemText } from "@mui/material";
+import { useShallow } from "zustand/react/shallow";
+import { useVoices } from "../store/voices";
+
+export default function Voices() {
+  const { voices, fetchVoices } = useVoices(
+    useShallow((s) => ({ voices: s.voices, fetchVoices: s.fetchVoices }))
+  );
+
+  useEffect(() => {
+    if (!voices.length) fetchVoices();
+  }, [voices.length, fetchVoices]);
+
+  return (
+    <Box sx={{ p: 2, color: "#fff" }}>
+      <Button variant="contained" onClick={() => fetchVoices()} sx={{ mb: 2 }}>
+        Reload
+      </Button>
+      <List>
+        {voices.map((v) => (
+          <ListItem key={v.id}>
+            <ListItemText primary={v.preset} secondary={v.provider} />
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+}

--- a/src/store/voices.ts
+++ b/src/store/voices.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { saveState, loadState } from "../utils/persist";
+import { fetchVoices as fetchBarkPresets } from "../features/voice/fetchVoices";
 
 export interface Voice {
   id: string;
@@ -12,6 +13,7 @@ export interface Voice {
 interface VoiceState {
   voices: Voice[];
   filter: (v: Voice) => boolean;
+  fetchVoices: () => Promise<void>;
   addVoice: (voice: Voice) => Promise<void>;
   removeVoice: (id: string) => Promise<void>;
   setTags: (id: string, tags: string[]) => Promise<void>;
@@ -25,6 +27,18 @@ const STORAGE_KEY = "voices";
 export const useVoices = create<VoiceState>((set, get) => ({
   voices: [],
   filter: () => true,
+  fetchVoices: async () => {
+    const presets = await fetchBarkPresets();
+    const voices = presets.map((preset) => ({
+      id: `bark-${preset}`,
+      provider: "bark",
+      preset,
+      tags: [],
+      favorite: false,
+    }));
+    set({ voices });
+    await saveState(STORAGE_KEY, voices);
+  },
   addVoice: async (voice) => {
     const withFavorite: Voice = { favorite: false, ...voice };
     const existing = get().voices.filter((v) => v.id !== withFavorite.id);
@@ -52,17 +66,14 @@ export const useVoices = create<VoiceState>((set, get) => ({
   setFilter: (fn) => set({ filter: fn }),
   load: async () => {
     const voices = await loadState<Voice[]>(STORAGE_KEY);
-    if (voices)
+    if (voices && voices.length) {
       set({ voices: voices.map((v) => ({ favorite: false, ...v })) });
+    } else if (process.env.NODE_ENV !== "test") {
+      await get().fetchVoices();
+    }
   },
 }));
 
-loadState<Voice[]>(STORAGE_KEY).then((voices) => {
-  if (voices)
-    useVoices.setState(
-      { voices: voices.map((v) => ({ favorite: false, ...v })) },
-      true
-    );
-});
+
 
 export type { VoiceState };


### PR DESCRIPTION
## Summary
- fetch Bark voice preset IDs with online fallback
- populate voice store from presets and allow reloading
- add Voices page with reload button and routing

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68ae50a9e66c832584ef94b62f344a5a