### PR TITLE
refactor: add TaskCommand union

### DIFF
--- a/src/components/AlbumWizard.tsx
+++ b/src/components/AlbumWizard.tsx
@@ -177,14 +177,13 @@ export default function AlbumWizard() {
     }
     try {
       const id = await enqueueTask("Music Generation", {
-        GenerateAlbum: {
-          meta: {
-            track_count: 1,
-            title_base: titleBase,
-            track_names: [titleBase],
-            out_dir: outDir,
-            specs: [makeSpec()],
-          },
+        id: "GenerateAlbum",
+        meta: {
+          track_count: 1,
+          title_base: titleBase,
+          track_names: [titleBase],
+          out_dir: outDir,
+          specs: [makeSpec()],
         },
       });
       setTaskId(id);

--- a/src/components/HomeChat.test.tsx
+++ b/src/components/HomeChat.test.tsx
@@ -62,12 +62,11 @@ describe('HomeChat', () => {
     fireEvent.click(screen.getByRole('button', { name: /send/i }));
     await waitFor(() => {
       expect(enqueueTask).toHaveBeenCalledWith('Music Generation', {
-        GenerateAlbum: {
-          meta: {
-            track_count: 2,
-            title_base: 'My Song',
-            template: 'Classic Lofi',
-          },
+        id: 'GenerateAlbum',
+        meta: {
+          track_count: 2,
+          title_base: 'My Song',
+          template: 'Classic Lofi',
         },
       });
     });

--- a/src/components/HomeChat.tsx
+++ b/src/components/HomeChat.tsx
@@ -69,9 +69,8 @@ export default function HomeChat() {
             `Example: /music My Song template="Classic Lofi" tracks=3`;
         } else {
           await enqueueTask("Music Generation", {
-            GenerateAlbum: {
-              meta: { track_count: trackCount, title_base: title, template },
-            },
+            id: "GenerateAlbum",
+            meta: { track_count: trackCount, title_base: title, template },
           });
           const plural = trackCount === 1 ? "track" : "tracks";
           reply = `Started music generation for "${title}" using "${template}" with ${trackCount} ${plural}.`;

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -107,7 +107,8 @@ describe('SongForm', () => {
 
     await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
     const [, args] = enqueueTask.mock.calls[0];
-    const spec = args.GenerateShort.spec;
+    const spec = args.spec;
+    expect(args.id).toBe('GenerateShort');
     expect(spec.structure[0]).toHaveProperty('chords');
     expect(spec.chord_span_beats).toBe(4);
     expect(spec).toMatchObject({
@@ -329,7 +330,8 @@ describe('SongForm', () => {
 
     await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
     const [, args] = enqueueTask.mock.calls[0];
-    expect(args.GenerateShort.spec.instruments).toEqual(['harp', 'lute', 'pan flute']);
+    expect(args.id).toBe('GenerateShort');
+    expect(args.spec.instruments).toEqual(['harp', 'lute', 'pan flute']);
   });
 
   it('uses raw sfz path in render spec', async () => {
@@ -355,7 +357,8 @@ describe('SongForm', () => {
 
     await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
     const [, args] = enqueueTask.mock.calls[0];
-    expect(args.GenerateShort.spec.sfzInstrument).toBe('/tmp/piano file.sfz');
+    expect(args.id).toBe('GenerateShort');
+    expect(args.spec.sfzInstrument).toBe('/tmp/piano file.sfz');
     expect(setPreviewSfzInstrument).toHaveBeenCalledWith(
       'tauri:///tmp/piano%20file.sfz'
     );
@@ -392,7 +395,8 @@ describe('SongForm', () => {
 
     await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
     const [, args] = enqueueTask.mock.calls[0];
-    expect(args.GenerateShort.spec.lead_instrument).toBe('flute');
+    expect(args.id).toBe('GenerateShort');
+    expect(args.spec.lead_instrument).toBe('flute');
   });
 
   it('exports an odd-bar through-composed preset', () => {
@@ -442,10 +446,11 @@ describe('SongForm', () => {
     await waitFor(() => {
       expect(enqueueTask).toHaveBeenCalled();
       const args = enqueueTask.mock.calls[0][1];
-      expect(args.GenerateAlbum.meta.album_name).toBe('My Album');
-      expect(args.GenerateAlbum.meta.track_names).toEqual(['T1', 'T2', 'T3']);
-      expect(args.GenerateAlbum.meta.specs).toHaveLength(3);
-      expect(args.GenerateAlbum.meta.specs[0]).toMatchObject({
+      expect(args.id).toBe('GenerateAlbum');
+      expect(args.meta.album_name).toBe('My Album');
+      expect(args.meta.track_names).toEqual(['T1', 'T2', 'T3']);
+      expect(args.meta.specs).toHaveLength(3);
+      expect(args.meta.specs[0]).toMatchObject({
         title: 'Test Song 1',
         album: 'My Album',
       });

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -706,9 +706,10 @@ export default function SongForm() {
       for (let i = 0; i < newJobs.length; i++) {
         const job = newJobs[i];
         try {
-          const taskId = await enqueueTask("Music Generation", {
-            GenerateShort: { spec: job.spec },
-          });
+          const taskId = await enqueueTask(
+            "Music Generation",
+            { id: "GenerateShort", spec: job.spec }
+          );
           setJobs((prev) =>
             prev.map((j) => (j.id === job.id ? { ...j, taskId } : j))
           );
@@ -739,15 +740,14 @@ export default function SongForm() {
         makeSpecForIndex(i)
       );
       await enqueueTask("Music Generation", {
-        GenerateAlbum: {
-          meta: {
-            track_count: trackCount,
-            title_base: titleBase,
-            album_name: albumName,
-            track_names: trackNames,
-            out_dir: outDir,
-            specs,
-          },
+        id: "GenerateAlbum",
+        meta: {
+          track_count: trackCount,
+          title_base: titleBase,
+          album_name: albumName,
+          track_names: trackNames,
+          out_dir: outDir,
+          specs,
         },
       });
       setOutDir(outDir);

--- a/src/features/dnd/LorePdfUpload.tsx
+++ b/src/features/dnd/LorePdfUpload.tsx
@@ -17,7 +17,9 @@ export default function LorePdfUpload({ world }: Props) {
     const selected = await open({ filters: [{ name: "PDF", extensions: ["pdf"] }] });
     if (typeof selected === "string") {
       const id = await enqueueTask("Import Lore PDF", {
-        ParseLorePdf: { path: selected, world },
+        id: "ParseLorePdf",
+        path: selected,
+        world,
       });
       setTaskId(id);
     }

--- a/src/features/dnd/NpcPdfUpload.tsx
+++ b/src/features/dnd/NpcPdfUpload.tsx
@@ -30,7 +30,9 @@ export default function NpcPdfUpload({ world, onParsed }: Props) {
     const selected = await open({ filters: [{ name: "PDF", extensions: ["pdf"] }] });
     if (typeof selected === "string") {
       const id = await enqueueTask("Import NPC PDF", {
-        ParseNpcPdf: { path: selected, world },
+        id: "ParseNpcPdf",
+        path: selected,
+        world,
       });
       setTaskId(id);
       setStatus("uploading");

--- a/src/features/dnd/RulePdfUpload.tsx
+++ b/src/features/dnd/RulePdfUpload.tsx
@@ -32,7 +32,8 @@ export default function RulePdfUpload() {
     });
     if (typeof selected === "string") {
       const id = await enqueueTask("Import Rule PDF", {
-        ParseRulePdf: { path: selected },
+        id: "ParseRulePdf",
+        path: selected,
       });
       setTaskId(id);
     }

--- a/src/features/dnd/SpellPdfUpload.tsx
+++ b/src/features/dnd/SpellPdfUpload.tsx
@@ -18,7 +18,8 @@ export default function SpellPdfUpload() {
     const selected = await open({ filters: [{ name: "PDF", extensions: ["pdf"] }] });
     if (typeof selected === "string") {
       const id = await enqueueTask("Import Spell PDF", {
-        ParseSpellPdf: { path: selected },
+        id: "ParseSpellPdf",
+        path: selected,
       });
       setTaskId(id);
     }

--- a/src/pages/GeneralChat.test.tsx
+++ b/src/pages/GeneralChat.test.tsx
@@ -179,12 +179,11 @@ describe('GeneralChat', () => {
 
     await waitFor(() => {
       expect(enqueueTask).toHaveBeenCalledWith('Music Generation', {
-        GenerateAlbum: {
-          meta: {
-            track_count: 2,
-            title_base: 'My Song',
-            template: 'Classic Lofi',
-          },
+        id: 'GenerateAlbum',
+        meta: {
+          track_count: 2,
+          title_base: 'My Song',
+          template: 'Classic Lofi',
         },
       });
     });
@@ -276,12 +275,11 @@ describe('GeneralChat', () => {
       })
     );
     expect(enqueueTask).toHaveBeenCalledWith('Music Generation', {
-      GenerateAlbum: {
-        meta: {
-          track_count: 2,
-          title_base: 'calm flute',
-          template: 'Classic Lofi',
-        },
+      id: 'GenerateAlbum',
+      meta: {
+        track_count: 2,
+        title_base: 'calm flute',
+        template: 'Classic Lofi',
       },
     });
   });

--- a/src/pages/GeneralChat.tsx
+++ b/src/pages/GeneralChat.tsx
@@ -216,7 +216,8 @@ export default function GeneralChat() {
             `Example: /music My Song template="Classic Lofi" tracks=3`;
         } else {
           await enqueueTask("Music Generation", {
-            GenerateAlbum: { meta: { track_count: trackCount, title_base: title, template } },
+            id: "GenerateAlbum",
+            meta: { track_count: trackCount, title_base: title, template },
           });
           const plural = trackCount === 1 ? "track" : "tracks";
           reply = `Started music generation for "${title}" using "${template}" with ${trackCount} ${plural}.`;

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -2,6 +2,31 @@ import { create } from 'zustand';
 import { invoke } from '@tauri-apps/api/core';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
 
+export type TaskCommand =
+  | { id: 'Example' }
+  | {
+      id: 'LofiGenerateGpu';
+      py: string;
+      script: string;
+      prompt: string;
+      duration: number;
+      seed: number;
+    }
+  | { id: 'PdfIngest'; py: string; script: string; doc_id: string }
+  | { id: 'ParseNpcPdf'; py?: string; script?: string; path: string; world: string }
+  | { id: 'ParseSpellPdf'; py?: string; script?: string; path: string }
+  | { id: 'ParseRulePdf'; py?: string; script?: string; path: string }
+  | { id: 'ParseLorePdf'; py?: string; script?: string; path: string; world: string }
+  | { id: 'GenerateAlbum'; meta: any }
+  | { id: 'GenerateShort'; spec: any };
+
+export function buildTaskCommand(
+  id: TaskCommand['id'],
+  fields: Record<string, unknown> = {}
+): TaskCommand {
+  return { id, ...fields } as TaskCommand;
+}
+
 export type TaskStatus =
   | 'queued'
   | 'running'
@@ -55,7 +80,7 @@ function normalize(raw: RawTask): Task {
 interface TasksState {
   tasks: Record<number, Task>;
   pollers: Record<number, ReturnType<typeof setInterval>>;
-  enqueueTask: (label: string, command: unknown) => Promise<number>;
+  enqueueTask: (label: string, command: TaskCommand) => Promise<number>;
   fetchStatus: (id: number) => Promise<void>;
   startPolling: (id: number, interval?: number) => void;
   stopPolling: (id: number) => void;


### PR DESCRIPTION
## Summary
- define TaskCommand union with `id` discriminator and helper
- require `TaskCommand` in enqueueTask API
- update enqueueTask call sites to use `{id: '<Variant>'}` commands

## Testing
- `npm test` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68af533b31408325a7b2ad863675ba7f