### PR TITLE
refactor: update tests for new Tauri runtime

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,7 +46,7 @@ png = "0.17"
 rand = "0.8"
 
 [dev-dependencies]
-tauri = { version = "2", features = ["protocol-asset", "test"] }
+tauri = { version = "2", features = ["protocol-asset", "test", "unstable"] }
 tempfile = "3"
 httpmock = "0.6"
 

--- a/src-tauri/tests/comfy_start_stop.rs
+++ b/src-tauri/tests/comfy_start_stop.rs
@@ -1,17 +1,14 @@
 use blossom_lib::commands::{comfy_start, comfy_stop, __has_comfy_child};
 use std::{env, fs};
-use tauri::Manager;
 
 #[tokio::test]
 async fn start_and_stop_comfy() {
-    let _rt = tauri::test::mock_runtime();
     let app = tauri::test::mock_builder()
         .build(tauri::test::mock_context(tauri::test::noop_assets()))
         .unwrap();
-    let _webview = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
+    let window = tauri::WindowBuilder::new(&app, "main")
         .build()
         .unwrap();
-    let window = app.get_window("main").unwrap();
 
     let dir = tempfile::tempdir().unwrap();
     fs::write(
@@ -19,7 +16,8 @@ async fn start_and_stop_comfy() {
         "import time\nwhile True: time.sleep(0.1)\n",
     )
     .unwrap();
-    env::set_var("BLOSSOM_PYTHON_PATH", "python3");
+    env::set_var("HOME", dir.path());
+    env::set_var("BLOSSOM_PYTHON_PATH", "/usr/bin/python3");
 
     assert!(!__has_comfy_child());
     comfy_start(window, dir.path().to_string_lossy().to_string())

--- a/src-tauri/tests/generate_ambience.rs
+++ b/src-tauri/tests/generate_ambience.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 use blossom_lib::commands::generate_ambience;
 use tauri::{test::mock_app, Listener, Manager, WebviewWindowBuilder};
@@ -9,6 +9,10 @@ async fn generate_ambience_logs_output() {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let repo_root = manifest_dir.parent().unwrap();
     std::env::set_current_dir(&repo_root).unwrap();
+
+    let home = tempfile::tempdir().unwrap();
+    env::set_var("HOME", home.path());
+    env::set_var("BLOSSOM_PYTHON_PATH", "/root/.pyenv/shims/python3");
 
     let app = mock_app();
     let window = WebviewWindowBuilder::new(&app, "main", Default::default())

--- a/src-tauri/tests/npc_log.rs
+++ b/src-tauri/tests/npc_log.rs
@@ -4,7 +4,8 @@ use tauri::{test::mock_app, Manager};
 
 #[tokio::test]
 async fn append_npc_log_includes_errors() {
-    let _rt = tauri::test::mock_runtime();
+    let dir = tempfile::tempdir().unwrap();
+    std::env::set_var("HOME", dir.path());
     let app = mock_app();
     let handle = app.app_handle();
 
@@ -30,7 +31,7 @@ async fn append_npc_log_includes_errors() {
     .await
     .unwrap();
 
-    let entries: Vec<Value> = read_npc_log(handle, None).await.unwrap();
+    let entries: Vec<Value> = read_npc_log(handle.clone(), None).await.unwrap();
     assert_eq!(entries.len(), 2);
     assert!(entries[0]["errorCode"].is_null());
     assert_eq!(entries[1]["errorCode"], "E1");

--- a/src-tauri/tests/save_paths.rs
+++ b/src-tauri/tests/save_paths.rs
@@ -4,7 +4,6 @@ use std::{env, fs};
 
 #[tokio::test]
 async fn save_paths_writes_config() {
-    let _rt = tauri::test::mock_runtime();
     let dir = tempfile::tempdir().unwrap();
     env::set_var("HOME", dir.path());
 


### PR DESCRIPTION
## Summary
- adjust tests to work with MockRuntime removal and new WindowBuilder
- ensure Python path isolation for rust tests
- enable Tauri's unstable test utilities

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68af38ecade88325adb7885f2f3023cd