### PR TITLE
feat: support ability scores for NPCs

### DIFF
--- a/src-tauri/python/pdf_tools.py
+++ b/src-tauri/python/pdf_tools.py
@@ -244,6 +244,22 @@ def extract_npcs(path: str):
                 data[k.strip().lower()] = v.strip()
         if not data:
             continue
+        ability_map = {
+            "str": "strength",
+            "dex": "dexterity",
+            "con": "constitution",
+            "int": "intelligence",
+            "wis": "wisdom",
+            "cha": "charisma",
+        }
+        abilities = {}
+        for short, full in ability_map.items():
+            val = data.pop(short, None)
+            if val is not None:
+                try:
+                    abilities[full] = int(val)
+                except ValueError:
+                    pass
         hooks = [h.strip() for h in (data.get("hooks") or "").split(",") if h.strip()]
         if not hooks:
             hooks = ["hook"]
@@ -273,6 +289,8 @@ def extract_npcs(path: str):
             "statblock": {},
             "tags": tags,
         }
+        if abilities:
+            npc["abilities"] = abilities
 
         age_raw = data.get("age")
         if age_raw:
@@ -310,22 +328,18 @@ def extract_npcs(path: str):
         if icon:
             npc["icon"] = icon
 
-        sections = {
-            k: v
-            for k, v in data.items()
-            if k
-            not in {
-                "name",
-                "species",
-                "race",
-                "role",
-                "alignment",
-                "playercharacter",
-                "backstory",
-                "location",
-                "hooks",
-                "quirks",
-                "portrait",
+        exclude = {
+            "name",
+            "species",
+            "race",
+            "role",
+            "alignment",
+            "playercharacter",
+            "backstory",
+            "location",
+            "hooks",
+            "quirks",
+            "portrait",
             "icon",
             "voice",
             "voice_style",
@@ -334,7 +348,8 @@ def extract_npcs(path: str):
             "tags",
             "age",
         }
-        }
+        exclude.update(ability_map.keys())
+        sections = {k: v for k, v in data.items() if k not in exclude}
         if sections:
             npc["sections"] = sections
         npcs.append(npc)

--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -39,6 +39,12 @@ interface FormState {
   icon: string;
   statblock: string;
   sections: string;
+  strength: string;
+  dexterity: string;
+  constitution: string;
+  intelligence: string;
+  wisdom: string;
+  charisma: string;
   voiceId: string;
 }
 
@@ -58,6 +64,12 @@ const initialState: FormState = {
   icon: "",
   statblock: "{}",
   sections: "{}",
+  strength: "",
+  dexterity: "",
+  constitution: "",
+  intelligence: "",
+  wisdom: "",
+  charisma: "",
   voiceId: "",
 };
 
@@ -101,6 +113,14 @@ export default function NpcForm({ world }: Props) {
   const [errors, setErrors] = useState<Record<string, string | null>>({});
   const [result, setResult] = useState<NpcData | null>(null);
   const [importedName, setImportedName] = useState<string | null>(null);
+  const abilityKeys = [
+    "strength",
+    "dexterity",
+    "constitution",
+    "intelligence",
+    "wisdom",
+    "charisma",
+  ] as const;
 
   const handleFileChange =
     (field: "portrait" | "icon") =>
@@ -132,6 +152,17 @@ export default function NpcForm({ world }: Props) {
       return;
     }
 
+    const abilities: Record<string, number> = {};
+    abilityKeys.forEach((ab) => {
+      const val = state[ab];
+      if (val) {
+        const num = parseInt(val, 10);
+        if (!Number.isNaN(num)) {
+          abilities[ab] = num;
+        }
+      }
+    });
+
     const data: NpcData = {
       id: crypto.randomUUID(),
       name: state.name,
@@ -152,6 +183,7 @@ export default function NpcForm({ world }: Props) {
       sections: Object.keys(parsedSections).length ? parsedSections : undefined,
       statblock: parsedStatblock,
       tags: state.tags.split(",").map((t) => t.trim()).filter(Boolean),
+      abilities: Object.keys(abilities).length ? (abilities as any) : undefined,
     };
 
     const parsed = zNpc.safeParse(data);
@@ -214,6 +246,17 @@ export default function NpcForm({ world }: Props) {
                     value: JSON.stringify(npc.sections || {}, null, 2),
                   });
                   dispatch({ type: "SET_FIELD", field: "voiceId", value: npc.voiceId || "" });
+                  abilityKeys.forEach((ab) =>
+                    dispatch({
+                      type: "SET_FIELD",
+                      field: ab,
+                      value:
+                        npc.abilities &&
+                        (npc.abilities as Record<string, number>)[ab] !== undefined
+                          ? (npc.abilities as Record<string, number>)[ab].toString()
+                          : "",
+                    })
+                  );
                 }}
               />
               {importedName && (
@@ -415,6 +458,35 @@ export default function NpcForm({ world }: Props) {
                 aria-describedby={errors.tags ? "tags-error" : undefined}
               />
             </Grid>
+        </Grid>
+      </Grid>
+
+        {/* Abilities */}
+        <Grid item xs={12}>
+          <Typography variant="subtitle1" sx={{ mt: 2 }}>
+            Abilities
+          </Typography>
+          <Divider sx={{ mb: 2 }} />
+          <Grid container spacing={2}>
+            {abilityKeys.map((ab) => (
+              <Grid item xs={4} key={ab}>
+                <StyledTextField
+                  id={ab}
+                  label={ab.charAt(0).toUpperCase() + ab.slice(1)}
+                  type="number"
+                  value={state[ab]}
+                  onChange={(e) =>
+                    dispatch({
+                      type: "SET_FIELD",
+                      field: ab,
+                      value: e.target.value,
+                    })
+                  }
+                  fullWidth
+                  margin="normal"
+                />
+              </Grid>
+            ))}
           </Grid>
         </Grid>
 

--- a/src/pages/NPCMaker.tsx
+++ b/src/pages/NPCMaker.tsx
@@ -7,6 +7,7 @@ import ErrorIcon from '@mui/icons-material/Error';
 import Center from './_Center';
 import { useNPCs } from '../store/npcs';
 import type { Npc } from '../dnd/schemas/npc';
+import type { Ability } from '../dnd/characters';
 import { useWorlds } from '../store/worlds';
 
 const systemPrompt =
@@ -29,6 +30,7 @@ export default function NPCMaker() {
     playerCharacter: false,
     statblock: {},
     tags: ['npc'],
+    abilities: {},
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>('');
@@ -37,6 +39,14 @@ export default function NPCMaker() {
 
   const addNPC = useNPCs((s) => s.addNPC);
   const world = useWorlds((s) => s.currentWorld);
+  const abilityKeys: Ability[] = [
+    'strength',
+    'dexterity',
+    'constitution',
+    'intelligence',
+    'wisdom',
+    'charisma',
+  ];
 
   useEffect(() => {
     async function start() {
@@ -113,6 +123,21 @@ export default function NPCMaker() {
     setNpc((prev) => ({ ...prev, [field]: value }));
   }
 
+  function handleAbilityChange(
+    ability: Ability,
+    value: number | undefined
+  ) {
+    setNpc((prev) => {
+      const abilities = { ...(prev.abilities || {}) } as Record<Ability, number>;
+      if (value === undefined) {
+        delete abilities[ability];
+      } else {
+        abilities[ability] = value;
+      }
+      return { ...prev, abilities };
+    });
+  }
+
   async function selectImage(field: 'portrait' | 'icon') {
     const selected = await open({
       multiple: false,
@@ -168,6 +193,7 @@ export default function NPCMaker() {
         playerCharacter: false,
         statblock: {},
         tags: ['npc'],
+        abilities: {},
       });
       setSnackbarOpen(true);
     } catch (e) {
@@ -225,6 +251,23 @@ export default function NPCMaker() {
           }
           fullWidth
         />
+        <Stack direction="row" spacing={1} sx={{ flexWrap: 'wrap' }}>
+          {abilityKeys.map((ab) => (
+            <TextField
+              key={ab}
+              label={ab[0].toUpperCase() + ab.slice(1)}
+              type="number"
+              value={npc.abilities?.[ab] ?? ''}
+              onChange={(e) =>
+                handleAbilityChange(
+                  ab,
+                  e.target.value ? Number(e.target.value) : undefined
+                )
+              }
+              sx={{ flex: 1, minWidth: 120 }}
+            />
+          ))}
+        </Stack>
         <TextField
           label="Backstory"
           multiline


### PR DESCRIPTION
## Summary
- add ability score inputs to NPC form and submit them as an abilities record
- allow NPC Maker to edit abilities with dedicated fields
- parse ability abbreviations when importing NPC PDFs, keeping them out of custom sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af739b6b6c8325afe735d5c9bf02d3