### PR TITLE
feat(chat): filter voice selector and show favorites

### DIFF
--- a/src/pages/GeneralChat.tsx
+++ b/src/pages/GeneralChat.tsx
@@ -52,10 +52,15 @@ export default function GeneralChat() {
   const [error, setError] = useState<string>("");
   const [logs, setLogs] = useState<string[]>([]);
   const enqueueTask = useTasks((s) => s.enqueueTask);
-  const voices = useVoices((s) => s.voices.filter(s.filter));
+  const allVoices = useVoices((s) => s.voices);
+  const voiceFilter = useVoices((s) => s.filter);
   const toggleFavorite = useVoices((s) => s.toggleFavorite);
   const loadVoices = useVoices((s) => s.load);
   const [voiceId, setVoiceId] = useState<string>("");
+  const [favoriteOnly, setFavoriteOnly] = useState(false);
+  const voices = allVoices
+    .filter(voiceFilter)
+    .filter((v) => !favoriteOnly || v.favorite);
 
   useEffect(() => {
     loadVoices();
@@ -343,35 +348,43 @@ export default function GeneralChat() {
       <Stack spacing={2} sx={{ p: 2, flexGrow: 1, width: "100%", maxWidth: 600, mx: "auto" }}>
         <ImagePromptGenerator onGenerate={(prompt) => send(prompt)} />
         <MusicPromptGenerator onGenerate={(prompt) => send(prompt)} />
-        <Autocomplete
-          options={voices}
-          getOptionLabel={(v) => v.id}
-          value={voices.find((v) => v.id === voiceId) || null}
-          onChange={(_e, v) => setVoiceId(v?.id || "")}
-          renderOption={(props, option) => (
-            <Box
-              component="li"
-              {...props}
-              sx={{ display: "flex", justifyContent: "space-between" }}
-            >
-              {option.id}
-              <IconButton
-                size="small"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  toggleFavorite(option.id);
-                }}
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Autocomplete
+            options={voices}
+            getOptionLabel={(v) => v.id}
+            value={voices.find((v) => v.id === voiceId) || null}
+            onChange={(_e, v) => setVoiceId(v?.id || "")}
+            renderOption={(props, option) => (
+              <Box
+                component="li"
+                {...props}
+                sx={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}
               >
-                {option.favorite ? (
-                  <StarIcon fontSize="small" />
-                ) : (
-                  <StarBorderIcon fontSize="small" />
-                )}
-              </IconButton>
-            </Box>
-          )}
-          renderInput={(params) => <TextField {...params} label="Voice" />}
-        />
+                {option.id}
+                <IconButton
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleFavorite(option.id);
+                  }}
+                >
+                  {option.favorite ? (
+                    <StarIcon fontSize="small" color="warning" />
+                  ) : (
+                    <StarBorderIcon fontSize="small" />
+                  )}
+                </IconButton>
+              </Box>
+            )}
+            renderInput={(params) => <TextField {...params} label="Voice" />}
+          />
+          <IconButton
+            onClick={() => setFavoriteOnly((prev) => !prev)}
+            color={favoriteOnly ? "primary" : "default"}
+          >
+            {favoriteOnly ? <StarIcon /> : <StarBorderIcon />}
+          </IconButton>
+        </Stack>
         <Box sx={{ flexGrow: 1, overflowY: "auto", width: "100%" }}>
           {messages.map((m, i) => (
             <Box


### PR DESCRIPTION
## Summary
- filter voice options using `useVoices` with optional favorites-only view
- show a star indicator for favorite voices and add toggle to view only favorites

## Testing
- `npm test` *(fails: Maximum update depth exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68ae538855f88325a1ae1f778b37fd89