### PR TITLE
Remove device argument from Bark TTS

### DIFF
--- a/src-tauri/python/bark_tts.py
+++ b/src-tauri/python/bark_tts.py
@@ -48,8 +48,7 @@ def speak(text: str, speaker: str) -> bytes:
     if generate_audio is None:
         raise RuntimeError("bark library is not installed") from _import_error
 
-    device = _get_device()
-    audio_array: np.ndarray = generate_audio(text, history_prompt=speaker, device=device)
+    audio_array: np.ndarray = generate_audio(text, history_prompt=speaker)
 
     buffer = io.BytesIO()
     import soundfile as sf  # imported lazily to keep module light


### PR DESCRIPTION
## Summary
- Simplify Bark TTS `speak` function by dropping explicit `device` argument when calling `generate_audio`
- Streamline audio handling to continue writing the generated array to a WAV buffer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af895661088325b9b72f39a88ed5e0