### PR TITLE
Add GenerateSong task and handler

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -892,6 +892,14 @@ pub async fn run_lofi_song<R: Runtime>(
 }
 
 #[tauri::command]
+pub async fn generate_song<R: Runtime>(
+    app: AppHandle<R>,
+    spec: SongSpec,
+) -> Result<String, String> {
+    run_lofi_song(app, spec).await
+}
+
+#[tauri::command]
 pub async fn generate_album<R: Runtime>(
     app: AppHandle<R>,
     meta: AlbumRequest,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -99,6 +99,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             commands::lofi_generate_gpu,
             commands::run_lofi_song,
+            commands::generate_song,
             commands::generate_album,
             commands::cancel_album,
             commands::dj_mix,

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -117,7 +117,7 @@ describe('SongForm', () => {
     await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
     const [, args] = enqueueTask.mock.calls[0];
     const spec = args.spec;
-    expect(args.id).toBe('GenerateShort');
+    expect(args.id).toBe('GenerateSong');
     expect(spec.structure[0]).toHaveProperty('chords');
     expect(spec.chord_span_beats).toBe(4);
     expect(spec).toMatchObject({
@@ -339,7 +339,7 @@ describe('SongForm', () => {
 
     await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
     const [, args] = enqueueTask.mock.calls[0];
-    expect(args.id).toBe('GenerateShort');
+    expect(args.id).toBe('GenerateSong');
     expect(args.spec.instruments).toEqual(['harp', 'lute', 'pan flute']);
   });
 
@@ -366,7 +366,7 @@ describe('SongForm', () => {
 
     await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
     const [, args] = enqueueTask.mock.calls[0];
-    expect(args.id).toBe('GenerateShort');
+    expect(args.id).toBe('GenerateSong');
     expect(args.spec.sfzInstrument).toBe('/tmp/piano file.sfz');
     expect(setPreviewSfzInstrument).toHaveBeenCalledWith(
       'tauri:///tmp/piano%20file.sfz'
@@ -404,7 +404,7 @@ describe('SongForm', () => {
 
     await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
     const [, args] = enqueueTask.mock.calls[0];
-    expect(args.id).toBe('GenerateShort');
+    expect(args.id).toBe('GenerateSong');
     expect(args.spec.lead_instrument).toBe('flute');
   });
 

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -722,7 +722,7 @@ export default function SongForm() {
         try {
           const taskId = await enqueueTask(
             "Music Generation",
-            { id: "GenerateShort", spec: job.spec }
+            { id: "GenerateSong", spec: job.spec }
           );
           setJobs((prev) =>
             prev.map((j) => (j.id === job.id ? { ...j, taskId } : j))

--- a/src/store/tasks.test.ts
+++ b/src/store/tasks.test.ts
@@ -57,11 +57,11 @@ describe('enqueueTask validation', () => {
 
   it('builds command when label is a valid id and id is missing', async () => {
     (invoke as any).mockResolvedValue(1);
-    const id = await useTasks.getState().enqueueTask('ParseSpellPdf', { path: 'x' } as any);
+    const id = await useTasks.getState().enqueueTask('GenerateSong', { spec: {} } as any);
     expect(id).toBe(1);
     expect(invoke).toHaveBeenCalledWith('enqueue_task', {
-      label: 'ParseSpellPdf',
-      command: { id: 'ParseSpellPdf', path: 'x' },
+      label: 'GenerateSong',
+      command: { id: 'GenerateSong', spec: {} },
     });
   });
 

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -17,6 +17,7 @@ export type TaskCommand =
   | { id: 'ParseSpellPdf'; py?: string; script?: string; path: string }
   | { id: 'ParseRulePdf'; py?: string; script?: string; path: string }
   | { id: 'ParseLorePdf'; py?: string; script?: string; path: string; world: string }
+  | { id: 'GenerateSong'; spec: any }
   | { id: 'GenerateAlbum'; meta: any }
   | { id: 'GenerateShort'; spec: any };
 
@@ -28,6 +29,7 @@ const TASK_IDS: TaskCommand['id'][] = [
   'ParseSpellPdf',
   'ParseRulePdf',
   'ParseLorePdf',
+  'GenerateSong',
   'GenerateAlbum',
   'GenerateShort',
 ];


### PR DESCRIPTION
## Summary
- support single-song rendering by adding `GenerateSong` task variant and queue handler
- expose new `generate_song` command and update frontend to enqueue it
- include `GenerateSong` in task store and tests

## Testing
- `cargo test` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7b880bc08325acb541cc76bf6bd1