### PR TITLE
Expose parsed NPC data and auto-fill form fields

### DIFF
--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -91,6 +91,7 @@ export default function NpcForm({ world }: Props) {
   const voiceOptions = voices;
   const [errors, setErrors] = useState<Record<string, string | null>>({});
   const [result, setResult] = useState<NpcData | null>(null);
+  const [importedName, setImportedName] = useState<string | null>(null);
 
   const selectFile = async (field: "portrait" | "icon") => {
     const selected = await open({
@@ -176,9 +177,10 @@ export default function NpcForm({ world }: Props) {
             <Grid item xs={8}>
               <NpcPdfUpload
                 world={world}
-                onImported={(npcs) => {
+                onParsed={(npcs) => {
                   const npc = npcs[0];
                   if (!npc) return;
+                  setImportedName(npc.name);
                   dispatch({ type: "SET_FIELD", field: "name", value: npc.name });
                   dispatch({ type: "SET_FIELD", field: "species", value: npc.species });
                   dispatch({ type: "SET_FIELD", field: "role", value: npc.role });
@@ -204,6 +206,9 @@ export default function NpcForm({ world }: Props) {
                   dispatch({ type: "SET_FIELD", field: "voiceId", value: npc.voiceId || "" });
                 }}
               />
+              {importedName && (
+                <Typography sx={{ mt: 1 }}>Imported: {importedName}</Typography>
+              )}
             </Grid>
             <Grid item xs={4}>
               <Typography component="label" htmlFor="name">

--- a/src/features/dnd/NpcPdfUpload.tsx
+++ b/src/features/dnd/NpcPdfUpload.tsx
@@ -9,10 +9,10 @@ import NpcLog from "./NpcLog";
 
 interface Props {
   world: string;
-  onImported?: (npcs: NpcData[]) => void;
+  onParsed?: (npcs: NpcData[]) => void;
 }
 
-export default function NpcPdfUpload({ world, onImported }: Props) {
+export default function NpcPdfUpload({ world, onParsed }: Props) {
   const enqueueTask = useTasks((s) => s.enqueueTask);
   const tasks = useTasks((s) => s.tasks);
   const loadNPCs = useNPCs((s) => s.loadNPCs);
@@ -43,6 +43,7 @@ export default function NpcPdfUpload({ world, onImported }: Props) {
     const task = tasks[taskId];
     if (task && task.status === "completed" && Array.isArray(task.result)) {
       const parsed = task.result as NpcData[];
+      onParsed?.(parsed);
       (async () => {
         const existing = await invoke<NpcData[]>("list_npcs", { world });
         for (const npc of parsed) {
@@ -53,7 +54,7 @@ export default function NpcPdfUpload({ world, onImported }: Props) {
           if (dup) {
             overwrite = window.confirm(`NPC ${npc.name} exists. Overwrite?`);
           }
-            if (overwrite) {
+          if (overwrite) {
             await invoke("save_npc", { world, npc, overwrite });
             await invoke("append_npc_log", {
               world,
@@ -64,7 +65,6 @@ export default function NpcPdfUpload({ world, onImported }: Props) {
         }
         await loadNPCs(world);
         setImported(parsed);
-        onImported?.(parsed);
         setStatus("completed");
         setSnackbarOpen(true);
         setTaskId(null);
@@ -87,7 +87,7 @@ export default function NpcPdfUpload({ world, onImported }: Props) {
       setTaskId(null);
       setShowLog(true);
     }
-  }, [taskId, tasks, world, loadNPCs, onImported]);
+  }, [taskId, tasks, world, loadNPCs, onParsed]);
 
   const task = taskId ? tasks[taskId] : null;
 

--- a/src/features/dnd/tests/NpcPdfUpload.test.tsx
+++ b/src/features/dnd/tests/NpcPdfUpload.test.tsx
@@ -77,4 +77,23 @@ describe("NpcPdfUpload logging", () => {
       }),
     );
   });
+
+  it("exposes parsed NPC data via callback", async () => {
+    tasksState.tasks = {
+      1: { status: "completed", result: [{ id: "1", name: "Bob" }] },
+    };
+    (invoke as any).mockImplementation((cmd: string) => {
+      if (cmd === "list_npcs") return Promise.resolve([]);
+      if (cmd === "read_npc_log") return Promise.resolve([]);
+      return Promise.resolve();
+    });
+
+    const cb = vi.fn();
+    render(<NpcPdfUpload world="w" onParsed={cb} />);
+    fireEvent.click(screen.getByText(/upload npc pdf/i));
+
+    await waitFor(() =>
+      expect(cb).toHaveBeenCalledWith([{ id: "1", name: "Bob" }])
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add `onParsed` callback to `NpcPdfUpload` to expose parsed NPC data
- auto-fill NPC form fields and show imported NPC name after PDF import
- test `onParsed` callback invocation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae57b047a483259a5dd896b66417e5