### PR TITLE
chore: improve task id error message

### DIFF
--- a/src/store/tasks.test.ts
+++ b/src/store/tasks.test.ts
@@ -68,6 +68,8 @@ describe('enqueueTask validation', () => {
   it('throws when command id is missing and label is not a task id', async () => {
     await expect(
       useTasks.getState().enqueueTask('NotATask', {} as any),
-    ).rejects.toThrow('id');
+    ).rejects.toThrow(
+      'Task command for NotATask is missing id: {}',
+    );
   });
 });

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -111,7 +111,7 @@ export const useTasks = create<TasksState>((set, get) => ({
       } else if (TASK_IDS.includes(label as TaskCommand['id'])) {
         cmd = buildTaskCommand(label as TaskCommand['id'], command as Record<string, unknown>);
       } else {
-        throw new Error('Task command must include an id field');
+        throw new Error(`Task command for ${label} is missing id: ${JSON.stringify(command)}`);
       }
       const id = await invoke<number>('enqueue_task', { label, command: cmd });
       set((state) => ({
@@ -123,6 +123,7 @@ export const useTasks = create<TasksState>((set, get) => ({
       get().startPolling(id);
       return id;
     } catch (error) {
+      console.error(error);
       throw error;
     }
   },


### PR DESCRIPTION
## Summary
- show label and payload when a task command is missing its id
- log enqueueTask errors to the console
- update tests for new error message

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68af6b9b775c832587e2872cd862a9a7