### PR TITLE
Add appearance field to NPC workflow

### DIFF
--- a/src-tauri/python/pdf_tools.py
+++ b/src-tauri/python/pdf_tools.py
@@ -270,6 +270,7 @@ def extract_npcs(path: str):
             "location": data.get("location"),
             "hooks": hooks,
             "quirks": [q.strip() for q in data.get("quirks", "").split(",") if q.strip()] or None,
+            "appearance": data.get("appearance"),
             "statblock": {},
             "tags": tags,
         }
@@ -325,15 +326,16 @@ def extract_npcs(path: str):
                 "location",
                 "hooks",
                 "quirks",
+                "appearance",
                 "portrait",
-            "icon",
-            "voice",
-            "voice_style",
-            "voice_provider",
-            "voice_preset",
-            "tags",
-            "age",
-        }
+                "icon",
+                "voice",
+                "voice_style",
+                "voice_provider",
+                "voice_preset",
+                "tags",
+                "age",
+            }
         }
         if sections:
             npc["sections"] = sections

--- a/src-tauri/python/tests/test_pdf_tools.py
+++ b/src-tauri/python/tests/test_pdf_tools.py
@@ -84,6 +84,38 @@ def test_validate_entry(monkeypatch):
     assert not pdf_tools._validate_entry("npc", {"name": "Bob"})
 
 
+def _make_npc_pdf(tmp_path, fields):
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", "", 12)
+    for k, v in fields.items():
+        pdf.cell(0, 10, f"{k}: {v}", ln=1)
+    path = tmp_path / "npc.pdf"
+    pdf.output(str(path))
+    return str(path)
+
+
+def test_extract_npcs_parses_appearance(tmp_path):
+    path = _make_npc_pdf(
+        tmp_path,
+        {
+            "Name": "Alice",
+            "Species": "Elf",
+            "Role": "Merchant",
+            "Hooks": "Trade",
+            "Tags": "npc",
+            "Appearance": "Tall and slender",
+            "Extra": "Value",
+        },
+    )
+    res = pdf_tools.extract_npcs(path)
+    npc = res["npcs"][0]
+    assert npc["appearance"] == "Tall and slender"
+    sections = npc.get("sections", {})
+    assert "appearance" not in sections
+    assert sections.get("extra") == "Value"
+
+
 def _make_pdf(tmp_path, entries, use_bold=True, use_colon=False):
     """Create a simple PDF file with given entries.
 

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -34,6 +34,7 @@ interface FormState {
   location: string;
   hooks: string;
   quirks: string;
+  appearance: string;
   tags: string;
   portrait: string;
   icon: string;
@@ -53,6 +54,7 @@ const initialState: FormState = {
   location: "",
   hooks: "",
   quirks: "",
+  appearance: "",
   tags: "",
   portrait: "",
   icon: "",
@@ -146,6 +148,7 @@ export default function NpcForm({ world }: Props) {
       quirks: state.quirks
         ? state.quirks.split(",").map((q) => q.trim()).filter(Boolean)
         : undefined,
+      appearance: state.appearance || undefined,
       voiceId: state.voiceId || undefined,
       portrait: state.portrait || "placeholder.png",
       icon: state.icon || "placeholder-icon.png",
@@ -200,6 +203,7 @@ export default function NpcForm({ world }: Props) {
                   dispatch({ type: "SET_FIELD", field: "location", value: npc.location || "" });
                   dispatch({ type: "SET_FIELD", field: "hooks", value: (npc.hooks || []).join(", ") });
                   dispatch({ type: "SET_FIELD", field: "quirks", value: (npc.quirks || []).join(", ") });
+                  dispatch({ type: "SET_FIELD", field: "appearance", value: npc.appearance || "" });
                   dispatch({ type: "SET_FIELD", field: "tags", value: (npc.tags || []).join(", ") });
                   dispatch({ type: "SET_FIELD", field: "portrait", value: npc.portrait || "" });
                   dispatch({ type: "SET_FIELD", field: "icon", value: npc.icon || "" });

--- a/src/pages/NPCMaker.tsx
+++ b/src/pages/NPCMaker.tsx
@@ -232,6 +232,12 @@ export default function NPCMaker() {
           onChange={(e) => handleChange('backstory', e.target.value)}
           fullWidth
         />
+        <TextField
+          label="Appearance"
+          value={npc.appearance}
+          onChange={(e) => handleChange('appearance', e.target.value)}
+          fullWidth
+        />
         <FormControlLabel
           control={
             <Checkbox


### PR DESCRIPTION
## Summary
- Support `appearance` in NPC form state and submission
- Add `Appearance` input to NPC maker page
- Parse `appearance` from NPC PDF imports and exclude from custom sections

## Testing
- `vitest src/features/dnd/tests/NpcForm.test.tsx src/features/dnd/tests/schemas.test.ts`
- `pytest src-tauri/python/tests/test_pdf_tools.py::test_extract_npcs_parses_appearance -q`

------
https://chatgpt.com/codex/tasks/task_e_68af739201688325b3dd6d4629396e8a