### PR TITLE
Use getCurrentWindow for Tauri window maximization

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import ReactDOM from "react-dom/client";
 import { HashRouter } from "react-router-dom";
-import { getCurrent } from "@tauri-apps/api/window";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import App from "./App";
 import "./styles.css";
 import { ThemeProvider } from "./features/theme/ThemeContext";
@@ -20,7 +20,7 @@ function RootContent() {
 
 function Root() {
   useEffect(() => {
-    getCurrent().maximize();
+    getCurrentWindow().maximize();
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- replace deprecated `getCurrent` import with `getCurrentWindow`
- call `getCurrentWindow().maximize()` during app initialization

## Testing
- `npm run build` *(fails: TS2345 in src/store/tags.ts and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af984c30e48325970b4737e7e1ce25