### PR TITLE
Hide RetroTV on SFZ Music page

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -8,6 +8,7 @@ vi.mock('./components/TopBar', () => ({ default: () => <div /> }));
 vi.mock('./components/CreateUserDialog', () => ({ default: () => <div /> }));
 vi.mock('./pages/Comfy', () => ({ default: () => <div>Comfy</div> }));
 vi.mock('./pages/Home', () => ({ default: () => <div>Home</div> }));
+vi.mock('./pages/SFZMusic', () => ({ default: () => <div>SFZ</div> }));
 
 // Provide minimal implementations for hooks used by RetroTV/App
 vi.mock('./features/theme/ThemeContext', () => ({
@@ -38,6 +39,15 @@ describe('App RetroTV overlay', () => {
   it('hides RetroTV on the Comfy route', () => {
     render(
       <MemoryRouter initialEntries={[{ pathname: '/comfy' }]}> 
+        <App />
+      </MemoryRouter>
+    );
+    expect(screen.queryByText('NO SIGNAL')).toBeNull();
+  });
+
+  it('hides RetroTV on the SFZ Music route', () => {
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/sfz-music' }]}> 
         <App />
       </MemoryRouter>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,9 +56,10 @@ export default function App() {
   return (
     <ErrorBoundary>
         <TopBar />
-        {pathname !== "/calendar" && pathname !== "/comfy" && (
-          <RetroTV>NO SIGNAL</RetroTV>
-        )}
+        {pathname !== "/calendar" && pathname !== "/comfy" &&
+          pathname !== "/sfz-music" && (
+            <RetroTV>NO SIGNAL</RetroTV>
+          )}
         <CreateUserDialog open={showUserDialog} onClose={() => setShowUserDialog(false)} />
       <Routes>
         <Route path="/" element={<Home />} />


### PR DESCRIPTION
## Summary
- hide RetroTV overlay on the `/sfz-music` route where the SFZ song form lives
- test RetroTV overlay is suppressed on the SFZ Music page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af9ba024d08325b67cbfad5f6b6a4e