### PR TITLE
fix: prevent ThemeProvider crash on missing user

### DIFF
--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -35,7 +35,7 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const theme = useUsers((state) => {
     const id = state.currentUserId;
-    return id ? state.users[id].theme : state.globalTheme;
+    return id && state.users[id] ? state.users[id].theme : state.globalTheme;
   });
   const setTheme = useUsers((state) => state.setTheme);
 

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -169,4 +169,11 @@ export const useUsers = create<UsersState>()(
     )
   );
 
+useUsers.persist.onFinishHydration((state) => {
+  const id = state.currentUserId;
+  if (id && !state.users[id]) {
+    useUsers.setState({ currentUserId: null });
+  }
+});
+
 export { type ModuleKey, type ModulesState, defaultModules, type RetroTvMedia };


### PR DESCRIPTION
## Summary
- guard theme lookup in ThemeProvider when current user is missing
- reset currentUserId if referenced user record is absent after hydration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae91ce4b2c8325a5e42d64539ad7a4