### PR TITLE
feat: support alternate npc location keys

### DIFF
--- a/src-tauri/python/pdf_tools.py
+++ b/src-tauri/python/pdf_tools.py
@@ -267,7 +267,10 @@ def extract_npcs(path: str):
             "playerCharacter": data.get("playercharacter", "false").lower()
             == "true",
             "backstory": data.get("backstory"),
-            "location": data.get("location"),
+            "location": data.get("location")
+            or data.get("origin")
+            or data.get("domain")
+            or data.get("origin/domain"),
             "hooks": hooks,
             "quirks": [q.strip() for q in data.get("quirks", "").split(",") if q.strip()] or None,
             "statblock": {},
@@ -323,17 +326,20 @@ def extract_npcs(path: str):
                 "playercharacter",
                 "backstory",
                 "location",
+                "origin",
+                "domain",
+                "origin/domain",
                 "hooks",
                 "quirks",
                 "portrait",
-            "icon",
-            "voice",
-            "voice_style",
-            "voice_provider",
-            "voice_preset",
-            "tags",
-            "age",
-        }
+                "icon",
+                "voice",
+                "voice_style",
+                "voice_provider",
+                "voice_preset",
+                "tags",
+                "age",
+            }
         }
         if sections:
             npc["sections"] = sections


### PR DESCRIPTION
## Summary
- fallback NPC location to origin/domain fields when location absent
- exclude origin-related keys from extra section export

## Testing
- `pytest src-tauri/python/tests/test_pdf_tools.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af738bb0c08325b6736cbf0cec8f80