### PR TITLE
test: add parsing and tagging tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,25 @@ pytest  # run Python tests
 npm test  # run JavaScript tests
 ```
 
+## UI Usage
+
+- **Uploading PDFs:** Use the D&D forms' PDF upload dialogs to import NPCs, rules,
+  lore, or spells. Parsed entries appear in their respective lists once the
+  background task finishes.
+- **World inventory:** After NPCs are loaded, open the *World Inventory* page to
+  see a consolidated list of items along with the NPCs that carry them.
+- **Ollama enrichment:** Features such as General Chat and the NPC Maker start
+  the local `ollama` model automatically. Ensure the `ollama` CLI is installed so
+  enrichment requests succeed.
+
+### Manual end‑to‑end test
+
+1. Start the app with `npm run tauri dev`.
+2. Upload an NPC PDF and confirm the character appears in the list.
+3. Visit *World Inventory* and verify items aggregate under their NPC owners.
+4. Open General Chat and send a message to trigger `start_ollama`; check that a
+   model response is received.
+
 ## RetroTV component
 
 The `RetroTV` component renders its children inside a styled television frame when

--- a/src-tauri/python/tests/test_pdf_tools.py
+++ b/src-tauri/python/tests/test_pdf_tools.py
@@ -187,3 +187,36 @@ def test_extract_rules_with_colon_headings(tmp_path):
     res = pdf_tools.extract_rules(path)
     names = [r["name"] for r in res["rules"]]
     assert names == ["RULE THREE", "RULE FOUR"]
+
+
+def test_extract_spells(tmp_path):
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", "", 12)
+    pdf.multi_cell(0, 10, "Magic Missile\nA bolt of force.")
+    path = tmp_path / "spells.pdf"
+    pdf.output(str(path))
+
+    res = pdf_tools.extract_spells(str(path))
+    spells = res["spells"]
+    assert spells == [{"name": "Magic Missile", "description": "A bolt of force."}]
+
+
+def test_extract_lore(tmp_path):
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", "", 12)
+    pdf.cell(0, 10, "Name: Ancient Forest", ln=1)
+    pdf.cell(0, 10, "Summary: A mythic wood", ln=1)
+    pdf.cell(0, 10, "Tags: history", ln=1)
+    pdf.cell(0, 10, "Location: North", ln=1)
+    pdf.cell(0, 10, "Hooks: Explore", ln=1)
+    pdf.cell(0, 10, "Extra: Hidden ruins", ln=1)
+    path = tmp_path / "lore.pdf"
+    pdf.output(str(path))
+
+    res = pdf_tools.extract_lore(str(path))
+    lore = res["lore"][0]
+    assert lore["name"] == "Ancient Forest"
+    assert lore["tags"] == ["history"]
+    assert lore["sections"].get("extra") == "Hidden ruins"

--- a/src/db/index.test.ts
+++ b/src/db/index.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+let mod: typeof import('./index');
+let cwd: string;
+let dir: string;
+
+beforeEach(async () => {
+  cwd = process.cwd();
+  dir = mkdtempSync(join(tmpdir(), 'dbtest-'));
+  process.chdir(dir);
+  vi.resetModules();
+  mod = await import('./index');
+  mod.initDb();
+});
+
+afterEach(() => {
+  process.chdir(cwd);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+it('creates items with tags and updates them', () => {
+  mod.createTag('weapon');
+  mod.createTag('magic');
+
+  mod.createItem({ id: '1', name: 'Sword', tags: ['weapon'] });
+  let item = mod.getItem('1');
+  expect(item?.tags).toEqual(['weapon']);
+
+  mod.updateItem({ id: '1', name: 'Sword', tags: ['weapon', 'magic'] });
+  item = mod.getItem('1');
+  expect(item?.tags?.sort()).toEqual(['magic', 'weapon']);
+
+  const tags = mod.listTags().map((t) => t.name).sort();
+  expect(tags).toEqual(['magic', 'weapon']);
+
+  mod.deleteItem('1');
+  expect(mod.getItem('1')).toBeNull();
+});
+

--- a/src/store/inventory.test.ts
+++ b/src/store/inventory.test.ts
@@ -39,4 +39,15 @@ describe('inventory scanning', () => {
     const sword = Object.values(useInventory.getState().items).find((i) => i.name === 'Sword');
     expect(sword?.npcIds).toEqual(['1']);
   });
+
+  it('clears npc references when items disappear', () => {
+    const npcs: Npc[] = [
+      { ...baseNpc, id: '1', name: 'A', inventory: ['Sword'] } as Npc,
+    ];
+    useInventory.getState().scanNPCs(npcs);
+    const swordId = Object.keys(useInventory.getState().items)[0];
+    useInventory.getState().scanNPCs([{ ...baseNpc, id: '1', name: 'A', inventory: [] } as Npc]);
+    const items = useInventory.getState().items;
+    expect(items[swordId].npcIds).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- add parser tests for spells and lore PDF extraction
- verify inventory aggregator clears stale NPC references
- cover tag creation and updating in SQLite DB
- document UI usage and manual testing steps

## Testing
- `pytest`
- `npm test`
- `npx vitest run src/pages/GeneralChat.test.tsx`
- manual PDF parse via pdf_tools
- manual inventory scan via useInventory

------
https://chatgpt.com/codex/tasks/task_e_68af836fde0c8325ab5f2164b763eb00