### PR TITLE
Add world inventory view and NPC item linking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import WorldBuilder from "./pages/WorldBuilder";
 import NPCMaker from "./pages/NPCMaker";
 import NPCList from "./pages/NPCList";
 import NPCDetail from "./pages/NPCDetail";
+import WorldInventory from "./pages/WorldInventory";
 import Laser from "./pages/Laser";
 import Lofi from "./pages/Lofi";
 import NotFound from "./pages/NotFound";
@@ -71,6 +72,7 @@ export default function App() {
         <Route path="/dnd/npcs-maker" element={<NPCMaker />} />
         <Route path="/dnd/npcs-library" element={<NPCList />} />
         <Route path="/dnd/npcs/:id" element={<NPCDetail />} />
+        <Route path="/dnd/world-inventory" element={<WorldInventory />} />
         <Route path="/laser" element={<Laser />} />
         <Route path="/fusion" element={<Fusion />} />
         <Route path="/construction" element={<Construction />} />

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -11,6 +11,7 @@ import {
   Map,
   MilitaryTech,
   LibraryBooks,
+  Inventory,
 } from "@mui/icons-material";
 import { SyntheticEvent, useState, ChangeEvent } from "react";
 import { createDndTheme } from "../theme";
@@ -24,6 +25,7 @@ import SpellForm from "../features/dnd/SpellForm";
 import DiceRoller from "../features/dnd/DiceRoller";
 import TabletopMap from "../features/dnd/TabletopMap";
 import WarTable from "../features/dnd/WarTable";
+import WorldInventory from "./WorldInventory";
 import { useWorlds } from "../store/worlds";
 import NewWorldDialog from "../components/NewWorldDialog";
 
@@ -56,6 +58,7 @@ export default function DND() {
   const tabs: TabConfig[] = [
     { icon: <Person />, label: "NPC", component: <NpcForm world={world} /> },
     { icon: <LibraryBooks />, label: "NPC Library", component: <NPCList /> },
+    { icon: <Inventory />, label: "Inventory", component: <WorldInventory /> },
     { icon: <MenuBook />, label: "Lore", component: <LoreForm world={world} /> },
     { icon: <TravelExplore />, label: "Quest", component: <QuestForm /> },
     { icon: <SportsKabaddi />, label: "Encounter", component: <EncounterForm /> },

--- a/src/pages/NPCDetail.tsx
+++ b/src/pages/NPCDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import {
   Typography,
   Stack,
@@ -12,6 +12,7 @@ import {
 import Center from './_Center';
 import { useNPCs } from '../store/npcs';
 import { useWorlds } from '../store/worlds';
+import { useInventory } from '../store/inventory';
 import { generateAudio } from '../features/voice/bark';
 import * as Tone from 'tone';
 
@@ -20,6 +21,7 @@ export default function NPCDetail() {
   const npcs = useNPCs((s) => s.npcs);
   const loadNPCs = useNPCs((s) => s.loadNPCs);
   const world = useWorlds((s) => s.currentWorld);
+  const items = useInventory((s) => s.items);
 
   useEffect(() => {
     if (world) loadNPCs(world);
@@ -92,11 +94,22 @@ export default function NPCDetail() {
               <strong>Inventory:</strong>
             </Typography>
             <List>
-              {npc.inventory.map((item, idx) => (
-                <ListItem key={idx}>
-                  <ListItemText primary={item} />
-                </ListItem>
-              ))}
+              {npc.inventory.map((item, idx) => {
+                const entry = Object.values(items).find((i) => i.name === item);
+                return (
+                  <ListItem key={idx}>
+                    <ListItemText
+                      primary={
+                        entry ? (
+                          <Link to={`/dnd/world-inventory#${entry.id}`}>{item}</Link>
+                        ) : (
+                          item
+                        )
+                      }
+                    />
+                  </ListItem>
+                );
+              })}
             </List>
           </div>
         )}

--- a/src/pages/WorldInventory.tsx
+++ b/src/pages/WorldInventory.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  Chip,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { Link, useLocation } from 'react-router-dom';
+import Center from './_Center';
+import { useInventory } from '../store/inventory';
+import { useNPCs } from '../store/npcs';
+import { useWorlds } from '../store/worlds';
+
+type Order = 'asc' | 'desc';
+type OrderBy = 'name' | 'value';
+
+export default function WorldInventory() {
+  const items = useInventory((s) => Object.values(s.items));
+  const npcs = useNPCs((s) => s.npcs);
+  const loadNPCs = useNPCs((s) => s.loadNPCs);
+  const world = useWorlds((s) => s.currentWorld);
+  const { hash } = useLocation();
+
+  useEffect(() => {
+    if (world) loadNPCs(world);
+  }, [world, loadNPCs]);
+
+  useEffect(() => {
+    if (hash) {
+      const el = document.getElementById(hash.substring(1));
+      if (el) el.scrollIntoView();
+    }
+  }, [hash, items]);
+
+  const [orderBy, setOrderBy] = useState<OrderBy>('name');
+  const [order, setOrder] = useState<Order>('asc');
+
+  const handleSort = (property: OrderBy) => {
+    const isAsc = orderBy === property && order === 'asc';
+    setOrder(isAsc ? 'desc' : 'asc');
+    setOrderBy(property);
+  };
+
+  const sorted = [...items].sort((a, b) => {
+    const aVal = (a[orderBy] || 0) as number | string;
+    const bVal = (b[orderBy] || 0) as number | string;
+    if (aVal < bVal) return order === 'asc' ? -1 : 1;
+    if (aVal > bVal) return order === 'asc' ? 1 : -1;
+    return 0;
+  });
+
+  return (
+    <Center>
+      <Stack spacing={2} sx={{ width: '100%', maxWidth: 900 }}>
+        <Typography variant="h4">World Inventory</Typography>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>
+                <TableSortLabel
+                  active={orderBy === 'name'}
+                  direction={orderBy === 'name' ? order : 'asc'}
+                  onClick={() => handleSort('name')}
+                >
+                  Name
+                </TableSortLabel>
+              </TableCell>
+              <TableCell align="right">
+                <TableSortLabel
+                  active={orderBy === 'value'}
+                  direction={orderBy === 'value' ? order : 'asc'}
+                  onClick={() => handleSort('value')}
+                >
+                  Value
+                </TableSortLabel>
+              </TableCell>
+              <TableCell>Description</TableCell>
+              <TableCell>Tags</TableCell>
+              <TableCell>NPCs</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {sorted.map((item) => (
+              <TableRow key={item.id} id={item.id} hover>
+                <TableCell>{item.name}</TableCell>
+                <TableCell align="right">{item.value ?? ''}</TableCell>
+                <TableCell>{item.description}</TableCell>
+                <TableCell>
+                  <Stack direction="row" spacing={1} flexWrap="wrap">
+                    {(item.tags || []).map((tag) => (
+                      <Chip key={tag} label={tag} size="small" />
+                    ))}
+                  </Stack>
+                </TableCell>
+                <TableCell>
+                  <Stack direction="row" spacing={1} flexWrap="wrap">
+                    {item.npcIds.map((id) => {
+                      const npc = npcs.find((n) => n.id === id);
+                      return npc ? (
+                        <Chip
+                          key={id}
+                          label={npc.name}
+                          component={Link}
+                          to={`/dnd/npcs/${id}`}
+                          clickable
+                          size="small"
+                        />
+                      ) : null;
+                    })}
+                  </Stack>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Stack>
+    </Center>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create world inventory page with sortable item table linking NPC owners
- link NPC inventory items to world inventory page
- expose world inventory via new DND tab and app route

## Testing
- `npm test` *(fails: SongForm omits instruments case)*

------
https://chatgpt.com/codex/tasks/task_e_68af817360d88325b4d75c6b16cebb68