### PR TITLE
refactor: remove ComfyUI path from store

### DIFF
--- a/src/features/paths/usePaths.test.ts
+++ b/src/features/paths/usePaths.test.ts
@@ -10,15 +10,10 @@ describe('usePaths save_paths error handling', () => {
       usePathsStore.setState({ error: null });
     });
 
-  const setters: [string, string][] = [
-    ['setPythonPath', 'py'],
-    ['setComfyPath', 'comfy'],
-  ];
-
-    it.each(setters)('%s surfaces errors', async (setter, value) => {
+    it('setPythonPath surfaces errors', async () => {
       (invoke as any).mockRejectedValue(new Error('fail'));
       const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      (usePathsStore.getState() as any)[setter](value);
+      usePathsStore.getState().setPythonPath('py');
       await Promise.resolve();
       expect(spy).toHaveBeenCalledWith(
         expect.stringContaining('Failed to save paths'),

--- a/src/features/paths/usePaths.ts
+++ b/src/features/paths/usePaths.ts
@@ -5,19 +5,16 @@ import { useEffect } from "react";
 interface PathsState {
   pythonPath: string;
   defaultPythonPath: string;
-  comfyPath: string;
   loaded: boolean;
   error: string | null;
   clearError: () => void;
   setPythonPath: (p: string) => void;
-  setComfyPath: (p: string) => void;
   load: () => Promise<void>;
 }
 
 export const usePathsStore = create<PathsState>((set, get) => ({
   pythonPath: "",
   defaultPythonPath: "",
-  comfyPath: "",
   loaded: false,
   error: null,
   clearError: () => set({ error: null }),
@@ -25,17 +22,6 @@ export const usePathsStore = create<PathsState>((set, get) => ({
     set({ pythonPath });
     invoke("save_paths", {
       python_path: pythonPath,
-      comfy_path: get().comfyPath,
-    }).catch((err) => {
-      console.error("Failed to save paths:", err);
-      set({ error: `Failed to save paths: ${String(err)}` });
-    });
-  },
-  setComfyPath: (comfyPath: string) => {
-    set({ comfyPath });
-    invoke("save_paths", {
-      python_path: get().pythonPath,
-      comfy_path: comfyPath,
     }).catch((err) => {
       console.error("Failed to save paths:", err);
       set({ error: `Failed to save paths: ${String(err)}` });
@@ -46,13 +32,11 @@ export const usePathsStore = create<PathsState>((set, get) => ({
     try {
       const res = await invoke<{
         python_path?: string;
-        comfy_path?: string;
       }>("load_paths");
       const detected = await invoke<string>("detect_python");
       set({
         pythonPath: res.python_path || "",
         defaultPythonPath: detected,
-        comfyPath: res.comfy_path || "",
         loaded: true,
       });
     } catch {


### PR DESCRIPTION
## Summary
- drop `comfyPath` and `setComfyPath` from paths store
- stop saving/loading a ComfyUI path and adjust tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afa95447c883258e8225957d1b75ec