### PR TITLE
fix: avoid repeated retro media clears

### DIFF
--- a/src/components/RetroTV.tsx
+++ b/src/components/RetroTV.tsx
@@ -84,11 +84,13 @@ export default function RetroTV({ children }: RetroTVProps) {
     }
   }, [currentUserId, retroTvMedia]);
 
+  // Clear any stored media when the component unmounts
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     return () => {
       clearRetroTvMedia();
     };
-  }, [clearRetroTvMedia]);
+  }, []);
 
   if (theme !== "retro") return null;
 


### PR DESCRIPTION
## Summary
- prevent RetroTV from repeatedly clearing media

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af3b959ca483259679f4f07abff8b3