### PR TITLE
Maximize Tauri window at startup

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,17 +11,29 @@
   },
   "app": {
     "windows": [
-      { "title": "blossom", "width": 800, "height": 600 }
+      {
+        "title": "blossom",
+        "width": 800,
+        "height": 600,
+        "decorations": true,
+        "maximized": true
+      }
     ],
     "security": {
-  "csp": null,
-  "assetProtocol": { "enable": true, "scope": ["**"] }
-}
-
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": [
+          "**"
+        ]
+      }
+    }
   },
   "plugins": {
     "sql": {
-      "preload": ["sqlite:stocks.db"]
+      "preload": [
+        "sqlite:stocks.db"
+      ]
     }
   },
   "bundle": {
@@ -40,6 +52,5 @@
       "python/ambience_generator.py",
       "python/bark_tts.py"
     ]
-
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,16 +1,28 @@
-import React from "react";
+import React, { useEffect } from "react";
 import ReactDOM from "react-dom/client";
 import { HashRouter } from "react-router-dom";
+import { appWindow } from "@tauri-apps/api/window";
 import App from "./App";
 import "./styles.css";
 import { ThemeProvider } from "./features/theme/ThemeContext";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
+function Root() {
+  useEffect(() => {
+    appWindow.maximize();
+  }, []);
+
+  return (
     <HashRouter>
       <ThemeProvider>
         <App />
       </ThemeProvider>
     </HashRouter>
-  </React.StrictMode>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <Root />
+  </React.StrictMode>,
 );
+


### PR DESCRIPTION
## Summary
- ensure Tauri window opens maximized and keep window decorations
- maximize the window on startup using appWindow API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af841c5c2483259ed5b0624273626a