### PR TITLE
chore: drop unused python deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ npm run tauri build  # build a release bundle
 The Rust backend can launch local tools such as ComfyUI and Ollama. Set the
 ComfyUI folder location in the app's Settings page. Python is detected
 automatically, and you can adjust the interpreter path from Settings if needed.
+Install the [`ollama`](https://github.com/ollama/ollama) CLI separately if you
+plan to use the general chat features; the Python package is not required.
 
 ## Running Python scripts
 

--- a/docs/dependency-notes.md
+++ b/docs/dependency-notes.md
@@ -1,0 +1,15 @@
+# Dependency audit
+
+The following dependencies were evaluated and removed from `requirements.txt`
+because no references were found in the codebase:
+
+- **Pillow** – no imports of `PIL` detected.
+- **feedparser** – no usage of the `feedparser` library.
+- **aiohttp** – no asynchronous HTTP client usage detected.
+- **pdfminer.six** – PDF processing is handled with `pdfplumber` instead.
+- **SQLAlchemy** – no database ORM code present.
+- **PySide6** – no Qt GUI components used.
+- **ollama** – the application uses the `ollama` CLI from Rust/TypeScript;
+  the Python package is not required.
+
+These packages have been removed from `requirements.txt` and `pyproject.toml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,4 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "pdfplumber>=0.10.3",
-    "pdfminer.six>=20221105",
-    "SQLAlchemy>=2.0",
-    "PySide6>=6.5",
-    "ollama>=0.1.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,17 +5,9 @@ scipy>=1.9.0
 pdfplumber>=0.10.3
 pytesseract>=0.3.10
 fpdf2>=2.7
-Pillow>=9.0.0
-feedparser>=6.0.0
 requests>=2.32.0
-aiohttp>=3.9.0
 vosk>=0.3.45
 audioop-lts ; python_version >= "3.13"  # audioop module for Python 3.13+
 bark>=0.1.5
 torch>=2.8.0
 soundfile>=0.13.1
-
-pdfminer.six>=20221105
-SQLAlchemy>=2.0
-PySide6>=6.5
-ollama>=0.1.0


### PR DESCRIPTION
## Summary
- remove unused Python dependencies from requirements and pyproject
- document dependency audit
- clarify Ollama CLI requirement in README

## Testing
- `pytest` *(fails: FFmpeg is required but was not found)*
- `npm test` *(fails: SongForm omits instruments for sfz-only songs)*

------
https://chatgpt.com/codex/tasks/task_e_68af8086a6808325b4c70f3ae995f05a