### PR TITLE
Auto-generate renderer seed

### DIFF
--- a/src-tauri/python/lofi/renderer.py
+++ b/src-tauri/python/lofi/renderer.py
@@ -1635,7 +1635,9 @@ def render_from_spec(spec: Dict[str, Any]) -> Tuple[AudioSegment, int]:
         except Exception:
             pass
     bpm = int(spec.get("bpm", 80))
-    seed = int(spec.get("seed", 12345))
+    seed = int(spec.get("seed") or random.randrange(2**32))
+    random.seed(seed)
+    np.random.seed(seed)
 
     try:
         v = spec.get("variety", 60)

--- a/src-tauri/python/tests/test_determinism.py
+++ b/src-tauri/python/tests/test_determinism.py
@@ -7,8 +7,8 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import lofi.renderer as renderer  # noqa: E402
 
 
-EXPECTED_RMS = 0.165903
-EXPECTED_HASH = "82fdd90872a6d191afc972db5890d113a419fa53c9239d7970063d64d1e3ad90"
+EXPECTED_RMS = 0.1113
+EXPECTED_HASH = "925de978ca033995cc5b56222872b0f02db33be6e999318b42afd18d4eafad60"
 
 
 def test_deterministic_render(caplog):


### PR DESCRIPTION
## Summary
- generate random seed when none provided and seed RNGs
- update determinism test expectations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aff4b188648325bcbe88aeb6fdef77