### PR TITLE
Log NPC PDF parsing output to terminal

### DIFF
--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -283,7 +283,9 @@ impl TaskQueue {
                                             ),
                                         })
                                     } else {
-                                        let stdout = String::from_utf8_lossy(&output.stdout);
+                                        let stdout =
+                                            String::from_utf8_lossy(&output.stdout).to_string();
+                                        log::info!("ParseNpcPdf stdout: {}", stdout.trim());
                                         serde_json::from_str::<Value>(&stdout).map_err(|e| {
                                             TaskError {
                                                 code: PdfErrorCode::InvalidJson,


### PR DESCRIPTION
## Summary
- log NPC PDF parsing stdout for easier debugging

## Testing
- `cargo test` *(fails: commands::tests::spawn_with_logging_cleans_up_tasks left 3 right 2)*
- `npm test` *(fails: 1 unhandled error, window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68af5b55e7588325940daa0933bdcd62