### PR TITLE
feat: show task list on music page

### DIFF
--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -2,6 +2,7 @@
 import SongForm from "../components/SongForm";
 import VersionBadge from "../components/VersionBadge";
 import SystemInfoWidget from "../components/SystemInfoWidget";
+import TaskList from "../components/TaskQueue/TaskList";
 import { Box } from "@mui/material";
 import { systemInfoWidgetSx } from "./homeStyles";
 
@@ -29,9 +30,10 @@ export default function Music() {
         <VersionBadge />
       </div>
 
-      {/* Checkbox Song Builder only */}
+      {/* Song builder and task list */}
       <div style={{ maxWidth: 980, margin: "0 auto", padding: "24px 16px" }}>
         <SongForm />
+        <TaskList />
       </div>
 
       {/* System info widget */}


### PR DESCRIPTION
## Summary
- display TaskList component on Music page beneath the SongForm

## Testing
- `npm test -- --run` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68af505309008325842c2b4079dc59a4