### PR TITLE
Add retro TV media setter

### DIFF
--- a/src/components/RetroTV.tsx
+++ b/src/components/RetroTV.tsx
@@ -32,12 +32,7 @@ export default function RetroTV({ children }: RetroTVProps) {
         setMediaWidth(width);
         setMediaHeight(height);
         if (currentUserId) {
-          setRetroTvMedia({
-            data: result,
-            type: isVideo ? "video" : "image",
-            width,
-            height,
-          });
+          setRetroTvMedia(result);
         }
       };
 
@@ -62,10 +57,31 @@ export default function RetroTV({ children }: RetroTVProps) {
     if (!currentUserId) return;
     const media = users[currentUserId]?.retroTvMedia;
     if (media) {
-      setMediaUrl(media.data);
-      setMediaType(media.type);
-      setMediaWidth(media.width);
-      setMediaHeight(media.height);
+      setMediaUrl(media);
+      const isVideo = media.startsWith("data:video");
+      setMediaType(isVideo ? "video" : "image");
+      if (isVideo) {
+        const video = document.createElement("video");
+        video.src = media;
+        video.addEventListener(
+          "loadedmetadata",
+          () => {
+            setMediaWidth(video.videoWidth);
+            setMediaHeight(video.videoHeight);
+          },
+          { once: true }
+        );
+      } else {
+        const img = new Image();
+        img.src = media;
+        img.onload = () => {
+          setMediaWidth(img.width);
+          setMediaHeight(img.height);
+        };
+      }
+    } else {
+      setMediaUrl(null);
+      setMediaType(null);
     }
   }, [currentUserId, users]);
 

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -37,13 +37,6 @@ const defaultModules: ModulesState = {
   construction: true,
 };
 
-interface RetroTvMedia {
-  data: string;
-  type: 'image' | 'video';
-  width: number;
-  height: number;
-}
-
 interface User {
   id: string;
   name: string;
@@ -52,7 +45,7 @@ interface User {
   modules: ModulesState;
   cpuLimit: number;
   memLimit: number;
-  retroTvMedia: RetroTvMedia | null;
+  retroTvMedia: string | null;
 }
 
 interface UsersState {
@@ -65,8 +58,7 @@ interface UsersState {
   toggleModule: (key: ModuleKey) => void;
   setCpuLimit: (limit: number) => void;
   setMemLimit: (limit: number) => void;
-  setRetroTvMedia: (media: RetroTvMedia) => void;
-  clearRetroTvMedia: () => void;
+  setRetroTvMedia: (dataUrl: string | null) => void;
 }
 
 export const useUsers = create<UsersState>()(
@@ -144,23 +136,13 @@ export const useUsers = create<UsersState>()(
             },
           }));
         },
-        setRetroTvMedia: (media) => {
+        setRetroTvMedia: (dataUrl) => {
           const id = get().currentUserId;
           if (!id) return;
           set((state) => ({
             users: {
               ...state.users,
-              [id]: { ...state.users[id], retroTvMedia: media },
-            },
-          }));
-        },
-        clearRetroTvMedia: () => {
-          const id = get().currentUserId;
-          if (!id) return;
-          set((state) => ({
-            users: {
-              ...state.users,
-              [id]: { ...state.users[id], retroTvMedia: null },
+              [id]: { ...state.users[id], retroTvMedia: dataUrl },
             },
           }));
         },
@@ -169,4 +151,7 @@ export const useUsers = create<UsersState>()(
     )
   );
 
-export { type ModuleKey, type ModulesState, defaultModules, type RetroTvMedia };
+export const setRetroTvMedia = (dataUrl: string | null) =>
+  useUsers.getState().setRetroTvMedia(dataUrl);
+
+export { type ModuleKey, type ModulesState, defaultModules };


### PR DESCRIPTION
## Summary
- store retro TV media as a simple data URL
- expose a `setRetroTvMedia` action for updating or clearing stored media
- update RetroTV component to use new media format

## Testing
- `npm test` *(fails: TypeError: Right-hand side of 'instanceof' is not an object)*

------
https://chatgpt.com/codex/tasks/task_e_68ae57ca164c8325ad1aabdfa9a35ece