### PR TITLE
Log NPC PDF parser output

### DIFF
--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -280,6 +280,7 @@ impl TaskQueue {
                                         })
                                     } else {
                                         let stdout = String::from_utf8_lossy(&output.stdout);
+                                        println!("ParseNpcPdf output: {}", stdout);
                                         serde_json::from_str::<Value>(&stdout).map_err(|e| TaskError {
                                             code: PdfErrorCode::InvalidJson,
                                             message: e.to_string(),


### PR DESCRIPTION
## Summary
- log NPC PDF parsing output to terminal for easier debugging

## Testing
- `npm test`
- `cargo test` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af5a505df08325ac29a384deda107c