### PR TITLE
feat: add SFZ Music nav entry

### DIFF
--- a/src/components/FeatureNav.tsx
+++ b/src/components/FeatureNav.tsx
@@ -40,6 +40,7 @@ type Item = {
 export const ITEMS: Item[] = [
   { key: "objects", icon: <FaCubes />, label: "3D Object", path: "/objects", color: "rgba(165,216,255,0.55)" },
   { key: "music", icon: <FaMusic />, label: "Music", path: "/music", color: "rgba(245,176,194,0.55)" },
+  { key: "sfz", icon: <FaMusic />, label: "SFZ Music", path: "/sfz-music", color: "rgba(200,150,200,0.55)" },
   { key: "calendar", icon: <FaCalendarAlt />, label: "Calendar", path: "/calendar", color: "rgba(211,200,255,0.55)" },
   { key: "comfy", icon: <FaCameraRetro />, label: "ComfyUI", path: "/comfy", color: "rgba(255,213,165,0.55)" },
   { key: "assistant", icon: <FaRobot />, label: "AI Assistant", path: "/assistant", color: "rgba(175,245,215,0.55)" },


### PR DESCRIPTION
## Summary
- show SFZ Music option in feature navigation
- confirm module key typing supports `sfz`

## Testing
- `npm test` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68af8abcd34c8325819997d6aa414ef1