### PR TITLE
Add top margin to Voices page layout

### DIFF
--- a/src/pages/Voices.tsx
+++ b/src/pages/Voices.tsx
@@ -72,6 +72,7 @@ export default function Voices() {
     <Box
       sx={{
         p: 2,
+        mt: 8,
         color: "#fff",
         display: "flex",
         flexDirection: "column",


### PR DESCRIPTION
## Summary
- ensure Voices page content clears fixed icons by adding top margin to main container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af65ba442c83259d9041c961cea7ad