### PR TITLE
Hide RetroTV on Comfy route

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Mock non-essential components and pages to isolate RetroTV behavior
+vi.mock('./components/TopBar', () => ({ default: () => <div /> }));
+vi.mock('./components/CreateUserDialog', () => ({ default: () => <div /> }));
+vi.mock('./pages/Comfy', () => ({ default: () => <div>Comfy</div> }));
+vi.mock('./pages/Home', () => ({ default: () => <div>Home</div> }));
+
+// Provide minimal implementations for hooks used by RetroTV/App
+vi.mock('./features/theme/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'retro' })
+}));
+
+vi.mock('./features/users/useUsers', () => ({
+  useUsers: (selector: any) =>
+    selector({ users: {}, currentUserId: null, switchUser: vi.fn() })
+}));
+
+import App from './App';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('App RetroTV overlay', () => {
+  it('shows RetroTV on non-Comfy routes', () => {
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/' }]}> 
+        <App />
+      </MemoryRouter>
+    );
+    expect(screen.getByText('NO SIGNAL')).toBeInTheDocument();
+  });
+
+  it('hides RetroTV on the Comfy route', () => {
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/comfy' }]}> 
+        <App />
+      </MemoryRouter>
+    );
+    expect(screen.queryByText('NO SIGNAL')).toBeNull();
+  });
+});
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,7 +53,9 @@ export default function App() {
   return (
     <ErrorBoundary>
         <TopBar />
-        {pathname !== "/calendar" && <RetroTV>NO SIGNAL</RetroTV>}
+        {pathname !== "/calendar" && pathname !== "/comfy" && (
+          <RetroTV>NO SIGNAL</RetroTV>
+        )}
         <CreateUserDialog open={showUserDialog} onClose={() => setShowUserDialog(false)} />
       <Routes>
         <Route path="/" element={<Home />} />


### PR DESCRIPTION
## Summary
- Hide RetroTV overlay when visiting the Comfy UI route
- Add regression tests verifying the overlay is absent on `/comfy`

## Testing
- `npm test -- --run src/App.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68af766d10108325bdf609668401c073