### PR TITLE
Parse NPC PDF result object

### DIFF
--- a/src/features/dnd/NpcPdfUpload.tsx
+++ b/src/features/dnd/NpcPdfUpload.tsx
@@ -43,8 +43,13 @@ export default function NpcPdfUpload({ world, onParsed }: Props) {
   useEffect(() => {
     if (!taskId) return;
     const task = tasks[taskId];
-    if (task && task.status === "completed" && Array.isArray(task.result)) {
-      const parsed = task.result as NpcData[];
+    if (
+      task &&
+      task.status === "completed" &&
+      task.result &&
+      Array.isArray((task.result as { npcs?: NpcData[] }).npcs)
+    ) {
+      const parsed = (task.result as { npcs: NpcData[] }).npcs;
       onParsed?.(parsed);
       (async () => {
         const existing = await invoke<NpcData[]>("list_npcs", { world });

--- a/src/features/dnd/tests/NpcForm.test.tsx
+++ b/src/features/dnd/tests/NpcForm.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { invoke } from "@tauri-apps/api/core";
+
+const enqueueTask = vi.fn();
+const loadNPCs = vi.fn();
+const tasksState: any = { enqueueTask, tasks: {} };
+
+vi.mock("../../../store/tasks", () => ({
+  useTasks: (selector: any) => selector(tasksState),
+}));
+vi.mock("../../../store/npcs", () => ({
+  useNPCs: (selector: any) => selector({ loadNPCs }),
+}));
+vi.mock("../../../store/voices", () => ({
+  useVoices: (selector: any) =>
+    selector({
+      voices: [],
+      filter: () => true,
+      toggleFavorite: vi.fn(),
+      load: vi.fn().mockResolvedValue(undefined),
+    }),
+}));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+import NpcForm from "../NpcForm";
+
+describe("NpcForm PDF import", () => {
+  beforeEach(() => {
+    tasksState.tasks = {};
+    enqueueTask.mockResolvedValue(1);
+    (open as any).mockResolvedValue("/tmp/npc.pdf");
+    (invoke as any).mockReset();
+    loadNPCs.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("fills fields and loads library from parsed NPC", async () => {
+    tasksState.tasks = {
+      1: {
+        status: "completed",
+        result: {
+          npcs: [
+            {
+              id: "1",
+              name: "Bob",
+              species: "Human",
+              role: "Villain",
+              alignment: "Neutral",
+              playerCharacter: false,
+            },
+          ],
+        },
+      },
+    };
+    (invoke as any).mockImplementation((cmd: string) => {
+      if (cmd === "list_npcs") return Promise.resolve([]);
+      if (cmd === "read_npc_log") return Promise.resolve([]);
+      return Promise.resolve();
+    });
+
+    render(<NpcForm world="w" />);
+    fireEvent.click(screen.getByRole("button", { name: /upload npc pdf/i }));
+
+    await waitFor(() => expect(screen.getByLabelText(/name/i)).toHaveValue("Bob"));
+    expect(screen.getByLabelText(/species/i)).toHaveValue("Human");
+    expect(screen.getByLabelText(/role/i)).toHaveValue("Villain");
+    expect(loadNPCs).toHaveBeenCalledWith("w");
+  });
+});

--- a/src/features/dnd/tests/NpcPdfUpload.test.tsx
+++ b/src/features/dnd/tests/NpcPdfUpload.test.tsx
@@ -34,7 +34,7 @@ describe("NpcPdfUpload logging", () => {
 
   it("logs successful imports", async () => {
     tasksState.tasks = {
-      1: { status: "completed", result: [{ id: "1", name: "Bob" }] },
+      1: { status: "completed", result: { npcs: [{ id: "1", name: "Bob" }] } },
     };
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === "list_npcs") return Promise.resolve([]);
@@ -80,7 +80,7 @@ describe("NpcPdfUpload logging", () => {
 
   it("exposes parsed NPC data via callback", async () => {
     tasksState.tasks = {
-      1: { status: "completed", result: [{ id: "1", name: "Bob" }] },
+      1: { status: "completed", result: { npcs: [{ id: "1", name: "Bob" }] } },
     };
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === "list_npcs") return Promise.resolve([]);


### PR DESCRIPTION
## Summary
- Handle NPC PDF parsing results shaped as `{ npcs: [...] }`
- Update NPC PDF upload tests for new result shape
- Add test ensuring parsed NPC populates form fields and NPC library

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af550d6bf08325bf6e08f7f8b2f0a6