### PR TITLE
Align pages below fixed top bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route, useLocation } from "react-router-dom";
 import { useEffect, useState } from "react";
+import { Box } from "@mui/material";
 import TopBar from "./components/TopBar";
 import ErrorBoundary from "./components/ErrorBoundary";
 import CreateUserDialog from "./components/CreateUserDialog";
@@ -61,39 +62,41 @@ export default function App() {
             <RetroTV>NO SIGNAL</RetroTV>
           )}
         <CreateUserDialog open={showUserDialog} onClose={() => setShowUserDialog(false)} />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/objects" element={<Objects />} />
-        <Route path="/objects/blender" element={<Blender />} />
-        <Route path="/music" element={<Music />} />
-        <Route path="/sfz-music" element={<SFZMusic />} />
-        <Route path="/calendar" element={<Calendar />} />
-        <Route path="/comfy" element={<Comfy />} />
-        <Route path="/assistant" element={<Assistant />} />
-        <Route path="/assistant/general-chat" element={<GeneralChat />} />
-        <Route path="/assistant/seo" element={<Seo />} />
-        <Route path="/dnd/world-builder" element={<WorldBuilder />} />
-        <Route path="/dnd/npcs-maker" element={<NPCMaker />} />
-        <Route path="/dnd/npcs-library" element={<NPCList />} />
-        <Route path="/dnd/npcs/:id" element={<NPCDetail />} />
-        <Route path="/dnd/world-inventory" element={<WorldInventory />} />
-        <Route path="/laser" element={<Laser />} />
-        <Route path="/fusion" element={<Fusion />} />
-        <Route path="/construction" element={<Construction />} />
-        <Route path="/lofi" element={<Lofi />} />
-        <Route path="/voices" element={<Voices />} />
-        <Route path="/tags" element={<TagManager />} />
-        <Route path="/stocks" element={<Stocks />} />
-        <Route path="/shorts" element={<Shorts />} />
-        <Route path="/chores" element={<Chores />} />
-        <Route path="/system" element={<SystemInfo />} />
-        <Route path="/transcription" element={<Transcription />} />
-        <Route path="/simulation" element={<Simulation />} />
-        <Route path="/big-brother" element={<BigBrother />} />
-        <Route path="/dnd" element={<DND />} />
-        <Route path="/user" element={<User />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+      <Box sx={{ pt: 'var(--top-bar-height)' }}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/objects" element={<Objects />} />
+          <Route path="/objects/blender" element={<Blender />} />
+          <Route path="/music" element={<Music />} />
+          <Route path="/sfz-music" element={<SFZMusic />} />
+          <Route path="/calendar" element={<Calendar />} />
+          <Route path="/comfy" element={<Comfy />} />
+          <Route path="/assistant" element={<Assistant />} />
+          <Route path="/assistant/general-chat" element={<GeneralChat />} />
+          <Route path="/assistant/seo" element={<Seo />} />
+          <Route path="/dnd/world-builder" element={<WorldBuilder />} />
+          <Route path="/dnd/npcs-maker" element={<NPCMaker />} />
+          <Route path="/dnd/npcs-library" element={<NPCList />} />
+          <Route path="/dnd/npcs/:id" element={<NPCDetail />} />
+          <Route path="/dnd/world-inventory" element={<WorldInventory />} />
+          <Route path="/laser" element={<Laser />} />
+          <Route path="/fusion" element={<Fusion />} />
+          <Route path="/construction" element={<Construction />} />
+          <Route path="/lofi" element={<Lofi />} />
+          <Route path="/voices" element={<Voices />} />
+          <Route path="/tags" element={<TagManager />} />
+          <Route path="/stocks" element={<Stocks />} />
+          <Route path="/shorts" element={<Shorts />} />
+          <Route path="/chores" element={<Chores />} />
+          <Route path="/system" element={<SystemInfo />} />
+          <Route path="/transcription" element={<Transcription />} />
+          <Route path="/simulation" element={<Simulation />} />
+          <Route path="/big-brother" element={<BigBrother />} />
+          <Route path="/dnd" element={<DND />} />
+          <Route path="/user" element={<User />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Box>
     </ErrorBoundary>
   );
 }

--- a/src/pages/Comfy.tsx
+++ b/src/pages/Comfy.tsx
@@ -35,14 +35,14 @@ export default function Comfy() {
 }
 
 const styles: Record<string, React.CSSProperties> = {
-  container: {
-    display: "grid",
-    gridTemplateColumns: "1fr 1fr",
-    height: "100vh",
-    padding: 16,
-    gap: 12,
-    color: "#eee",
-  },
+    container: {
+      display: "grid",
+      gridTemplateColumns: "1fr 1fr",
+      height: "calc(100vh - var(--top-bar-height))",
+      padding: 16,
+      gap: 12,
+      color: "#eee",
+    },
   form: {
     background: "#121214",
     borderRadius: 10,

--- a/src/pages/GeneralChat.tsx
+++ b/src/pages/GeneralChat.tsx
@@ -309,7 +309,7 @@ export default function GeneralChat() {
   }
 
   return (
-    <Box sx={{ height: "100vh", display: "flex" }}>
+    <Box sx={{ height: "calc(100vh - var(--top-bar-height))", display: "flex" }}>
       <Box
         sx={{
           width: 200,

--- a/src/pages/Music.tsx
+++ b/src/pages/Music.tsx
@@ -11,7 +11,7 @@ export default function Music() {
     <div
       style={{
         position: "relative",
-        minHeight: "100vh",
+          minHeight: "calc(100vh - var(--top-bar-height))",
         background: "#0f0f10",
         color: "#fff",
         paddingBottom: 24,

--- a/src/pages/Objects.tsx
+++ b/src/pages/Objects.tsx
@@ -6,7 +6,7 @@ export default function Objects() {
   return (
     <div
       style={{
-        height: "100vh",
+        height: "calc(100vh - var(--top-bar-height))",
         display: "flex",
         justifyContent: "center",
         alignItems: "center",

--- a/src/pages/SystemInfo.tsx
+++ b/src/pages/SystemInfo.tsx
@@ -32,8 +32,8 @@ export default function SystemInfo() {
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        justifyContent: "center",
-        height: "100vh",
+          justifyContent: "center",
+          height: "calc(100vh - var(--top-bar-height))",
         color: "#fff",
         backgroundColor:
           theme === "retro"

--- a/src/pages/_Center.tsx
+++ b/src/pages/_Center.tsx
@@ -1,7 +1,16 @@
 import { PropsWithChildren } from "react";
-export default function Center({children}:PropsWithChildren){
-  return <div style={{
-    height:"100vh", display:"grid", placeItems:"center",
-    color:"#111", fontSize:18
-  }}>{children}</div>;
+export default function Center({ children }: PropsWithChildren) {
+  return (
+    <div
+      style={{
+        height: "calc(100vh - var(--top-bar-height))",
+        display: "grid",
+        placeItems: "center",
+        color: "#111",
+        fontSize: 18,
+      }}
+    >
+      {children}
+    </div>
+  );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,7 +4,10 @@
 
 /* color-scheme is controlled dynamically via ThemeContext */
 /* default to dark to match existing behavior */
-:root { color-scheme: dark; }
+:root {
+  color-scheme: dark;
+  --top-bar-height: 64px;
+}
 * { box-sizing: border-box; }
 html, body, #root {
   height: 100%;


### PR DESCRIPTION
## Summary
- define global `--top-bar-height` CSS variable
- pad routed content by top-bar height and adjust full-screen layouts accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aff6c40ac4832580eb0290475b7e19