### PR TITLE
Allow batch rendering without mandatory fields

### DIFF
--- a/src/components/BatchActions.tsx
+++ b/src/components/BatchActions.tsx
@@ -107,12 +107,7 @@ export default function BatchActions({
       <div className={styles.actions}>
         <button
           className={styles.btn}
-          disabled={
-            busy ||
-            !outDir ||
-            !titleBase ||
-            (albumMode && !albumReady)
-          }
+          disabled={busy}
           onClick={onRender}
         >
           {albumMode

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -90,6 +90,15 @@ describe('SongForm', () => {
     }
   });
 
+  it('shows validation errors when required fields are missing', async () => {
+    render(<SongForm />);
+    const btn = screen.getByText(/render songs/i) as HTMLButtonElement;
+    expect(btn).not.toBeDisabled();
+    fireEvent.click(btn);
+    await screen.findByText(/choose an output folder/i);
+    expect(enqueueTask).not.toHaveBeenCalled();
+  });
+
   it('adds a job and enqueues task', async () => {
     (openDialog as any).mockResolvedValue('/tmp/out');
     (invoke as any).mockResolvedValue('');

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -685,8 +685,22 @@ export default function SongForm() {
     setIsPlaying(false);
     setProgress(0);
 
-    if (!titleBase || !outDir || (albumMode && !albumReady)) {
-      setErr("Please set required titles and choose an output folder.");
+    const title = titleBase.trim();
+    const dir = outDir.trim();
+    if (!title && !dir) {
+      setErr("Please set a title and choose an output folder.");
+      return;
+    }
+    if (!title) {
+      setErr("Please set a title.");
+      return;
+    }
+    if (!dir) {
+      setErr("Please choose an output folder.");
+      return;
+    }
+    if (albumMode && !albumReady) {
+      setErr("Please complete album details.");
       return;
     }
     if (numSongs < 1) {
@@ -729,8 +743,22 @@ export default function SongForm() {
     setGlobalStatus("");
     setProgress(0);
 
-    if (!titleBase || !outDir) {
+    const title = titleBase.trim();
+    const dir = outDir.trim();
+    if (!title && !dir) {
       setErr("Please set a title and choose an output folder.");
+      return;
+    }
+    if (!title) {
+      setErr("Please set a title.");
+      return;
+    }
+    if (!dir) {
+      setErr("Please choose an output folder.");
+      return;
+    }
+    if (!albumReady) {
+      setErr("Please complete album details.");
       return;
     }
 

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -2824,7 +2824,6 @@ exports[`SongForm > renders default form 1`] = `
       >
         <button
           class="_btn_913096"
-          disabled=""
         >
           Render Songs
         </button>


### PR DESCRIPTION
## Summary
- keep batch render button enabled unless busy
- validate title and output folder in SongForm with specific errors
- test that rendering relies on validation rather than disabled UI

## Testing
- `npm test src/components/SongForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af61efdee48325b9fb2d7850b1b998