### PR TITLE
test: expand sfzLoader coverage

### DIFF
--- a/src/utils/sfzLoader.test.ts
+++ b/src/utils/sfzLoader.test.ts
@@ -26,4 +26,25 @@ pitch_keycenter=36
     expect(regions[0].hikey).toBe(36);
     expect(regions[0].pitch_keycenter).toBe(36);
   });
+
+  it('resolves sample paths relative to basePath', () => {
+    const sfz = `\n<region>\nsample=snare.wav`;
+    const regions = parseSfz(sfz, '/audio/');
+    expect(regions).toHaveLength(1);
+    expect(regions[0].sample).toBe('/audio/snare.wav');
+  });
+
+  it('ignores unsupported sections and unknown opcodes', () => {
+    const sfz = `\n<group>\nfoo=bar\n<region>\nsample=hat.wav\nunknown=42`;
+    const regions = parseSfz(sfz);
+    expect(regions).toHaveLength(1);
+    expect(regions[0].sample).toBe('hat.wav');
+    expect((regions[0] as any).unknown).toBe(42);
+  });
+
+  it('preserves order of multiple regions', () => {
+    const sfz = `\n<region>\nsample=one.wav\n<region>\nsample=two.wav`;
+    const regions = parseSfz(sfz);
+    expect(regions.map((r) => r.sample)).toEqual(['one.wav', 'two.wav']);
+  });
 });


### PR DESCRIPTION
## Summary
- add tests for resolving sample paths relative to a base path
- verify parser skips unsupported sections and handles unknown opcodes
- ensure multiple region blocks preserve order

## Testing
- `npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68af945b1a188325a87b801ec65ae89b