### PR TITLE
feat: enable sfz module

### DIFF
--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -395,7 +395,7 @@ describe('SongForm', () => {
 
     await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
     const [, args] = enqueueTask.mock.calls[0];
-    expect(args.id).toBe('GenerateShort');
+    expect(args.id).toBe('GenerateSong');
     expect(args.spec.sfzInstrument).toBeDefined();
     expect(args.spec.instruments).toEqual([]);
     expect(args.spec.lead_instrument).toBeUndefined();

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -16,7 +16,8 @@ type ModuleKey =
   | 'stocks'
   | 'shorts'
   | 'chores'
-  | 'construction';
+  | 'construction'
+  | 'sfz';
 
 type ModulesState = Record<ModuleKey, boolean>;
 
@@ -35,6 +36,7 @@ const defaultModules: ModulesState = {
   shorts: true,
   chores: true,
   construction: true,
+  sfz: true,
 };
 
 interface RetroTvMedia {


### PR DESCRIPTION
## Summary
- include `sfz` in module keys and default modules
- adjust SongForm test to expect full song generation for sfz-only scenarios

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68af818f10f4832590668156179ab862