### PR TITLE
test: narrow path store tests

### DIFF
--- a/src/features/paths/usePaths.test.ts
+++ b/src/features/paths/usePaths.test.ts
@@ -7,7 +7,15 @@ vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 describe('setPythonPath', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    usePathsStore.setState({ error: null });
+    usePathsStore.setState({ error: null, pythonPath: '' });
+  });
+
+  it('saves the python path', () => {
+    (invoke as any).mockResolvedValue(undefined);
+    usePathsStore.getState().setPythonPath('py');
+    expect(invoke).toHaveBeenCalledWith('save_paths', { python_path: 'py' });
+    expect(usePathsStore.getState().pythonPath).toBe('py');
+    expect(usePathsStore.getState().error).toBeNull();
   });
 
   it('surfaces save_paths errors', async () => {


### PR DESCRIPTION
## Summary
- ensure paths store tests cover only Python path handling
- add positive path save test and preserve save_paths error coverage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aff55d2dec8325afbe87a7dd669bf0