### PR TITLE
Increase calendar cell height

### DIFF
--- a/src/components/CalendarDay.tsx
+++ b/src/components/CalendarDay.tsx
@@ -40,7 +40,7 @@ const CalendarDay = React.memo(
       }[]
     >([]);
     if (!day) {
-      return <Box sx={{ minHeight: 96, bgcolor: 'grey.50' }} />;
+      return <Box sx={{ minHeight: 140, bgcolor: 'grey.50' }} />;
     }
 
     const handleClick = useCallback(
@@ -90,7 +90,7 @@ const CalendarDay = React.memo(
         aria-current={isToday ? 'date' : undefined}
         sx={{
           position: 'relative',
-          minHeight: 96,
+          minHeight: 140,
           p: 2,
           border: '1px solid',
           borderColor: isToday ? 'primary.light' : 'grey.200',

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -382,6 +382,7 @@ export default function Calendar() {
                 sx={{
                   display: "grid",
                   gridTemplateColumns: "repeat(7, 1fr)",
+                  gridAutoRows: "minmax(140px, auto)",
                   gap: 1,
                   mb: 8,
                 }}


### PR DESCRIPTION
## Summary
- raise calendar day min height to 140px
- ensure calendar grid rows match new cell size

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68af68b43cd0832583abb226d7e9d348