### PR TITLE
Use MockRuntime constructor in tests

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -551,6 +551,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-sql",
+ "tauri-runtime",
  "tempfile",
  "tokio",
  "url",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,4 +49,5 @@ rand = "0.8"
 tauri = { version = "2", features = ["protocol-asset", "test"] }
 tempfile = "3"
 httpmock = "0.6"
+tauri-runtime = { version = "2" }
 

--- a/src-tauri/tests/comfy_start_stop.rs
+++ b/src-tauri/tests/comfy_start_stop.rs
@@ -1,17 +1,17 @@
 use blossom_lib::commands::{comfy_start, comfy_stop, __has_comfy_child};
 use std::{env, fs};
-use tauri::Manager;
+use which::which;
 
 #[tokio::test]
 async fn start_and_stop_comfy() {
-    let _rt = tauri::test::mock_runtime();
+    let _rt = <tauri::test::MockRuntime as tauri_runtime::Runtime<()>>::new(Default::default()).unwrap();
     let app = tauri::test::mock_builder()
         .build(tauri::test::mock_context(tauri::test::noop_assets()))
         .unwrap();
-    let _webview = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
+    let webview = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
         .build()
         .unwrap();
-    let window = app.get_window("main").unwrap();
+    let window = webview.as_ref().window();
 
     let dir = tempfile::tempdir().unwrap();
     fs::write(
@@ -19,7 +19,7 @@ async fn start_and_stop_comfy() {
         "import time\nwhile True: time.sleep(0.1)\n",
     )
     .unwrap();
-    env::set_var("BLOSSOM_PYTHON_PATH", "python3");
+    env::set_var("BLOSSOM_PYTHON_PATH", which("python3").unwrap());
 
     assert!(!__has_comfy_child());
     comfy_start(window, dir.path().to_string_lossy().to_string())

--- a/src-tauri/tests/npc_log.rs
+++ b/src-tauri/tests/npc_log.rs
@@ -4,9 +4,9 @@ use tauri::{test::mock_app, Manager};
 
 #[tokio::test]
 async fn append_npc_log_includes_errors() {
-    let _rt = tauri::test::mock_runtime();
+    let _rt = <tauri::test::MockRuntime as tauri_runtime::Runtime<()>>::new(Default::default()).unwrap();
     let app = mock_app();
-    let handle = app.app_handle();
+    let handle = app.app_handle().clone();
 
     append_npc_log(
         handle.clone(),

--- a/src-tauri/tests/save_paths.rs
+++ b/src-tauri/tests/save_paths.rs
@@ -4,7 +4,7 @@ use std::{env, fs};
 
 #[tokio::test]
 async fn save_paths_writes_config() {
-    let _rt = tauri::test::mock_runtime();
+    let _rt = <tauri::test::MockRuntime as tauri_runtime::Runtime<()>>::new(Default::default()).unwrap();
     let dir = tempfile::tempdir().unwrap();
     env::set_var("HOME", dir.path());
 


### PR DESCRIPTION
## Summary
- replace deprecated `mock_runtime` with `MockRuntime::new` in integration tests
- adjust `comfy_start_stop` test to build a window and locate Python via `which`
- add `tauri-runtime` as a dev dependency

## Testing
- `cargo test` *(fails: commands::tests::spawn_with_logging_cleans_up_tasks, start_and_stop_comfy)*

------
https://chatgpt.com/codex/tasks/task_e_68af38ddedd48325bea93a24a713432d