### PR TITLE
Handle optional lead instrument in SongForm spec

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -123,13 +123,13 @@ describe('SongForm', () => {
     expect(spec).toMatchObject({
       ambience: ['rain'],
       ambience_level: 0.5,
-      lead_instrument: 'synth lead',
       hq_stereo: true,
       hq_reverb: true,
       hq_sidechain: true,
       hq_chorus: true,
       limiter_drive: 1.02,
     });
+    expect(spec.lead_instrument).toBe('synth lead');
   });
 
   it('generates a title with ollama', async () => {
@@ -368,9 +368,37 @@ describe('SongForm', () => {
     const [, args] = enqueueTask.mock.calls[0];
     expect(args.id).toBe('GenerateShort');
     expect(args.spec.sfzInstrument).toBe('/tmp/piano file.sfz');
+    expect(args.spec.instruments).toEqual([]);
     expect(setPreviewSfzInstrument).toHaveBeenCalledWith(
       'tauri:///tmp/piano%20file.sfz'
     );
+  });
+
+  it('omits instruments and lead instrument for sfz-only songs', async () => {
+    (openDialog as any).mockResolvedValue('/tmp/out');
+    (invoke as any).mockResolvedValue('');
+
+    render(<SongForm />);
+
+    fireEvent.click(screen.getByText(/choose folder/i));
+    await screen.findByText('/tmp/out');
+
+    openSection('sfz-section');
+    fireEvent.click(screen.getByText('Acoustic Grand Piano'));
+    await waitFor(() => expect(setPreviewSfzInstrument).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByPlaceholderText(/song title base/i), {
+      target: { value: 'Test Song' },
+    });
+
+    fireEvent.click(screen.getByText(/render songs/i));
+
+    await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
+    const [, args] = enqueueTask.mock.calls[0];
+    expect(args.id).toBe('GenerateShort');
+    expect(args.spec.sfzInstrument).toBeDefined();
+    expect(args.spec.instruments).toEqual([]);
+    expect(args.spec.lead_instrument).toBeUndefined();
   });
 
   it('updates lead instrument when adding a lead-capable instrument', () => {

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -645,11 +645,13 @@ export default function SongForm() {
   function makeSpecForIndex(i: number): SongSpec {
     const amb = Math.max(0, Math.min(1, ambienceLevel));
     const varPct = Math.max(0, Math.min(100, variety));
-    const instrs = instruments.length
-      ? instruments
-      : leadInstrument
-        ? [leadInstrument]
-        : [];
+    const instrs = sfzInstrument
+      ? []
+      : instruments.length
+        ? instruments
+        : leadInstrument
+          ? [leadInstrument]
+          : [];
 
     return {
       title: buildTitle(i),
@@ -660,7 +662,7 @@ export default function SongForm() {
       structure: structure.map(({ name, bars, chords }) => ({ name, bars, chords })),
       mood,
       instruments: instrs,
-      lead_instrument: leadInstrument,
+      lead_instrument: leadInstrument || undefined,
       sfzInstrument: sfzInstrument ?? undefined,
       ambience,
       ambience_level: amb,


### PR DESCRIPTION
## Summary
- Allow SongForm to omit `lead_instrument` when none selected and keep instruments empty for SFZ-only songs
- Expand tests for SFZ instrument handling and optional lead instrument

## Testing
- `npm test src/components/SongForm.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68af7b8d50f083258d841f32e947235e