### PR TITLE
Allowlist numpy classes for Bark torch.load

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ pip install -r requirements.txt  # base dependencies including Bark
 `audioop-lts` is included in the requirements and will be installed automatically on
 Python 3.13+ to replace the removed `audioop` module.
 
-`bark` (>=0.1.5) provides text‑to‑speech support and depends on `torch` (>=2.8.0)
+`bark` (>=0.1.6) provides text‑to‑speech support and depends on `torch` (>=2.8.0)
 and `soundfile` (>=0.13.1). These packages are included in `requirements.txt`, or
 install them separately with:
 
 ```bash
-pip install bark>=0.1.5 torch>=2.8.0 soundfile>=0.13.1
+pip install bark>=0.1.6 torch>=2.8.0 soundfile>=0.13.1
 ```
 
 ## Running the Tauri app

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ fpdf2>=2.7
 requests>=2.32.0
 vosk>=0.3.45
 audioop-lts ; python_version >= "3.13"  # audioop module for Python 3.13+
-bark>=0.1.5
+bark>=0.1.6
 torch>=2.8.0
 soundfile>=0.13.1

--- a/src-tauri/python/bark_tts.py
+++ b/src-tauri/python/bark_tts.py
@@ -22,6 +22,14 @@ def load_model() -> None:
     """Load Bark models, using the GPU when available."""
     if preload_models is None:
         raise RuntimeError("bark library is not installed") from _import_error
+    import numpy
+    import torch.serialization
+
+    torch.serialization.add_safe_globals([
+        (numpy._core.multiarray.scalar, 'numpy.core.multiarray.scalar'),
+        numpy.dtype,
+        numpy.dtypes.Float64DType,
+    ])
 
     use_gpu = torch.cuda.is_available()
     preload_models(


### PR DESCRIPTION
## Summary
- allowlist NumPy classes in `bark_tts` so `torch.load` with `weights_only=True` succeeds under PyTorch 2.6+
- document the new Bark requirement and bump `requirements.txt`

## Testing
- `pytest -q` (fails: FFmpeg is required but missing)
- `PYTHONPATH=src-tauri/python python - <<'PY'
try:
    import importlib
    bark_tts = importlib.reload(importlib.import_module('bark_tts'))
    print('import succeeded')
except Exception as e:
    print('error during import:', type(e).__name__, e)
PY` (fails: ProxyError)

------
https://chatgpt.com/codex/tasks/task_e_68afa65973448325b282c3292d937c7f