### PR TITLE
Pulse retro elements with audio

### DIFF
--- a/src/components/HoverCircle.tsx
+++ b/src/components/HoverCircle.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from "react";
+import { useAudioLevel } from "../utils/useAudioLevel";
 
-export default function HoverCircle({ color="rgba(255,255,255,0.22)" }:{ color?: string }) {
+export default function HoverCircle({
+  color = "rgba(255,255,255,0.22)",
+}: {
+  color?: string;
+}) {
   const [pos, setPos] = useState({ x: -200, y: -200 });
+  const level = useAudioLevel();
 
   useEffect(() => {
     const onMove = (e: MouseEvent) => setPos({ x: e.clientX, y: e.clientY });
@@ -9,21 +15,28 @@ export default function HoverCircle({ color="rgba(255,255,255,0.22)" }:{ color?:
     return () => window.removeEventListener("mousemove", onMove);
   }, []);
 
-  return (
-    <div
-      style={{
-        position: "fixed",
-        top: pos.y - 60,
-        left: pos.x - 60,
-        width: 120,
-        height: 120,
-        borderRadius: "50%",
-        background: color,
-        filter: "blur(28px)",
-        pointerEvents: "none",
-        transition: "background 200ms ease",
-        zIndex: 0
-      }}
-    />
-  );
+  const size = 120 + level * 60;
+  const match = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/);
+  const r = match ? match[1] : "0";
+  const g = match ? match[2] : "255";
+  const b = match ? match[3] : "0";
+  const baseAlpha = match && match[4] ? parseFloat(match[4]) : 0.22;
+  const alpha = baseAlpha + level * (1 - baseAlpha);
+
+  const style: React.CSSProperties & { "--audio-alpha": number } = {
+    position: "fixed",
+    top: pos.y - size / 2,
+    left: pos.x - size / 2,
+    width: size,
+    height: size,
+    borderRadius: "50%",
+    background: `rgba(${r},${g},${b}, var(--audio-alpha))`,
+    filter: "blur(28px)",
+    pointerEvents: "none",
+    transition: "background 200ms ease",
+    zIndex: 0,
+    "--audio-alpha": alpha,
+  };
+
+  return <div style={style} />;
 }

--- a/src/components/SystemInfoWidget.tsx
+++ b/src/components/SystemInfoWidget.tsx
@@ -2,6 +2,7 @@ import { Box } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 import { useSystemInfo } from "../features/system/useSystemInfo";
 import { Theme, useTheme } from "../features/theme/ThemeContext";
+import { useAudioLevel } from "../utils/useAudioLevel";
 
 const themeColors: Record<Theme, string> = {
   default: "rgba(255,255,255,0.22)",
@@ -24,12 +25,19 @@ export default function SystemInfoWidget() {
   const info = useSystemInfo();
   const { theme } = useTheme();
   const nav = useNavigate();
+  const level = useAudioLevel();
+
+  const retroAlpha = 0.22 + level * (1 - 0.22);
 
   return (
     <Box
       onClick={() => nav("/system")}
       sx={{
-        backgroundColor: themeColors[theme],
+        backgroundColor:
+          theme === "retro"
+            ? "rgba(0,255,0,var(--audio-alpha))"
+            : themeColors[theme],
+        "--audio-alpha": theme === "retro" ? retroAlpha : undefined,
         color: "#fff",
         px: 2,
         py: 1,

--- a/src/pages/SystemInfo.tsx
+++ b/src/pages/SystemInfo.tsx
@@ -1,6 +1,7 @@
 import { Box, Typography } from "@mui/material";
 import { useSystemInfo } from "../features/system/useSystemInfo";
 import { Theme, useTheme } from "../features/theme/ThemeContext";
+import { useAudioLevel } from "../utils/useAudioLevel";
 
 const themeColors: Record<Theme, string> = {
   default: "rgba(255,255,255,0.22)",
@@ -22,6 +23,8 @@ const themeColors: Record<Theme, string> = {
 export default function SystemInfo() {
   const info = useSystemInfo();
   const { theme } = useTheme();
+  const level = useAudioLevel();
+  const retroAlpha = 0.22 + level * (1 - 0.22);
 
   return (
     <Box
@@ -32,7 +35,11 @@ export default function SystemInfo() {
         justifyContent: "center",
         height: "100vh",
         color: "#fff",
-        backgroundColor: themeColors[theme],
+        backgroundColor:
+          theme === "retro"
+            ? "rgba(0,255,0,var(--audio-alpha))"
+            : themeColors[theme],
+        "--audio-alpha": theme === "retro" ? retroAlpha : undefined,
         textAlign: "center",
         p: 4,
       }}


### PR DESCRIPTION
## Summary
- Drive `HoverCircle` size and opacity using `useAudioLevel` and a CSS variable for synchronized pulsing
- Apply audio-driven green glow to `SystemInfoWidget` and `SystemInfo` for retro theme

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68af8b9ae6b08325b6f3562bb15a23c7