### PR TITLE
Include sfz soundbank in Tauri bundle resources

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -35,6 +35,7 @@
       "icons/icon.ico"
     ],
     "resources": [
+      "../public/sfz_sounds",
       "python/lofi",
       "python/ambience_generator.py"
     ]


### PR DESCRIPTION
## Summary
- Ensure `public/sfz_sounds` directory is packaged with the Tauri app so SFZ instruments can be found at runtime

## Testing
- `npm test` *(fails: ReferenceError: window is not defined; 39 passed, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68ae587230a08325ac408599f50bdc87