### PR TITLE
Validate task command ids before enqueueing

### DIFF
--- a/src/store/tasks.test.ts
+++ b/src/store/tasks.test.ts
@@ -43,3 +43,31 @@ describe('useTasks error handling', () => {
     expect(state.tasks[1]).toMatchObject({ status: 'failed', error: 'nope' });
   });
 });
+
+describe('enqueueTask validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useTasks.setState({ tasks: {}, pollers: {} });
+  });
+
+  afterEach(() => {
+    const { pollers, stopPolling } = useTasks.getState();
+    Object.keys(pollers).forEach((id) => stopPolling(Number(id)));
+  });
+
+  it('builds command when label is a valid id and id is missing', async () => {
+    (invoke as any).mockResolvedValue(1);
+    const id = await useTasks.getState().enqueueTask('ParseSpellPdf', { path: 'x' } as any);
+    expect(id).toBe(1);
+    expect(invoke).toHaveBeenCalledWith('enqueue_task', {
+      label: 'ParseSpellPdf',
+      command: { id: 'ParseSpellPdf', path: 'x' },
+    });
+  });
+
+  it('throws when command id is missing and label is not a task id', async () => {
+    await expect(
+      useTasks.getState().enqueueTask('NotATask', {} as any),
+    ).rejects.toThrow('id');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure task commands include an `id` before calling the backend
- handle missing ids by building a command from the task label or throwing an error
- test enqueueTask id validation logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af64b3896c8325bc84d3840557bb09