### PR TITLE
Handle race field in NPC extraction

### DIFF
--- a/src-tauri/python/pdf_tools.py
+++ b/src-tauri/python/pdf_tools.py
@@ -261,7 +261,7 @@ def extract_npcs(path: str):
         npc = {
             "id": str(uuid.uuid4()),
             "name": data.get("name", "Unknown"),
-            "species": data.get("species", "Unknown"),
+            "species": data.get("species") or data.get("race") or "Unknown",
             "role": data.get("role", "Unknown"),
             "alignment": data.get("alignment", "Neutral"),
             "playerCharacter": data.get("playercharacter", "false").lower()
@@ -308,6 +308,7 @@ def extract_npcs(path: str):
             not in {
                 "name",
                 "species",
+                "race",
                 "role",
                 "alignment",
                 "playercharacter",


### PR DESCRIPTION
## Summary
- Use `race` as a fallback when populating NPC species
- Exclude `race` from extra sections when parsing NPC data

## Testing
- `pytest -q src-tauri/python/tests/test_pdf_tools.py`
- `pytest -q src-tauri/python/tests`

------
https://chatgpt.com/codex/tasks/task_e_68af6dc878dc8325a88e463d4fa44f91