### PR TITLE
feat(voices): show testing progress

### DIFF
--- a/src/pages/Voices.tsx
+++ b/src/pages/Voices.tsx
@@ -12,6 +12,7 @@ import {
   Checkbox,
   Snackbar,
   Alert,
+  LinearProgress,
 } from "@mui/material";
 import Star from "@mui/icons-material/Star";
 import StarBorder from "@mui/icons-material/StarBorder";
@@ -80,6 +81,7 @@ export default function Voices() {
         gap: 2,
       }}
     >
+      {status === "testing" && <LinearProgress />}
       <TextField
         label="Text to speak"
         value={text}


### PR DESCRIPTION
## Summary
- show an inline progress bar when a voice test is running

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af9c06ad6083258d988c56dda27834