### PR TITLE
Allow optional song spec metadata

### DIFF
--- a/src/store/tasks.test.ts
+++ b/src/store/tasks.test.ts
@@ -61,11 +61,6 @@ describe('enqueueTask validation', () => {
       outDir: '/tmp/out',
       title: 't',
       bpm: 120,
-      key: 'C',
-      mood: ['chill'],
-      instruments: ['piano'],
-      ambience: ['rain'],
-      seed: 1,
     };
     const id = await useTasks.getState().enqueueTask('GenerateSong', { spec });
     expect(id).toBe(1);

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -13,15 +13,15 @@ export interface SongSpec {
   title: string;
   album?: string;
   bpm: number;
-  key: string;
+  key?: string;
   form?: string;
   structure?: SongSection[];
-  mood: string[];
-  instruments: string[];
+  mood?: string[];
+  instruments?: string[];
   leadInstrument?: string;
-  ambience: string[];
+  ambience?: string[];
   ambienceLevel?: number;
-  seed: number;
+  seed?: number;
   variety?: number;
   chordSpanBeats?: number;
   drumPattern?: string;
@@ -149,16 +149,7 @@ export const useTasks = create<TasksState>((set, get) => ({
       }
       if (cmd.id === 'GenerateSong') {
         const spec = (cmd as Extract<TaskCommand, { id: 'GenerateSong' }>).spec;
-        const required: (keyof SongSpec)[] = [
-          'outDir',
-          'title',
-          'bpm',
-          'key',
-          'mood',
-          'instruments',
-          'ambience',
-          'seed',
-        ];
+        const required: (keyof SongSpec)[] = ['outDir', 'title', 'bpm'];
         const missing = required.filter((field) => {
           const value = spec[field];
           return (


### PR DESCRIPTION
## Summary
- Allow optional `key`, `mood`, `instruments`, `ambience`, and `seed` in `SongSpec`
- Only require output directory, title, and BPM when enqueuing song tasks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afa5c06c188325bbfa1345763637ab