### PR TITLE
Add favorite-only voice filters

### DIFF
--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -3,6 +3,7 @@ import {
   Typography,
   Button,
   Checkbox,
+  FormControlLabel,
   Grid,
   Box,
   Divider,
@@ -82,7 +83,14 @@ export default function NpcForm({ world }: Props) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const allVoices = useVoices((s) => s.voices);
   const voiceFilter = useVoices((s) => s.filter);
-  const voices = useMemo(() => allVoices.filter(voiceFilter), [allVoices, voiceFilter]);
+  const [favoriteOnly, setFavoriteOnly] = useState(false);
+  const voices = useMemo(
+    () =>
+      allVoices
+        .filter(voiceFilter)
+        .filter((v) => !favoriteOnly || v.favorite),
+    [allVoices, voiceFilter, favoriteOnly]
+  );
   const toggleFavorite = useVoices((s) => s.toggleFavorite);
   const loadVoices = useVoices((s) => s.load);
   useEffect(() => {
@@ -487,6 +495,15 @@ export default function NpcForm({ world }: Props) {
                   </Typography>
                 </Grid>
                 <Grid item xs={8}>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={favoriteOnly}
+                        onChange={(e) => setFavoriteOnly(e.target.checked)}
+                      />
+                    }
+                    label="Favorites"
+                  />
                   <Autocomplete
                     options={voiceOptions}
                     getOptionLabel={(v) => v.id}

--- a/src/features/settings/VoiceSettings.tsx
+++ b/src/features/settings/VoiceSettings.tsx
@@ -6,6 +6,8 @@ import {
   TextField,
   Typography,
   IconButton,
+  FormControlLabel,
+  Checkbox,
 } from "@mui/material";
 import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
@@ -14,7 +16,14 @@ import { useVoices } from "../../store/voices";
 export default function VoiceSettings() {
   const allVoices = useVoices((s) => s.voices);
   const voiceFilter = useVoices((s) => s.filter);
-  const voices = useMemo(() => allVoices.filter(voiceFilter), [allVoices, voiceFilter]);
+  const [favoriteOnly, setFavoriteOnly] = useState(false);
+  const voices = useMemo(
+    () =>
+      allVoices
+        .filter(voiceFilter)
+        .filter((v) => !favoriteOnly || v.favorite),
+    [allVoices, voiceFilter, favoriteOnly]
+  );
   const addVoice = useVoices((s) => s.addVoice);
   const removeVoice = useVoices((s) => s.removeVoice);
   const setTags = useVoices((s) => s.setTags);
@@ -61,6 +70,15 @@ export default function VoiceSettings() {
   return (
     <Box id="voice-settings">
       <Typography variant="subtitle1">Bark Voices</Typography>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={favoriteOnly}
+            onChange={(e) => setFavoriteOnly(e.target.checked)}
+          />
+        }
+        label="Favorites"
+      />
       <Stack spacing={2} sx={{ mt: 2 }}>
         {voices.map((v) => (
           <Stack key={v.id} direction="row" spacing={1} alignItems="center">

--- a/src/pages/GeneralChat.tsx
+++ b/src/pages/GeneralChat.tsx
@@ -11,6 +11,8 @@ import {
   TextField,
   Typography,
   Autocomplete,
+  FormControlLabel,
+  Checkbox,
 } from "@mui/material";
 import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
@@ -54,7 +56,14 @@ export default function GeneralChat() {
   const enqueueTask = useTasks((s) => s.enqueueTask);
   const allVoices = useVoices((s) => s.voices);
   const voiceFilter = useVoices((s) => s.filter);
-  const voices = useMemo(() => allVoices.filter(voiceFilter), [allVoices, voiceFilter]);
+  const [favoriteOnly, setFavoriteOnly] = useState(false);
+  const voices = useMemo(
+    () =>
+      allVoices
+        .filter(voiceFilter)
+        .filter((v) => !favoriteOnly || v.favorite),
+    [allVoices, voiceFilter, favoriteOnly]
+  );
   const toggleFavorite = useVoices((s) => s.toggleFavorite);
   const loadVoices = useVoices((s) => s.load);
   const [voiceId, setVoiceId] = useState<string>("");
@@ -345,6 +354,15 @@ export default function GeneralChat() {
       <Stack spacing={2} sx={{ p: 2, flexGrow: 1, width: "100%", maxWidth: 600, mx: "auto" }}>
         <ImagePromptGenerator onGenerate={(prompt) => send(prompt)} />
         <MusicPromptGenerator onGenerate={(prompt) => send(prompt)} />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={favoriteOnly}
+              onChange={(e) => setFavoriteOnly(e.target.checked)}
+            />
+          }
+          label="Favorites"
+        />
         <Autocomplete
           options={voices}
           getOptionLabel={(v) => v.id}


### PR DESCRIPTION
## Summary
- allow filtering voice lists to favorites
- add favorite-only checkbox to voice UIs

## Testing
- `npm test` *(fails: ReferenceError window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ae63e7560483259eff863117bf41f2