### PR TITLE
Fallback occupation for NPC role and clarify label

### DIFF
--- a/src-tauri/python/pdf_tools.py
+++ b/src-tauri/python/pdf_tools.py
@@ -262,7 +262,7 @@ def extract_npcs(path: str):
             "id": str(uuid.uuid4()),
             "name": data.get("name", "Unknown"),
             "species": data.get("species") or data.get("race") or "Unknown",
-            "role": data.get("role", "Unknown"),
+            "role": data.get("role") or data.get("occupation") or "Unknown",
             "alignment": data.get("alignment", "Neutral"),
             "playerCharacter": data.get("playercharacter", "false").lower()
             == "true",
@@ -319,6 +319,7 @@ def extract_npcs(path: str):
                 "species",
                 "race",
                 "role",
+                "occupation",
                 "alignment",
                 "playercharacter",
                 "backstory",

--- a/src/pages/NPCMaker.tsx
+++ b/src/pages/NPCMaker.tsx
@@ -205,7 +205,7 @@ export default function NPCMaker() {
           fullWidth
         />
         <TextField
-          label="Role"
+          label="Role/Occupation"
           value={npc.role}
           onChange={(e) => handleChange('role', e.target.value)}
           fullWidth


### PR DESCRIPTION
## Summary
- Default NPC role to occupation when role is missing
- Show "Role/Occupation" label in NPC Maker UI

## Testing
- `pytest` *(fails: FFmpeg is required but was not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af739855348325956eb8771dab357c