### PR TITLE
Auto-start ComfyUI without path config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ npm run tauri dev    # start the app in development mode
 npm run tauri build  # build a release bundle
 ```
 
-The Rust backend can launch local tools such as ComfyUI and Ollama. Set the
-ComfyUI folder location in the app's Settings page. Python is detected
+The Rust backend can launch local tools such as ComfyUI and Ollama. ComfyUI is
+bundled and starts without any folder configuration. Python is detected
 automatically, and you can adjust the interpreter path from Settings if needed.
 Install the [`ollama`](https://github.com/ollama/ollama) CLI separately if you
 plan to use the general chat features; the Python package is not required.
@@ -133,8 +133,9 @@ When a user uploads a video, it plays automatically on an endless loop.
 - **Stock data provider:** Set `STOCKS_PROVIDER=twelvedata` and provide a
   `TWELVEDATA_API_KEY` to fetch quotes and time series from Twelve Data. The
   free tier allows up to 800 requests per day and 8 per minute.
-- **Paths:** Set the ComfyUI directory in the Settings page. The Python
-  interpreter path is detected automatically but can be changed there if needed.
+- **Paths:** ComfyUI is bundled, so no directory needs to be configured. The
+  Python interpreter path is detected automatically but can be changed there if
+  needed.
 - **Blender path:** If Blender is not on your system `PATH`, set the
   `BLENDER_PATH` environment variable to the Blender executable so `/objects/blender`
   can run scripts.

--- a/src/pages/Comfy.tsx
+++ b/src/pages/Comfy.tsx
@@ -2,7 +2,6 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { usePaths } from "../features/paths/usePaths";
 import PromptManager from "../components/PromptManager";
 import { useComfyTutorial } from "../features/comfyTutorial/useComfyTutorial";
 
@@ -10,7 +9,6 @@ export default function Comfy() {
   const [running, setRunning] = useState(false);
   const [log, setLog] = useState<string[]>([]);
   const [pingOk, setPingOk] = useState(false);
-  const { comfyPath } = usePaths();
   const { showTutorial, setShowTutorial } = useComfyTutorial();
 
   useEffect(() => {
@@ -42,12 +40,8 @@ export default function Comfy() {
   }, [running]);
 
   const start = async () => {
-    if (!comfyPath) {
-      setLog((prev) => [...prev, "Set ComfyUI folder in Settings first."]); 
-      return;
-    }
     try {
-      await invoke("comfy_start", { dir: comfyPath });
+      await invoke("comfy_start", { dir: "" });
       setRunning(true);
       setTimeout(() => setPingOk(true), 2000);
     } catch (e: any) {
@@ -69,11 +63,10 @@ export default function Comfy() {
     <div style={styles.wrap}>
       {showTutorial && (
         <div style={styles.tut}>
-          <h3 style={{ marginTop: 0 }}>Connect Blossom to ComfyUI</h3>
+          <h3 style={{ marginTop: 0 }}>ComfyUI Tutorial</h3>
           <ol style={{ marginTop: 4 }}>
-            <li>Install ComfyUI; the folder should contain <code>main.py</code>.</li>
-            <li>Open Settings → Paths and set "ComfyUI Folder" to that directory.</li>
-            <li>Return here and click Start to launch ComfyUI.</li>
+            <li>ComfyUI is bundled with Blossom; no folder setup is required.</li>
+            <li>Click Start to launch ComfyUI.</li>
           </ol>
           <button onClick={() => setShowTutorial(false)} style={styles.tutBtn}>Got it</button>
         </div>


### PR DESCRIPTION
## Summary
- auto-start bundled ComfyUI with no user path
- refresh ComfyUI tutorial and README for built-in setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afa98c94748325ae205f7f98f9f060