### PR TITLE
Refactor window import

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import ReactDOM from "react-dom/client";
 import { HashRouter } from "react-router-dom";
-import { appWindow } from "@tauri-apps/api/window";
+import { getCurrent } from "@tauri-apps/api/window";
 import App from "./App";
 import "./styles.css";
 import { ThemeProvider } from "./features/theme/ThemeContext";
@@ -20,7 +20,7 @@ function RootContent() {
 
 function Root() {
   useEffect(() => {
-    appWindow.maximize();
+    getCurrent().maximize();
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- replace deprecated `appWindow` usage with `getCurrent()` in main entrypoint

## Testing
- `npm test`
- `npm run build` *(fails: Type '{ npcs: { tags: string[]; id: string; role: string; name: string; species: string; alignment: string; playerCharacter: boolean; hooks: [string, ...string[]]; statblock: Record<string, unknown>; appearance?: string | undefined; ... 12 more ...; inventory?: string[] | undefined; }[]; }' is not assignable to type 'Partial<NpcState>'.)*

------
https://chatgpt.com/codex/tasks/task_e_68af96af1f6c83258c587dd46eb5d765