### PR TITLE
feat: track world inventory items

### DIFF
--- a/dnd/schemas/item.schema.json
+++ b/dnd/schemas/item.schema.json
@@ -12,6 +12,9 @@
           "type": "string",
           "minLength": 1
         },
+        "value": {
+          "type": "number"
+        },
         "description": {
           "type": "string"
         },

--- a/src/dnd/items/index.ts
+++ b/src/dnd/items/index.ts
@@ -4,7 +4,9 @@ export const zItem = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
   quantity: z.number().int().min(1).default(1),
+  value: z.number().optional(),
   description: z.string().optional(),
+  tags: z.array(z.string()).optional(),
 });
 
 export type Item = z.infer<typeof zItem>;

--- a/src/dnd/schemas/item.ts
+++ b/src/dnd/schemas/item.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const zItem = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
+  value: z.number().optional(),
   description: z.string().optional(),
   tags: z.array(z.string()).optional(),
 });

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -6,6 +6,7 @@ import { useEncounterStore } from "./encounter";
 import { useWarTableStore } from "./warTable";
 import { useTabletopStore } from "./tabletop";
 import { useVoices } from "./voices";
+import { useInventory } from "./inventory";
 
 // Export individual stores for existing imports elsewhere
 export {
@@ -16,6 +17,7 @@ export {
   useWarTableStore,
   useTabletopStore,
   useVoices,
+  useInventory,
 };
 
 const slices = {
@@ -25,6 +27,7 @@ const slices = {
   encounter: useEncounterStore,
   warTable: useWarTableStore,
   tabletop: useTabletopStore,
+  inventory: useInventory,
 };
 
 type StoreState<T> = {

--- a/src/store/inventory.test.ts
+++ b/src/store/inventory.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useInventory } from './inventory';
+import type { Npc } from '../dnd/schemas/npc';
+
+const baseNpc = {
+  species: 'Human',
+  role: 'Villager',
+  alignment: 'Neutral',
+  playerCharacter: false,
+  hooks: ['hook'],
+  tags: ['tag'],
+  statblock: {},
+};
+
+describe('inventory scanning', () => {
+  beforeEach(() => {
+    useInventory.setState({ items: {} });
+  });
+
+  it('creates world items with npc references', () => {
+    const npcs: Npc[] = [
+      { ...baseNpc, id: '1', name: 'A', inventory: ['Sword'] } as Npc,
+      { ...baseNpc, id: '2', name: 'B', inventory: ['Sword', 'Shield'] } as Npc,
+    ];
+    useInventory.getState().scanNPCs(npcs);
+    const items = useInventory.getState().items;
+    const sword = Object.values(items).find((i) => i.name === 'Sword');
+    const shield = Object.values(items).find((i) => i.name === 'Shield');
+    expect(sword?.npcIds.sort()).toEqual(['1', '2']);
+    expect(shield?.npcIds).toEqual(['2']);
+  });
+
+  it('does not duplicate npc references on rescan', () => {
+    const npcs: Npc[] = [
+      { ...baseNpc, id: '1', name: 'A', inventory: ['Sword'] } as Npc,
+    ];
+    useInventory.getState().scanNPCs(npcs);
+    useInventory.getState().scanNPCs(npcs);
+    const sword = Object.values(useInventory.getState().items).find((i) => i.name === 'Sword');
+    expect(sword?.npcIds).toEqual(['1']);
+  });
+});

--- a/src/store/inventory.ts
+++ b/src/store/inventory.ts
@@ -1,0 +1,56 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { Npc } from '../dnd/schemas/npc';
+import type { Item } from '../dnd/schemas/item';
+
+export interface WorldItem extends Item {
+  npcIds: string[];
+}
+
+interface InventoryState {
+  items: Record<string, WorldItem>;
+  scanNPCs: (npcs: Npc[]) => void;
+}
+
+export const useInventory = create<InventoryState>()(
+  persist(
+    (set) => ({
+      items: {},
+      scanNPCs: (npcs) =>
+        set((state) => {
+          const items = { ...state.items };
+          const nameToId: Record<string, string> = {};
+          // reset npc references
+          for (const [id, item] of Object.entries(items)) {
+            nameToId[item.name] = id;
+            item.npcIds = [];
+          }
+          for (const npc of npcs) {
+            for (const name of npc.inventory || []) {
+              let itemId = nameToId[name];
+              if (!itemId) {
+                itemId = crypto.randomUUID();
+                nameToId[name] = itemId;
+                items[itemId] = {
+                  id: itemId,
+                  name,
+                  value: 0,
+                  description: '',
+                  tags: [],
+                  npcIds: [],
+                };
+              }
+              const entry = items[itemId];
+              if (!entry.npcIds.includes(npc.id)) {
+                entry.npcIds.push(npc.id);
+              }
+            }
+          }
+          return { items };
+        }),
+    }),
+    { name: 'inventory-store' }
+  )
+);
+
+export type { InventoryState };


### PR DESCRIPTION
## Summary
- add world inventory store that consolidates NPC items
- scan NPC inventories to populate shared entries
- expand item schema with optional value field

## Testing
- `npm test -- --run` *(fails: SongForm > omits instruments and lead instrument for sfz-only songs)*
- `npx vitest run src/store/inventory.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af800575b08325a9867f8b87589c13