### PR TITLE
feat: show error messages in ErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -6,6 +6,8 @@ interface ErrorBoundaryProps {
 
 interface ErrorBoundaryState {
   hasError: boolean;
+  errorMessage?: string;
+  componentStack?: string;
 }
 
 export default class ErrorBoundary extends Component<
@@ -24,11 +26,22 @@ export default class ErrorBoundary extends Component<
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     // You could log the error to an error reporting service
     console.error("ErrorBoundary caught an error", error, errorInfo);
+    this.setState({
+      errorMessage: error.message,
+      componentStack: errorInfo.componentStack,
+    });
   }
 
   render() {
     if (this.state.hasError) {
-      return <div>Something went wrong.</div>;
+      return (
+        <div>
+          <p>{this.state.errorMessage}</p>
+          {this.state.componentStack && (
+            <pre>{this.state.componentStack}</pre>
+          )}
+        </div>
+      );
     }
 
     return this.props.children;


### PR DESCRIPTION
## Summary
- include error message and component stack in ErrorBoundary state
- display captured error details when rendering the fallback UI

## Testing
- `npm test`
- `npm run build` *(fails: TS errors in unrelated files)*
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68af36675cfc8325b4a5575f064180c5