### PR TITLE
Clone task command payload for clearer errors

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2328,8 +2328,9 @@ pub async fn enqueue_task(
     label: String,
     command: Value,
 ) -> Result<u64, String> {
+    let payload = command.clone();
     let command = serde_json::from_value::<TaskCommand>(command)
-        .map_err(|e| format!("invalid task command: {e}; payload: {command}"))?;
+        .map_err(|e| format!("invalid task command: {e}; payload: {payload}"))?;
     Ok(queue.enqueue(label, command).await)
 }
 


### PR DESCRIPTION
## Summary
- Clone command payload before parsing so it remains available in error messages

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: test failed, to rerun pass --lib)*

------
https://chatgpt.com/codex/tasks/task_e_68af6fb2d68c8325a318dbfd84590df9