### PR TITLE
Add SFZ samplers for chords, pads, and bass

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ When a user uploads a video, it plays automatically on an endless loop.
   clipping intensity (values around `1.0` keep saturation subtle).
 - **Chord span:** Control how long each chord lasts with `chord_span_beats`
   (2 = ½ bar, 4 = 1 bar, 8 = 2 bars).
+- **SFZ instruments:** Supply custom samples in the song JSON with
+  `sfz_instrument` for leads or `sfz_chords`, `sfz_pads`, and `sfz_bass` for
+  chords, pads, and bass lines.
 - **Song form:** Structure songs with through‑composed templates (e.g.
   `Intro–A–B–C–D–E–F–Outro`) and use odd bar lengths like 5 or 7 bars for
   asymmetrical phrases.

--- a/public/sfz_sounds/README.md
+++ b/public/sfz_sounds/README.md
@@ -39,3 +39,17 @@ loadSfz(convertFileSrc(path));
 
 Because sample paths are relative, the loader automatically locates files inside
 the matching sample folder (`piano/` in this example).
+
+## Using in song specs
+
+Reference SFZ files in the song JSON to swap instruments:
+
+```json
+{
+  "sfz_chords": "sfz_sounds/piano.sfz",
+  "sfz_pads": "sfz_sounds/pads.sfz",
+  "sfz_bass": "sfz_sounds/bass.sfz"
+}
+```
+
+`sfz_instrument` remains available for lead melodies.

--- a/src-tauri/python/tests/test_sfz_instrument.py
+++ b/src-tauri/python/tests/test_sfz_instrument.py
@@ -26,3 +26,67 @@ def test_sfz_sampler_used(monkeypatch, tmp_path):
     }
     renderer.render_from_spec(spec)
     assert calls, "Sampler render was not invoked"
+
+
+def _dummy_sampler_factory(calls):
+    class DummySampler:
+        def render(self, freq, ms):
+            calls.append((freq, ms))
+            return np.zeros(int(ms * renderer.SR / 1000), dtype=np.float32)
+
+    return DummySampler
+
+
+def test_sfz_chords_sampler_used(monkeypatch, tmp_path):
+    calls = []
+    DummySampler = _dummy_sampler_factory(calls)
+    monkeypatch.setattr(
+        renderer.SfzSampler, "from_file", staticmethod(lambda p: DummySampler())
+    )
+    sfz_file = tmp_path / "dummy.sfz"
+    sfz_file.write_text("<region>\n")
+    spec = {
+        "bpm": 80,
+        "seed": 1,
+        "structure": [{"name": "A", "bars": 1}],
+        "sfz_chords": str(sfz_file),
+    }
+    renderer.render_from_spec(spec)
+    assert calls, "Chord sampler render was not invoked"
+
+
+def test_sfz_pads_sampler_used(monkeypatch, tmp_path):
+    calls = []
+    DummySampler = _dummy_sampler_factory(calls)
+    monkeypatch.setattr(
+        renderer.SfzSampler, "from_file", staticmethod(lambda p: DummySampler())
+    )
+    sfz_file = tmp_path / "dummy.sfz"
+    sfz_file.write_text("<region>\n")
+    spec = {
+        "bpm": 80,
+        "seed": 1,
+        "structure": [{"name": "A", "bars": 1}],
+        "sfz_pads": str(sfz_file),
+    }
+    renderer.render_from_spec(spec)
+    assert calls, "Pad sampler render was not invoked"
+
+
+def test_sfz_bass_sampler_used(monkeypatch, tmp_path):
+    calls = []
+    DummySampler = _dummy_sampler_factory(calls)
+    monkeypatch.setattr(
+        renderer.SfzSampler, "from_file", staticmethod(lambda p: DummySampler())
+    )
+    sfz_file = tmp_path / "dummy.sfz"
+    sfz_file.write_text("<region>\n")
+    spec = {
+        "bpm": 80,
+        "seed": 1,
+        "structure": [{"name": "A", "bars": 1}],
+        "sfz_bass": str(sfz_file),
+        "instruments": ["upright bass"],
+    }
+    renderer.render_from_spec(spec)
+    assert calls, "Bass sampler render was not invoked"


### PR DESCRIPTION
## Summary
- load optional `sfz_chords`, `sfz_pads`, and `sfz_bass` paths and their samplers
- render chords, pads, and bass via SFZ samplers when provided
- document new SFZ keys and add tests covering their usage

## Testing
- `pytest src-tauri/python/tests/test_sfz_instrument.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af6490741083259585b3c4f8064f24