### PR TITLE
Handle heading-style NPC names in extract_npcs

### DIFF
--- a/src-tauri/python/pdf_tools.py
+++ b/src-tauri/python/pdf_tools.py
@@ -255,6 +255,9 @@ def extract_npcs(path: str, db_path: str | Path | None = None):
         if not lines:
             continue
         data = {}
+        # If the first line doesn't contain a key-value pair, treat it as the NPC's name.
+        if lines and ":" not in lines[0]:
+            data["name"] = lines.pop(0).strip()
         current = None
         list_fields = {"traits", "quirks", "inventory", "equipment", "items"}
         synonym_map = {

--- a/src-tauri/python/tests/test_pdf_tools.py
+++ b/src-tauri/python/tests/test_pdf_tools.py
@@ -119,6 +119,29 @@ def test_extract_npcs_parses_appearance(tmp_path):
     assert sections.get("extra") == "Value"
 
 
+def test_extract_npcs_heading_and_inline_fields(tmp_path):
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", "", 12)
+    pdf.cell(0, 10, "Gorruk", ln=1)
+    pdf.cell(
+        0,
+        10,
+        "Species: Human Age: 27 Class/Role: Beast-Handler Alignment: Neutral",
+        ln=1,
+    )
+    path = tmp_path / "npc.pdf"
+    pdf.output(str(path))
+
+    res = pdf_tools.extract_npcs(str(path))
+    npc = res["npcs"][0]
+    assert npc["name"] == "Gorruk"
+    assert npc["species"] == "Human"
+    assert npc["age"] == 27
+    assert npc["role"] == "Beast-Handler"
+    assert npc["alignment"] == "Neutral"
+
+
 def test_extract_npcs_stats_traits_inventory_persist(tmp_path):
     pdf = FPDF()
     pdf.add_page()


### PR DESCRIPTION
## Summary
- support NPC names presented as a heading without `Name:` prefix
- test parsing of NPCs where the second line contains multiple inline fields

## Testing
- `pytest src-tauri/python/tests/test_pdf_tools.py::test_extract_npcs_heading_and_inline_fields -q`
- `pytest src-tauri/python/tests`

------
https://chatgpt.com/codex/tasks/task_e_68afa67b31b88325a1875f6231cd2c29