### PR TITLE
feat: add optional personality for NPCs

### DIFF
--- a/src-tauri/python/pdf_tools.py
+++ b/src-tauri/python/pdf_tools.py
@@ -267,6 +267,7 @@ def extract_npcs(path: str):
             "playerCharacter": data.get("playercharacter", "false").lower()
             == "true",
             "backstory": data.get("backstory"),
+            "personality": data.get("personality"),
             "location": data.get("location"),
             "hooks": hooks,
             "quirks": [q.strip() for q in data.get("quirks", "").split(",") if q.strip()] or None,
@@ -322,6 +323,7 @@ def extract_npcs(path: str):
                 "alignment",
                 "playercharacter",
                 "backstory",
+                "personality",
                 "location",
                 "hooks",
                 "quirks",

--- a/src/dnd/schemas/npc.ts
+++ b/src/dnd/schemas/npc.ts
@@ -32,6 +32,7 @@ export const zNpc = z.object({
   playerCharacter: z.boolean(),
   age: z.number().int().positive().optional(),
   backstory: z.string().optional(),
+  personality: z.string().optional(),
   location: z.string().optional(),
   hooks: z.array(z.string()).nonempty(),
   quirks: z.array(z.string()).optional(),

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -31,6 +31,7 @@ interface FormState {
   playerCharacter: boolean;
   age: string;
   backstory: string;
+  personality: string;
   location: string;
   hooks: string;
   quirks: string;
@@ -50,6 +51,7 @@ const initialState: FormState = {
   playerCharacter: false,
   age: "",
   backstory: "",
+  personality: "",
   location: "",
   hooks: "",
   quirks: "",
@@ -141,6 +143,7 @@ export default function NpcForm({ world }: Props) {
       playerCharacter: state.playerCharacter,
       age: state.age ? parseInt(state.age, 10) : undefined,
       backstory: state.backstory || undefined,
+      personality: state.personality || undefined,
       location: state.location || undefined,
       hooks: state.hooks.split(",").map((h) => h.trim()).filter(Boolean),
       quirks: state.quirks

--- a/src/pages/NPCMaker.tsx
+++ b/src/pages/NPCMaker.tsx
@@ -20,6 +20,7 @@ export default function NPCMaker() {
     alignment: '',
     age: undefined,
     backstory: '',
+    personality: '',
     location: '',
     hooks: ['Hook'],
     quirks: [],
@@ -159,6 +160,7 @@ export default function NPCMaker() {
         alignment: '',
         age: undefined,
         backstory: '',
+        personality: '',
         location: '',
         hooks: ['Hook'],
         quirks: [],
@@ -230,6 +232,12 @@ export default function NPCMaker() {
           multiline
           value={npc.backstory}
           onChange={(e) => handleChange('backstory', e.target.value)}
+          fullWidth
+        />
+        <TextField
+          label="Personality"
+          value={npc.personality}
+          onChange={(e) => handleChange('personality', e.target.value)}
           fullWidth
         />
         <FormControlLabel


### PR DESCRIPTION
## Summary
- extend NPC schema with optional personality field
- wire personality through NPC forms and NPCMaker UI
- parse personality in PDF NPC extraction and exclude from sections

## Testing
- `npm test`
- `pytest` *(fails: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af739757ac83259b9b170fb1ee563d