### PR TITLE
style: improve text field label readability

### DIFF
--- a/src/features/dnd/StyledTextField.tsx
+++ b/src/features/dnd/StyledTextField.tsx
@@ -6,7 +6,15 @@ export default function StyledTextField(props: TextFieldProps) {
     <TextField
       variant="outlined"
       label={label}
-      InputLabelProps={InputLabelProps}
+      InputLabelProps={{
+        ...InputLabelProps,
+        sx: {
+          backgroundColor: "background.paper",
+          px: 0.5,
+          color: "text.primary",
+          ...(InputLabelProps && (InputLabelProps as any).sx),
+        },
+      }}
       InputProps={{
         ...InputProps,
         sx: {


### PR DESCRIPTION
## Summary
- Improve text field label readability by adding background, padding, and color styling

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68af6c039dec8325a0113980ab837dd3