### PR TITLE
feat: add NPC log clearing

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1490,6 +1490,21 @@ pub async fn read_npc_log<R: Runtime>(
     Ok(entries)
 }
 
+#[tauri::command]
+pub async fn clear_npc_log<R: Runtime>(app: AppHandle<R>) -> Result<(), String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|_| "app data dir".to_string())?
+        .join("npc")
+        .join("log");
+    let path = dir.join("npc-import.log");
+    if path.exists() {
+        fs::write(&path, "").map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
 /* ==============================
 Ollama general chat
 ============================== */

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -130,6 +130,7 @@ fn main() {
             commands::list_npcs,
             commands::append_npc_log,
             commands::read_npc_log,
+            commands::clear_npc_log,
             commands::save_rule,
             commands::list_rules,
             commands::save_spell,

--- a/src/features/dnd/NpcLog.tsx
+++ b/src/features/dnd/NpcLog.tsx
@@ -23,6 +23,15 @@ export default function NpcLog() {
     }
   }
 
+  async function clear() {
+    try {
+      await invoke("clear_npc_log");
+      await load();
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
   useEffect(() => {
     load();
   }, []);
@@ -34,6 +43,9 @@ export default function NpcLog() {
       </Typography>
       <Button size="small" onClick={load} sx={{ mb: 1 }}>
         Refresh
+      </Button>
+      <Button size="small" onClick={clear} sx={{ mb: 1, ml: 1 }}>
+        Clear Log
       </Button>
       <List dense>
         {entries.length === 0 && (

--- a/src/features/dnd/tests/NpcLog.test.tsx
+++ b/src/features/dnd/tests/NpcLog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { render, screen, waitFor, cleanup, fireEvent } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
@@ -31,5 +31,31 @@ describe("NpcLog", () => {
     );
     expect(screen.getByText(/E1/)).toBeInTheDocument();
     expect(screen.getByText(/boom/)).toBeInTheDocument();
+  });
+
+  it("clears the log", async () => {
+    (invoke as any)
+      .mockResolvedValueOnce([
+        {
+          timestamp: "2024-01-01T00:00:00Z",
+          world: "w",
+          id: "1",
+          name: "Test",
+        },
+      ])
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([]);
+
+    render(<NpcLog />);
+    await waitFor(() =>
+      expect(screen.getByText(/Test/)).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByText(/clear log/i));
+
+    await waitFor(() =>
+      expect(screen.getByText(/No entries/)).toBeInTheDocument(),
+    );
+    expect((invoke as any).mock.calls[1][0]).toBe("clear_npc_log");
   });
 });


### PR DESCRIPTION
## Summary
- add `clear_npc_log` tauri command and register
- add Clear Log button to NPC log viewer
- test log clearing logic

## Testing
- `npm test` *(fails: Vitest reports 1 unhandled error in unrelated WarTable test)*
- `npx vitest run src/features/dnd/tests/NpcLog.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af5511253c8325bfc1609a0d1f23f3