### PR TITLE
Expand supported Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node
@@ -22,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
       - run: pip install -r requirements.txt
       - run: pytest src-tauri/python/tests
 

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(
         'audioop-lts; python_version >= "3.13"',
         'pdfplumber>=0.10.3',
     ],
-    python_requires='>=3.10,<3.12',
+    python_requires='>=3.10',
 )


### PR DESCRIPTION
## Summary
- expand supported Python versions to match README
- test against Python 3.10–3.13 in CI workflow

## Testing
- `npm test -- --run`
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af97181fcc83259166e84b30cc23cb