### PR TITLE
feat: add tag management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import Construction from "./pages/Construction";
 import Simulation from "./pages/Simulation";
 import BigBrother from "./pages/BigBrother";
 import Voices from "./pages/Voices";
+import TagManager from "./pages/TagManager";
 
 export default function App() {
   const { pathname } = useLocation();
@@ -76,6 +77,7 @@ export default function App() {
         <Route path="/construction" element={<Construction />} />
         <Route path="/lofi" element={<Lofi />} />
         <Route path="/voices" element={<Voices />} />
+        <Route path="/tags" element={<TagManager />} />
         <Route path="/stocks" element={<Stocks />} />
         <Route path="/shorts" element={<Shorts />} />
         <Route path="/chores" element={<Chores />} />

--- a/src/components/GenerateNPCModal.tsx
+++ b/src/components/GenerateNPCModal.tsx
@@ -23,6 +23,7 @@ interface Props {
 export default function GenerateNPCModal({ open, onClose }: Props) {
   const [count, setCount] = useState(1);
   const [loading, setLoading] = useState(false);
+  const [tags, setTags] = useState('');
   const addNPC = useNPCs((s) => s.addNPC);
 
   async function generate() {
@@ -50,6 +51,13 @@ export default function GenerateNPCModal({ open, onClose }: Props) {
             icon: 'placeholder-icon.png',
             ...parsed,
           };
+          const manualTags = tags
+            .split(',')
+            .map((t) => t.trim())
+            .filter(Boolean);
+          if (manualTags.length) {
+            data.tags = manualTags;
+          }
           addNPC(data);
         } catch {
           // ignore parse errors for now
@@ -72,6 +80,11 @@ export default function GenerateNPCModal({ open, onClose }: Props) {
             value={count}
             onChange={(e) => setCount(parseInt(e.target.value, 10) || 1)}
             inputProps={{ min: 1 }}
+          />
+          <TextField
+            label="Tags (comma separated)"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
           />
         </Stack>
       </DialogContent>

--- a/src/pages/TagManager.tsx
+++ b/src/pages/TagManager.tsx
@@ -1,0 +1,83 @@
+import { useEffect } from 'react';
+import {
+  List,
+  ListItem,
+  ListItemText,
+  IconButton,
+  Stack,
+  Typography,
+  Button,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import MergeIcon from '@mui/icons-material/MergeType';
+import Center from './_Center';
+import { useTags } from '../store/tags';
+
+export default function TagManager() {
+  const { tags, loadFromData, renameTag, deleteTag, mergeTags } = useTags();
+
+  useEffect(() => {
+    loadFromData();
+  }, [loadFromData]);
+
+  return (
+    <Center>
+      <Stack spacing={2} sx={{ width: '100%', maxWidth: 600 }}>
+        <Typography variant="h4">Tag Manager</Typography>
+        {tags.length === 0 ? (
+          <Typography>No tags found.</Typography>
+        ) : (
+          <List>
+            {tags.map((tag) => (
+              <ListItem
+                key={tag}
+                secondaryAction={
+                  <Stack direction="row" spacing={1}>
+                    <IconButton
+                      edge="end"
+                      aria-label="rename"
+                      onClick={() => {
+                        const name = window.prompt('New name', tag);
+                        if (name) renameTag(tag, name);
+                      }}
+                    >
+                      <EditIcon />
+                    </IconButton>
+                    <IconButton
+                      edge="end"
+                      aria-label="merge"
+                      onClick={() => {
+                        const target = window.prompt('Merge into tag', tag);
+                        if (target) mergeTags(tag, target);
+                      }}
+                    >
+                      <MergeIcon />
+                    </IconButton>
+                    <IconButton
+                      edge="end"
+                      aria-label="delete"
+                      onClick={() => {
+                        if (window.confirm(`Delete tag ${tag}?`)) deleteTag(tag);
+                      }}
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </Stack>
+                }
+              >
+                <ListItemText primary={tag} />
+              </ListItem>
+            ))}
+          </List>
+        )}
+        <Button
+          variant="outlined"
+          onClick={() => loadFromData()}
+        >
+          Refresh
+        </Button>
+      </Stack>
+    </Center>
+  );
+}

--- a/src/store/tags.test.ts
+++ b/src/store/tags.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useTags } from './tags';
+import { useNPCs } from './npcs';
+import { useInventory } from './inventory';
+
+function reset() {
+  useNPCs.setState({ npcs: [] });
+  useInventory.setState({ items: {} });
+  useTags.setState({ tags: [] });
+}
+
+describe('useTags', () => {
+  beforeEach(() => {
+    reset();
+    useNPCs.setState({
+      npcs: [
+        { id: '1', name: 'a', tags: ['old'], species: '', role: '', alignment: 'Unaligned', playerCharacter: false, hooks: [], appearance: 'Unknown', statblock: {}, portrait: '', icon: '' },
+      ],
+    } as any);
+    useInventory.setState({
+      items: {
+        i1: { id: 'i1', name: 'item', value: 0, description: '', tags: ['old'], npcIds: [] },
+      },
+    });
+    useTags.getState().loadFromData();
+  });
+
+  it('renames tags across stores', () => {
+    useTags.getState().renameTag('old', 'new');
+    expect(useTags.getState().tags).toEqual(['new']);
+    expect(useNPCs.getState().npcs[0].tags).toEqual(['new']);
+    expect(useInventory.getState().items.i1.tags).toEqual(['new']);
+  });
+
+  it('deletes tags across stores', () => {
+    useTags.getState().deleteTag('old');
+    expect(useTags.getState().tags).toEqual([]);
+    expect(useNPCs.getState().npcs[0].tags).toEqual([]);
+    expect(useInventory.getState().items.i1.tags).toEqual([]);
+  });
+
+  it('merges tags across stores', () => {
+    useNPCs.setState({ npcs: [{ ...useNPCs.getState().npcs[0], tags: ['old', 'keep'] }] });
+    useInventory.setState({ items: { i1: { ...useInventory.getState().items.i1, tags: ['old', 'keep'] } } });
+    useTags.getState().loadFromData();
+    useTags.getState().mergeTags('old', 'keep');
+    expect(useTags.getState().tags.sort()).toEqual(['keep']);
+    expect(useNPCs.getState().npcs[0].tags).toEqual(['keep']);
+    expect(useInventory.getState().items.i1.tags).toEqual(['keep']);
+  });
+});

--- a/src/store/tags.ts
+++ b/src/store/tags.ts
@@ -1,0 +1,100 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { useNPCs } from './npcs';
+import { useInventory } from './inventory';
+
+interface TagState {
+  tags: string[];
+  loadFromData: () => void;
+  renameTag: (oldName: string, newName: string) => void;
+  deleteTag: (name: string) => void;
+  mergeTags: (source: string, target: string) => void;
+}
+
+export const useTags = create<TagState>()(
+  persist(
+    (set) => ({
+      tags: [],
+      loadFromData: () =>
+        set(() => {
+          const setTags = new Set<string>();
+          for (const npc of useNPCs.getState().npcs) {
+            for (const t of npc.tags || []) setTags.add(t);
+          }
+          for (const item of Object.values(useInventory.getState().items)) {
+            for (const t of item.tags || []) setTags.add(t);
+          }
+          return { tags: Array.from(setTags).sort() };
+        }),
+      renameTag: (oldName, newName) =>
+        set((state) => {
+          const tags = state.tags.map((t) => (t === oldName ? newName : t));
+          useNPCs.setState((npcState) => ({
+            npcs: npcState.npcs.map((npc) => ({
+              ...npc,
+              tags: npc.tags?.map((t) => (t === oldName ? newName : t)),
+            })),
+          }));
+          useInventory.setState((invState) => {
+            const items = { ...invState.items };
+            for (const item of Object.values(items)) {
+              if (item.tags) {
+                item.tags = item.tags.map((t) => (t === oldName ? newName : t));
+              }
+            }
+            return { items };
+          });
+          return { tags: Array.from(new Set(tags)).sort() };
+        }),
+      deleteTag: (name) =>
+        set((state) => {
+          const tags = state.tags.filter((t) => t !== name);
+          useNPCs.setState((npcState) => ({
+            npcs: npcState.npcs.map((npc) => ({
+              ...npc,
+              tags: npc.tags?.filter((t) => t !== name),
+            })),
+          }));
+          useInventory.setState((invState) => {
+            const items = { ...invState.items };
+            for (const item of Object.values(items)) {
+              if (item.tags) {
+                item.tags = item.tags.filter((t) => t !== name);
+              }
+            }
+            return { items };
+          });
+          return { tags };
+        }),
+      mergeTags: (source, target) =>
+        set((state) => {
+          const tags = state.tags.filter((t) => t !== source);
+          if (!tags.includes(target)) tags.push(target);
+          useNPCs.setState((npcState) => ({
+            npcs: npcState.npcs.map((npc) => {
+              const newTags = (npc.tags || []).map((t) =>
+                t === source ? target : t
+              );
+              return { ...npc, tags: Array.from(new Set(newTags)) };
+            }),
+          }));
+          useInventory.setState((invState) => {
+            const items = { ...invState.items };
+            for (const item of Object.values(items)) {
+              if (item.tags) {
+                const newTags = item.tags.map((t) =>
+                  t === source ? target : t
+                );
+                item.tags = Array.from(new Set(newTags));
+              }
+            }
+            return { items };
+          });
+          return { tags: tags.sort() };
+        }),
+    }),
+    { name: 'tags-store' }
+  )
+);
+
+export type { TagState };


### PR DESCRIPTION
## Summary
- add zustand store to rename, delete, and merge tags
- provide Tag Manager UI for tag edits
- allow manual tag overrides when generating NPCs

## Testing
- `npm test` *(fails: SongForm.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68af8174931c8325be119256232b3a40