### PR TITLE
feat: add optional age for NPCs

### DIFF
--- a/src-tauri/python/pdf_tools.py
+++ b/src-tauri/python/pdf_tools.py
@@ -274,6 +274,15 @@ def extract_npcs(path: str):
             "tags": tags,
         }
 
+        age_raw = data.get("age")
+        if age_raw:
+            try:
+                age_val = int(age_raw)
+                if age_val > 0:
+                    npc["age"] = age_val
+            except ValueError:
+                pass
+
         voice_raw = data.get("voice")
         if voice_raw:
             parts = [p.strip() for p in voice_raw.split(",")]
@@ -317,13 +326,14 @@ def extract_npcs(path: str):
                 "hooks",
                 "quirks",
                 "portrait",
-                "icon",
-                "voice",
-                "voice_style",
-                "voice_provider",
-                "voice_preset",
-                "tags",
-            }
+            "icon",
+            "voice",
+            "voice_style",
+            "voice_provider",
+            "voice_preset",
+            "tags",
+            "age",
+        }
         }
         if sections:
             npc["sections"] = sections

--- a/src/dnd/schemas/npc.ts
+++ b/src/dnd/schemas/npc.ts
@@ -30,6 +30,7 @@ export const zNpc = z.object({
   role: z.string().min(1),
   alignment: z.string().min(1),
   playerCharacter: z.boolean(),
+  age: z.number().int().positive().optional(),
   backstory: z.string().optional(),
   location: z.string().optional(),
   hooks: z.array(z.string()).nonempty(),

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -29,6 +29,7 @@ interface FormState {
   role: string;
   alignment: string;
   playerCharacter: boolean;
+  age: string;
   backstory: string;
   location: string;
   hooks: string;
@@ -47,6 +48,7 @@ const initialState: FormState = {
   role: "",
   alignment: "",
   playerCharacter: false,
+  age: "",
   backstory: "",
   location: "",
   hooks: "",
@@ -137,6 +139,7 @@ export default function NpcForm({ world }: Props) {
       role: state.role,
       alignment: state.alignment,
       playerCharacter: state.playerCharacter,
+      age: state.age ? parseInt(state.age, 10) : undefined,
       backstory: state.backstory || undefined,
       location: state.location || undefined,
       hooks: state.hooks.split(",").map((h) => h.trim()).filter(Boolean),
@@ -192,6 +195,7 @@ export default function NpcForm({ world }: Props) {
                   dispatch({ type: "SET_FIELD", field: "role", value: npc.role });
                   dispatch({ type: "SET_FIELD", field: "alignment", value: npc.alignment });
                   dispatch({ type: "SET_FIELD", field: "playerCharacter", value: npc.playerCharacter });
+                  dispatch({ type: "SET_FIELD", field: "age", value: npc.age?.toString() || "" });
                   dispatch({ type: "SET_FIELD", field: "backstory", value: npc.backstory || "" });
                   dispatch({ type: "SET_FIELD", field: "location", value: npc.location || "" });
                   dispatch({ type: "SET_FIELD", field: "hooks", value: (npc.hooks || []).join(", ") });
@@ -292,6 +296,23 @@ export default function NpcForm({ world }: Props) {
                 aria-describedby={
                   errors.alignment ? "alignment-error" : undefined
                 }
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <StyledTextField
+                id="age"
+                label="Age"
+                type="number"
+                value={state.age}
+                onChange={(e) => {
+                  dispatch({ type: "SET_FIELD", field: "age", value: e.target.value });
+                  setErrors((prev) => ({ ...prev, age: null }));
+                }}
+                fullWidth
+                margin="normal"
+                error={Boolean(errors.age)}
+                helperText={<FormErrorText id="age-error">{errors.age}</FormErrorText>}
+                aria-describedby={errors.age ? "age-error" : undefined}
               />
             </Grid>
             <Grid item xs={4}>

--- a/src/pages/NPCMaker.tsx
+++ b/src/pages/NPCMaker.tsx
@@ -18,6 +18,7 @@ export default function NPCMaker() {
     species: '',
     role: '',
     alignment: '',
+    age: undefined,
     backstory: '',
     location: '',
     hooks: ['Hook'],
@@ -105,7 +106,10 @@ export default function NPCMaker() {
     }
   }
 
-  function handleChange(field: keyof Omit<Npc, 'id'>, value: string | boolean) {
+  function handleChange(
+    field: keyof Omit<Npc, 'id'>,
+    value: string | boolean | number | undefined
+  ) {
     setNpc((prev) => ({ ...prev, [field]: value }));
   }
 
@@ -153,6 +157,7 @@ export default function NPCMaker() {
         species: '',
         role: '',
         alignment: '',
+        age: undefined,
         backstory: '',
         location: '',
         hooks: ['Hook'],
@@ -209,6 +214,15 @@ export default function NPCMaker() {
           label="Alignment"
           value={npc.alignment}
           onChange={(e) => handleChange('alignment', e.target.value)}
+          fullWidth
+        />
+        <TextField
+          label="Age"
+          type="number"
+          value={npc.age ?? ''}
+          onChange={(e) =>
+            handleChange('age', e.target.value ? Number(e.target.value) : undefined)
+          }
           fullWidth
         />
         <TextField


### PR DESCRIPTION
## Summary
- allow NPCs to include optional `age`
- capture age in NPC form and maker UI
- parse age from NPC PDF extraction

## Testing
- `npm test`
- `pytest` *(fails: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6fbe31588325ae959dc713dba7fd