### PR TITLE
Include Bark TTS script in Tauri bundle resources

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,7 +37,8 @@
     "resources": [
       "../public/sfz_sounds",
       "python/lofi",
-      "python/ambience_generator.py"
+      "python/ambience_generator.py",
+      "python/bark_tts.py"
     ]
 
   }


### PR DESCRIPTION
## Summary
- include `python/bark_tts.py` in Tauri bundle resources

## Testing
- `cargo build`
- `ls target/debug/python`
- `python - <<'PY' ...` (Bark TTS import)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af78f0aff8832595b9562a6d9ee9a8