### PR TITLE
Use GPU flags for Bark model preload

### DIFF
--- a/src-tauri/python/bark_tts.py
+++ b/src-tauri/python/bark_tts.py
@@ -20,10 +20,17 @@ def _get_device() -> torch.device:
 
 
 def load_model() -> None:
-    """Load Bark models onto the appropriate device."""
+    """Load Bark models, using the GPU when available."""
     if preload_models is None:
         raise RuntimeError("bark library is not installed") from _import_error
-    preload_models(device=_get_device())
+
+    use_gpu = torch.cuda.is_available()
+    preload_models(
+        text_use_gpu=use_gpu,
+        coarse_use_gpu=use_gpu,
+        fine_use_gpu=use_gpu,
+        codec_use_gpu=use_gpu,
+    )
 
 
 # Load models as soon as the module is imported.


### PR DESCRIPTION
## Summary
- preload Bark models with boolean GPU flags instead of a single device
- ensure all Bark components use the same GPU setting

## Testing
- `pytest src-tauri/python/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68af8954405083259411dd4289b13036