### PR TITLE
feat(retro-tv): add persistent video upload

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -527,6 +527,7 @@ name = "blossom"
 version = "0.1.8"
 dependencies = [
  "async-trait",
+ "base64 0.21.7",
  "chrono",
  "chrono-tz",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,7 @@ sysinfo = "0.37"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "io-util", "process"] }
 png = "0.17"
 rand = "0.8"
+base64 = "0.21"
 
 [dev-dependencies]
 tauri = { version = "2", features = ["protocol-asset", "test"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -148,6 +148,8 @@ fn main() {
             commands::load_shorts,
             commands::save_shorts,
             commands::generate_short,
+            // Retro TV:
+            commands::save_retro_tv_video,
             // Transcription:
             commands::load_transcripts,
             commands::transcribe_audio,

--- a/src/components/RetroTV.test.tsx
+++ b/src/components/RetroTV.test.tsx
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
 import RetroTV from './RetroTV';
 
-const clearRetroTvMedia = vi.fn();
 vi.mock('../features/theme/ThemeContext', () => ({
   useTheme: () => ({ theme: 'retro' }),
 }));
@@ -11,10 +10,13 @@ vi.mock('../features/users/useUsers', () => ({
   useUsers: (selector: any) =>
     selector({
       currentUserId: '1',
-      users: { '1': { retroTvMedia: null } },
-      setRetroTvMedia: vi.fn(),
-      clearRetroTvMedia,
+      users: {
+        '1': { retroTvMedia: { path: '/tmp/video.mp4', width: 640, height: 480 } },
+      },
     }),
+}));
+vi.mock('@tauri-apps/api/core', () => ({
+  convertFileSrc: (p: string) => `tauri://${p}`,
 }));
 
 afterEach(() => {
@@ -23,10 +25,8 @@ afterEach(() => {
 });
 
 describe('RetroTV', () => {
-  it('clears media only on unmount', () => {
-    const { unmount } = render(<RetroTV />);
-    expect(clearRetroTvMedia).not.toHaveBeenCalled();
-    unmount();
-    expect(clearRetroTvMedia).toHaveBeenCalledTimes(1);
+  it('renders video when media is present', () => {
+    const { container } = render(<RetroTV />);
+    expect(container.querySelector('video')).not.toBeNull();
   });
 });

--- a/src/components/RetroTV.tsx
+++ b/src/components/RetroTV.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
+import { convertFileSrc } from "@tauri-apps/api/core";
 import { useTheme } from "../features/theme/ThemeContext";
 import { useUsers } from "../features/users/useUsers";
 import BouncingIcons from "./BouncingIcons";
@@ -9,94 +10,38 @@ interface RetroTVProps {
 
 export default function RetroTV({ children }: RetroTVProps) {
   const { theme } = useTheme();
-  const currentUserId = useUsers((state) => state.currentUserId);
   const retroTvMedia = useUsers((state) =>
-    state.currentUserId
-      ? state.users[state.currentUserId]?.retroTvMedia
-      : null
+    state.currentUserId ? state.users[state.currentUserId]?.retroTvMedia : null
   );
-  const setRetroTvMedia = useUsers((state) => state.setRetroTvMedia);
-  const clearRetroTvMedia = useUsers((state) => state.clearRetroTvMedia);
   const [mediaUrl, setMediaUrl] = useState<string | null>(null);
-  const [mediaType, setMediaType] = useState<"image" | "video" | null>(null);
   const [mediaWidth, setMediaWidth] = useState(640);
   const [mediaHeight, setMediaHeight] = useState(480);
-  const fileInput = useRef<HTMLInputElement>(null);
-
-  const handleFileChange = (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => {
-      const result = reader.result as string;
-      const isVideo = file.type.startsWith("video");
-
-      const update = (width: number, height: number) => {
-        setMediaUrl(result);
-        setMediaType(isVideo ? "video" : "image");
-        setMediaWidth(width);
-        setMediaHeight(height);
-        if (currentUserId) {
-          setRetroTvMedia({
-            data: result,
-            type: isVideo ? "video" : "image",
-            width,
-            height,
-          });
-        }
-      };
-
-      if (isVideo) {
-        const video = document.createElement("video");
-        video.src = result;
-        video.addEventListener(
-          "loadedmetadata",
-          () => update(video.videoWidth, video.videoHeight),
-          { once: true }
-        );
-      } else {
-        const img = new Image();
-        img.src = result;
-        img.onload = () => update(img.width, img.height);
-      }
-    };
-    reader.readAsDataURL(file);
-  };
 
   useEffect(() => {
     if (retroTvMedia) {
-      setMediaUrl(retroTvMedia.data);
-      setMediaType(retroTvMedia.type);
+      setMediaUrl(convertFileSrc(retroTvMedia.path));
       setMediaWidth(retroTvMedia.width);
       setMediaHeight(retroTvMedia.height);
     } else {
       setMediaUrl(null);
-      setMediaType(null);
       setMediaWidth(640);
       setMediaHeight(480);
     }
-  }, [currentUserId, retroTvMedia]);
-
-  useEffect(() => () => clearRetroTvMedia(), []);
+  }, [retroTvMedia]);
 
   if (theme !== "retro") return null;
 
   let content: React.ReactNode;
   if (mediaUrl) {
-    content =
-      mediaType === "video" ? (
-        <video
-          src={mediaUrl}
-          className="retro-tv-content"
-          controls
-          autoPlay
-          loop
-        />
-      ) : (
-        <img src={mediaUrl} className="retro-tv-content" alt="Uploaded media" />
-      );
+    content = (
+      <video
+        src={mediaUrl}
+        className="retro-tv-content"
+        controls
+        autoPlay
+        loop
+      />
+    );
   } else if (children) {
     content = <div className="retro-tv-content">{children}</div>;
   } else {
@@ -108,23 +53,7 @@ export default function RetroTV({ children }: RetroTVProps) {
       className="retro-tv-container"
       style={{ width: mediaWidth, height: mediaHeight }}
     >
-      <input
-        type="file"
-        accept="image/*,video/*"
-        ref={fileInput}
-        style={{ display: "none" }}
-        onChange={handleFileChange}
-      />
-      <div className="retro-tv-screen">
-        {content}
-        <button
-          type="button"
-          className="retro-tv-upload"
-          onClick={() => fileInput.current?.click()}
-        >
-          Upload
-        </button>
-      </div>
+      <div className="retro-tv-screen">{content}</div>
     </div>
   );
 }

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -38,8 +38,7 @@ const defaultModules: ModulesState = {
 };
 
 interface RetroTvMedia {
-  data: string;
-  type: 'image' | 'video';
+  path: string;
   width: number;
   height: number;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -292,28 +292,6 @@ img.retro-tv-content {
   filter: hue-rotate(90deg) saturate(0.6) brightness(0.9);
 }
 
-.retro-tv-upload {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.5);
-  color: #0f0;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s ease;
-  z-index: 3;
-}
-
-.retro-tv-screen:hover .retro-tv-upload {
-  opacity: 1;
-  pointer-events: auto;
-}
-
 .retro-tv-screen::before {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Summary
- add settings option to upload retro TV video and save it to persistent storage
- display saved video in RetroTV component
- handle filesystem saving with new Tauri command

## Testing
- `npm test`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af529c0f048325a1d41a3d5d56e13c