### PR TITLE
Handle unnamed NPC headings

### DIFF
--- a/src-tauri/python/pdf_tools.py
+++ b/src-tauri/python/pdf_tools.py
@@ -256,6 +256,19 @@ def extract_npcs(path: str, db_path: str | Path | None = None):
             continue
         data = {}
         current = None
+        heading = None
+        first_line = lines[0].strip()
+        m = re.search(r"\b([A-Za-z/ ]+):", first_line)
+        if m and m.start() > 0:
+            heading = first_line[: m.start()].strip()
+            rest = first_line[m.start():].strip()
+            if rest:
+                lines[0] = rest
+            else:
+                lines = lines[1:]
+        elif ":" not in first_line:
+            heading = first_line
+            lines = lines[1:]
         list_fields = {"traits", "quirks", "inventory", "equipment", "items"}
         synonym_map = {
             "class/role": "role",
@@ -283,6 +296,8 @@ def extract_npcs(path: str, db_path: str | Path | None = None):
                     data[current][-1] += " " + line.strip()
                 elif current:
                     data[current] = f"{data.get(current, '')} {line.strip()}".strip()
+        if "name" not in data and heading:
+            data["name"] = heading.strip()
         if not data:
             continue
 


### PR DESCRIPTION
## Summary
- infer NPC names from leading heading when missing
- keep field parsing intact by removing heading before key extraction

## Testing
- `pytest tests/test_pdf_tools.py::test_extract_npcs_parses_appearance`
- `pytest tests/test_pdf_tools.py::test_extract_npcs_stats_traits_inventory_persist`


------
https://chatgpt.com/codex/tasks/task_e_68afa678d18c8325897e250ff8091aee