### PR TITLE
Add favorites-only voice filter and indicators

### DIFF
--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -84,6 +84,8 @@ export default function NpcForm({ world }: Props) {
   const voiceFilter = useVoices((s) => s.filter);
   const voices = useMemo(() => allVoices.filter(voiceFilter), [allVoices, voiceFilter]);
   const toggleFavorite = useVoices((s) => s.toggleFavorite);
+  const favoritesOnly = useVoices((s) => s.showFavoritesOnly);
+  const toggleFavoritesOnly = useVoices((s) => s.toggleFavoritesOnly);
   const loadVoices = useVoices((s) => s.load);
   useEffect(() => {
     loadVoices();
@@ -482,58 +484,72 @@ export default function NpcForm({ world }: Props) {
                   </Typography>
                 </Grid>
                 <Grid item xs={8}>
-                  <Autocomplete
-                    options={voiceOptions}
-                    getOptionLabel={(v) => v.id}
-                    value={voiceOptions.find((v) => v.id === state.voiceId) || null}
-                    onChange={(_e, v) => {
-                      dispatch({
-                        type: "SET_FIELD",
-                        field: "voiceId",
-                        value: v?.id || "",
-                      });
-                      setErrors((prev) => ({ ...prev, voiceId: null }));
-                    }}
-                    renderOption={(props, option) => (
-                      <Box
-                        component="li"
-                        {...props}
-                        sx={{ display: "flex", justifyContent: "space-between" }}
-                      >
-                        {option.id}
-                        <IconButton
-                          size="small"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            toggleFavorite(option.id);
+                  <Box sx={{ display: "flex", alignItems: "center" }}>
+                    <Autocomplete
+                      options={voiceOptions}
+                      getOptionLabel={(v) => v.id}
+                      value={
+                        voiceOptions.find((v) => v.id === state.voiceId) || null
+                      }
+                      onChange={(_e, v) => {
+                        dispatch({
+                          type: "SET_FIELD",
+                          field: "voiceId",
+                          value: v?.id || "",
+                        });
+                        setErrors((prev) => ({ ...prev, voiceId: null }));
+                      }}
+                      renderOption={(props, option) => (
+                        <Box
+                          component="li"
+                          {...props}
+                          sx={{
+                            display: "flex",
+                            justifyContent: "space-between",
                           }}
                         >
-                          {option.favorite ? (
-                            <StarIcon fontSize="small" />
-                          ) : (
-                            <StarBorderIcon fontSize="small" />
-                          )}
-                        </IconButton>
-                      </Box>
-                    )}
-                    renderInput={(params) => (
-                      <StyledTextField
-                        {...params}
-                        id="voiceId"
-                        margin="normal"
-                        error={Boolean(errors.voiceId)}
-                        helperText={
-                          <FormErrorText id="voiceId-error">
-                            {errors.voiceId}
-                          </FormErrorText>
-                        }
-                        aria-describedby={
-                          errors.voiceId ? "voiceId-error" : undefined
-                        }
-                      />
-                    )}
-                    fullWidth
-                  />
+                          {option.id}
+                          <IconButton
+                            size="small"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              toggleFavorite(option.id);
+                            }}
+                          >
+                            {option.favorite ? (
+                              <StarIcon fontSize="small" />
+                            ) : (
+                              <StarBorderIcon fontSize="small" />
+                            )}
+                          </IconButton>
+                        </Box>
+                      )}
+                      renderInput={(params) => (
+                        <StyledTextField
+                          {...params}
+                          id="voiceId"
+                          margin="normal"
+                          error={Boolean(errors.voiceId)}
+                          helperText={
+                            <FormErrorText id="voiceId-error">
+                              {errors.voiceId}
+                            </FormErrorText>
+                          }
+                          aria-describedby={
+                            errors.voiceId ? "voiceId-error" : undefined
+                          }
+                        />
+                      )}
+                      fullWidth
+                    />
+                    <Checkbox
+                      icon={<StarBorderIcon />}
+                      checkedIcon={<StarIcon />}
+                      checked={favoritesOnly}
+                      onChange={toggleFavoritesOnly}
+                      sx={{ ml: 1 }}
+                    />
+                  </Box>
                 </Grid>
               </Grid>
             </AccordionDetails>

--- a/src/features/settings/VoiceSettings.tsx
+++ b/src/features/settings/VoiceSettings.tsx
@@ -6,6 +6,8 @@ import {
   TextField,
   Typography,
   IconButton,
+  Checkbox,
+  FormControlLabel,
 } from "@mui/material";
 import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
@@ -19,6 +21,8 @@ export default function VoiceSettings() {
   const removeVoice = useVoices((s) => s.removeVoice);
   const setTags = useVoices((s) => s.setTags);
   const toggleFavorite = useVoices((s) => s.toggleFavorite);
+  const favoritesOnly = useVoices((s) => s.showFavoritesOnly);
+  const toggleFavoritesOnly = useVoices((s) => s.toggleFavoritesOnly);
   const load = useVoices((s) => s.load);
 
   useEffect(() => {
@@ -60,7 +64,20 @@ export default function VoiceSettings() {
 
   return (
     <Box id="voice-settings">
-      <Typography variant="subtitle1">Bark Voices</Typography>
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <Typography variant="subtitle1">Bark Voices</Typography>
+        <FormControlLabel
+          control={
+            <Checkbox
+              icon={<StarBorderIcon />}
+              checkedIcon={<StarIcon />}
+              checked={favoritesOnly}
+              onChange={toggleFavoritesOnly}
+            />
+          }
+          label="Favorites only"
+        />
+      </Stack>
       <Stack spacing={2} sx={{ mt: 2 }}>
         {voices.map((v) => (
           <Stack key={v.id} direction="row" spacing={1} alignItems="center">

--- a/src/pages/GeneralChat.tsx
+++ b/src/pages/GeneralChat.tsx
@@ -11,6 +11,7 @@ import {
   TextField,
   Typography,
   Autocomplete,
+  Checkbox,
 } from "@mui/material";
 import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
@@ -56,6 +57,8 @@ export default function GeneralChat() {
   const voiceFilter = useVoices((s) => s.filter);
   const voices = useMemo(() => allVoices.filter(voiceFilter), [allVoices, voiceFilter]);
   const toggleFavorite = useVoices((s) => s.toggleFavorite);
+  const favoritesOnly = useVoices((s) => s.showFavoritesOnly);
+  const toggleFavoritesOnly = useVoices((s) => s.toggleFavoritesOnly);
   const loadVoices = useVoices((s) => s.load);
   const [voiceId, setVoiceId] = useState<string>("");
 
@@ -345,35 +348,45 @@ export default function GeneralChat() {
       <Stack spacing={2} sx={{ p: 2, flexGrow: 1, width: "100%", maxWidth: 600, mx: "auto" }}>
         <ImagePromptGenerator onGenerate={(prompt) => send(prompt)} />
         <MusicPromptGenerator onGenerate={(prompt) => send(prompt)} />
-        <Autocomplete
-          options={voices}
-          getOptionLabel={(v) => v.id}
-          value={voices.find((v) => v.id === voiceId) || null}
-          onChange={(_e, v) => setVoiceId(v?.id || "")}
-          renderOption={(props, option) => (
-            <Box
-              component="li"
-              {...props}
-              sx={{ display: "flex", justifyContent: "space-between" }}
-            >
-              {option.id}
-              <IconButton
-                size="small"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  toggleFavorite(option.id);
-                }}
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <Autocomplete
+            options={voices}
+            getOptionLabel={(v) => v.id}
+            value={voices.find((v) => v.id === voiceId) || null}
+            onChange={(_e, v) => setVoiceId(v?.id || "")}
+            renderOption={(props, option) => (
+              <Box
+                component="li"
+                {...props}
+                sx={{ display: "flex", justifyContent: "space-between" }}
               >
-                {option.favorite ? (
-                  <StarIcon fontSize="small" />
-                ) : (
-                  <StarBorderIcon fontSize="small" />
-                )}
-              </IconButton>
-            </Box>
-          )}
-          renderInput={(params) => <TextField {...params} label="Voice" />}
-        />
+                {option.id}
+                <IconButton
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggleFavorite(option.id);
+                  }}
+                >
+                  {option.favorite ? (
+                    <StarIcon fontSize="small" />
+                  ) : (
+                    <StarBorderIcon fontSize="small" />
+                  )}
+                </IconButton>
+              </Box>
+            )}
+            renderInput={(params) => <TextField {...params} label="Voice" />}
+            sx={{ flexGrow: 1 }}
+          />
+          <Checkbox
+            icon={<StarBorderIcon />}
+            checkedIcon={<StarIcon />}
+            checked={favoritesOnly}
+            onChange={toggleFavoritesOnly}
+            sx={{ ml: 1 }}
+          />
+        </Box>
         <Box sx={{ flexGrow: 1, overflowY: "auto", width: "100%" }}>
           {messages.map((m, i) => (
             <Box

--- a/src/pages/Voices.tsx
+++ b/src/pages/Voices.tsx
@@ -1,25 +1,58 @@
-import { useEffect } from "react";
-import { Box, Button, List, ListItem, ListItemText } from "@mui/material";
-import { useShallow } from "zustand/react/shallow";
+import { useEffect, useMemo } from "react";
+import {
+  Box,
+  Button,
+  List,
+  ListItem,
+  ListItemText,
+  IconButton,
+  Checkbox,
+  FormControlLabel,
+} from "@mui/material";
+import StarIcon from "@mui/icons-material/Star";
+import StarBorderIcon from "@mui/icons-material/StarBorder";
 import { useVoices } from "../store/voices";
 
 export default function Voices() {
-  const { voices, fetchVoices } = useVoices(
-    useShallow((s) => ({ voices: s.voices, fetchVoices: s.fetchVoices }))
-  );
+  const allVoices = useVoices((s) => s.voices);
+  const voiceFilter = useVoices((s) => s.filter);
+  const voices = useMemo(() => allVoices.filter(voiceFilter), [allVoices, voiceFilter]);
+  const fetchVoices = useVoices((s) => s.fetchVoices);
+  const toggleFavorite = useVoices((s) => s.toggleFavorite);
+  const favoritesOnly = useVoices((s) => s.showFavoritesOnly);
+  const toggleFavoritesOnly = useVoices((s) => s.toggleFavoritesOnly);
 
   useEffect(() => {
-    if (!voices.length) fetchVoices();
-  }, [voices.length, fetchVoices]);
+    if (!allVoices.length) fetchVoices();
+  }, [allVoices.length, fetchVoices]);
 
   return (
     <Box sx={{ p: 2, color: "#fff" }}>
       <Button variant="contained" onClick={() => fetchVoices()} sx={{ mb: 2 }}>
         Reload
       </Button>
+      <FormControlLabel
+        control={
+          <Checkbox
+            icon={<StarBorderIcon />}
+            checkedIcon={<StarIcon />}
+            checked={favoritesOnly}
+            onChange={toggleFavoritesOnly}
+          />
+        }
+        label="Favorites only"
+        sx={{ mb: 2 }}
+      />
       <List>
         {voices.map((v) => (
-          <ListItem key={v.id}>
+          <ListItem
+            key={v.id}
+            secondaryAction={
+              <IconButton edge="end" onClick={() => toggleFavorite(v.id)}>
+                {v.favorite ? <StarIcon /> : <StarBorderIcon />}
+              </IconButton>
+            }
+          >
             <ListItemText primary={v.preset} secondary={v.provider} />
           </ListItem>
         ))}

--- a/src/store/voices.ts
+++ b/src/store/voices.ts
@@ -13,12 +13,14 @@ export interface Voice {
 interface VoiceState {
   voices: Voice[];
   filter: (v: Voice) => boolean;
+  showFavoritesOnly: boolean;
   fetchVoices: () => Promise<void>;
   addVoice: (voice: Voice) => Promise<void>;
   removeVoice: (id: string) => Promise<void>;
   setTags: (id: string, tags: string[]) => Promise<void>;
   toggleFavorite: (id: string) => Promise<void>;
   setFilter: (fn: (v: Voice) => boolean) => void;
+  toggleFavoritesOnly: () => void;
   load: () => Promise<void>;
 }
 
@@ -27,6 +29,7 @@ const STORAGE_KEY = "voices";
 export const useVoices = create<VoiceState>((set, get) => ({
   voices: [],
   filter: () => true,
+  showFavoritesOnly: false,
   fetchVoices: async () => {
     const presets = await fetchBarkPresets();
     const voices = presets.map((preset) => ({
@@ -64,6 +67,14 @@ export const useVoices = create<VoiceState>((set, get) => ({
     await saveState(STORAGE_KEY, voices);
   },
   setFilter: (fn) => set({ filter: fn }),
+  toggleFavoritesOnly: () =>
+    set((state) => {
+      const showFavoritesOnly = !state.showFavoritesOnly;
+      return {
+        showFavoritesOnly,
+        filter: showFavoritesOnly ? (v: Voice) => v.favorite : () => true,
+      };
+    }),
   load: async () => {
     const voices = await loadState<Voice[]>(STORAGE_KEY);
     if (voices && voices.length) {


### PR DESCRIPTION
## Summary
- allow toggling to show only favorite voices
- display star icons on voice options and add favorite-only checkbox in voice-related UIs

## Testing
- `npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68ae5792104c832598252a78ccdb1ed8