### PR TITLE
feat: add default piano SFZ song form

### DIFF
--- a/src/components/SFZSongForm.test.tsx
+++ b/src/components/SFZSongForm.test.tsx
@@ -28,15 +28,12 @@ describe('SFZSongForm', () => {
   });
 
   it('enqueues GenerateSong with empty arrays', async () => {
-    (openDialog as any)
-      .mockResolvedValueOnce('/tmp/out')
-      .mockResolvedValueOnce('/tmp/piano.sfz');
+    (openDialog as any).mockResolvedValueOnce('/tmp/out');
 
     render(<SFZSongForm />);
     fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'Test' } });
     fireEvent.click(screen.getByText('Choose Output Folder'));
     await screen.findByText('Output: /tmp/out');
-    fireEvent.click(screen.getByText('Pick SFZ Instrument'));
     await screen.findByText('Change SFZ');
 
     fireEvent.click(screen.getByText('Generate'));
@@ -45,6 +42,9 @@ describe('SFZSongForm', () => {
     expect(args.id).toBe('GenerateSong');
     expect(args.spec.instruments).toEqual([]);
     expect(args.spec.ambience).toEqual([]);
+    expect(args.spec.bpm).toBe(64);
+    expect(typeof args.spec.seed).toBe('number');
+    expect(args.spec.seed).toBeLessThan(2 ** 32);
   });
 });
 

--- a/src/components/SFZSongForm.tsx
+++ b/src/components/SFZSongForm.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { resolveResource } from "@tauri-apps/api/path";
 import { Alert, Snackbar } from "@mui/material";
@@ -19,6 +19,7 @@ interface SongSpec {
   ambience: string[];
   drum_pattern: string;
   sfz_instrument?: string;
+  seed?: number;
 }
 
 export default function SFZSongForm() {
@@ -63,10 +64,14 @@ export default function SFZSongForm() {
     }
   }
 
+  useEffect(() => {
+    loadAcousticGrand();
+  }, []);
+
   const spec = useMemo((): SongSpec => ({
     title,
     outDir,
-    bpm: 60,
+    bpm: 64,
     structure: [{ name: "A", bars: 8, chords: ["Cmaj7"] }],
     instruments: [],
     ambience: [],
@@ -75,7 +80,11 @@ export default function SFZSongForm() {
   }), [title, outDir, sfzInstrument]);
 
   function generate() {
-    tasks.enqueueTask("Music Generation", { id: "GenerateSong", spec });
+    const seed = Math.floor(Math.random() * 2 ** 32);
+    tasks.enqueueTask("Music Generation", {
+      id: "GenerateSong",
+      spec: { ...spec, seed },
+    });
   }
 
   return (


### PR DESCRIPTION
## Summary
- default SFZ song spec uses 64 BPM and auto-loads the UprightPianoKW sample
- generate now seeds song spec and test verifies BPM/seed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aff4e17f388325834a77e4738f084d