### PR TITLE
test: prune ComfyUI path coverage

### DIFF
--- a/src/features/paths/usePaths.test.ts
+++ b/src/features/paths/usePaths.test.ts
@@ -4,23 +4,23 @@ import { usePathsStore } from './usePaths';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 
-describe('usePaths save_paths error handling', () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-      usePathsStore.setState({ error: null });
-    });
+describe('setPythonPath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usePathsStore.setState({ error: null });
+  });
 
-    it('setPythonPath surfaces errors', async () => {
-      (invoke as any).mockRejectedValue(new Error('fail'));
-      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      usePathsStore.getState().setPythonPath('py');
-      await Promise.resolve();
-      expect(spy).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to save paths'),
-        expect.any(Error)
-      );
-      expect(usePathsStore.getState().error).toContain('Failed to save paths');
-      usePathsStore.setState({ error: null });
-      spy.mockRestore();
-    });
+  it('surfaces save_paths errors', async () => {
+    (invoke as any).mockRejectedValue(new Error('fail'));
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    usePathsStore.getState().setPythonPath('py');
+    await Promise.resolve();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to save paths'),
+      expect.any(Error)
+    );
+    expect(usePathsStore.getState().error).toContain('Failed to save paths');
+    spy.mockRestore();
+  });
 });
+


### PR DESCRIPTION
## Summary
- narrow `usePaths` tests to the python path setter
- preserve coverage for `save_paths` error handling

## Testing
- `npm test -- --run src/features/paths/usePaths.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68afea318ed88325965da9c0f974755e