### PR TITLE
Guard RetroTV media cleanup against strict-mode mount

### DIFF
--- a/src/components/RetroTV.test.tsx
+++ b/src/components/RetroTV.test.tsx
@@ -1,0 +1,36 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import React, { StrictMode } from 'react';
+import RetroTV from './RetroTV';
+
+const clearRetroTvMedia = vi.fn();
+vi.mock('../features/theme/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'retro' }),
+}));
+vi.mock('../features/users/useUsers', () => ({
+  useUsers: (selector: any) =>
+    selector({
+      currentUserId: '1',
+      users: { '1': { retroTvMedia: null } },
+      setRetroTvMedia: vi.fn(),
+      clearRetroTvMedia,
+    }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('RetroTV', () => {
+  it('clears media only on unmount', () => {
+    const { unmount } = render(
+      <StrictMode>
+        <RetroTV />
+      </StrictMode>
+    );
+    expect(clearRetroTvMedia).not.toHaveBeenCalled();
+    unmount();
+    expect(clearRetroTvMedia).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/RetroTV.tsx
+++ b/src/components/RetroTV.tsx
@@ -27,6 +27,7 @@ export default function RetroTV({ children }: RetroTVProps) {
   const [mediaWidth, setMediaWidth] = useState(640);
   const [mediaHeight, setMediaHeight] = useState(480);
   const fileInput = useRef<HTMLInputElement>(null);
+  const mounted = useRef(false);
 
   const handleFileChange = (
     e: React.ChangeEvent<HTMLInputElement>
@@ -84,13 +85,15 @@ export default function RetroTV({ children }: RetroTVProps) {
     }
   }, [currentUserId, retroTvMedia]);
 
-  // Clear any stored media when the component unmounts
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     return () => {
-      clearRetroTvMedia();
+      if (mounted.current) {
+        clearRetroTvMedia();
+      } else {
+        mounted.current = true;
+      }
     };
-  }, []);
+  }, [clearRetroTvMedia]);
 
   if (theme !== "retro") return null;
 


### PR DESCRIPTION
## Summary
- ensure RetroTV only clears media on real unmounts using a mounted ref
- add test verifying cleanup doesn't run during strict-mode mount cycle

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af3df27f3c832594e58af03b311f20