### PR TITLE
Log song spec before generation

### DIFF
--- a/src-tauri/python/lofi/renderer.py
+++ b/src-tauri/python/lofi/renderer.py
@@ -1732,6 +1732,7 @@ def main():
         INSTRUMENTS_DATA = _load_instruments(args.instruments_file)
 
     spec = json.loads(args.song_json)
+    logger.info({"stage": "spec", "spec": spec})
     album = spec.get("album")
 
     logger.info({"stage": "generate", "message": "building sections"})


### PR DESCRIPTION
## Summary
- log the full song spec before starting rendering so the UI can see configuration details

## Testing
- `pytest src-tauri/python/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae537ab9048325aa2da5bc95131ef5