### PR TITLE
Add development requirements and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ After installation, verify the binaries are visible with `ffmpeg -version`.
 
 ## Testing
 
-Run the test suite to verify the application:
+Install the Python test dependencies and run the test suites:
 
 ```bash
-npm test
+pip install -r requirements-dev.txt  # includes pytest
+pytest  # run Python tests
+npm test  # run JavaScript tests
 ```
 
 ## RetroTV component

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest


### PR DESCRIPTION
## Summary
- add requirements-dev.txt with pytest for test runs
- document installing dev requirements and running Python and JavaScript tests

## Testing
- `pytest -q` *(fails: FFmpeg is required but was not found)*
- `npm test --silent` *(fails: SongForm test expected `GenerateShort` task id)*

------
https://chatgpt.com/codex/tasks/task_e_68af807d4c108325a99ba80d4020c748