### PR TITLE
feat: add video editor module

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2067,6 +2067,43 @@ pub async fn save_retro_tv_video(data: String, ext: String) -> Result<String, St
 }
 
 /* ==============================
+Video tools
+============================== */
+
+#[tauri::command]
+pub async fn loop_video(
+    input: String,
+    output_dir: String,
+    output_name: String,
+    hours: u64,
+    minutes: u64,
+    seconds: u64,
+) -> Result<String, String> {
+    let duration = hours * 3600 + minutes * 60 + seconds;
+    if duration == 0 {
+        return Err("duration must be greater than zero".into());
+    }
+    let out_path = Path::new(&output_dir).join(format!("{}.mp4", output_name));
+    let status = PCommand::new("ffmpeg")
+        .arg("-y")
+        .arg("-stream_loop")
+        .arg("-1")
+        .arg("-i")
+        .arg(&input)
+        .arg("-c")
+        .arg("copy")
+        .arg("-t")
+        .arg(duration.to_string())
+        .arg(&out_path)
+        .status()
+        .map_err(|e| e.to_string())?;
+    if !status.success() {
+        return Err(format!("ffmpeg exited with status {}", status));
+    }
+    Ok(out_path.to_string_lossy().to_string())
+}
+
+/* ==============================
 Transcription
 ============================== */
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -152,6 +152,7 @@ fn main() {
             commands::generate_short,
             // Retro TV:
             commands::save_retro_tv_video,
+            commands::loop_video,
             // Transcription:
             commands::load_transcripts,
             commands::transcribe_audio,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import Simulation from "./pages/Simulation";
 import BigBrother from "./pages/BigBrother";
 import Voices from "./pages/Voices";
 import TagManager from "./pages/TagManager";
+import VideoEditor from "./pages/VideoEditor";
 
 export default function App() {
   const { pathname } = useLocation();
@@ -87,6 +88,7 @@ export default function App() {
           <Route path="/tags" element={<TagManager />} />
           <Route path="/stocks" element={<Stocks />} />
           <Route path="/shorts" element={<Shorts />} />
+          <Route path="/video-editor" element={<VideoEditor />} />
           <Route path="/chores" element={<Chores />} />
           <Route path="/system" element={<SystemInfo />} />
           <Route path="/transcription" element={<Transcription />} />

--- a/src/components/FeatureNav.tsx
+++ b/src/components/FeatureNav.tsx
@@ -17,6 +17,7 @@ import {
   FaFilm,
   FaBroom,
   FaTools,
+  FaVideo,
 } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import { useSettings } from "../features/settings/useSettings";
@@ -52,6 +53,7 @@ export const ITEMS: Item[] = [
   { key: "stocks", icon: <FaChartLine />, label: "Stocks", path: "/stocks", color: "rgba(200,255,200,0.55)" },
   { key: "shorts", icon: <FaFilm />, label: "Shorts", path: "/shorts", color: "rgba(200,200,200,0.55)" },
   { key: "chores", icon: <FaBroom />, label: "Chores", path: "/chores", color: "rgba(200,200,255,0.55)" },
+  { key: "video", icon: <FaVideo />, label: "Video Editor", path: "/video-editor", color: "rgba(180,180,255,0.55)" },
   {
     key: "construction",
     icon: <FaTools />,

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -135,6 +135,7 @@ const MODULE_LABELS: Record<ModuleKey, string> = {
   shorts: "Shorts",
   chores: "Chores",
   construction: "Under Construction",
+  video: "Video Editor",
 };
 
 interface SettingsDrawerProps {

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -17,6 +17,7 @@ type ModuleKey =
   | 'shorts'
   | 'chores'
   | 'construction'
+  | 'video'
   | 'sfz';
 
 type ModulesState = Record<ModuleKey, boolean>;
@@ -36,6 +37,7 @@ const defaultModules: ModulesState = {
   shorts: true,
   chores: true,
   construction: true,
+  video: true,
   sfz: true,
 };
 

--- a/src/pages/VideoEditor.tsx
+++ b/src/pages/VideoEditor.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { Stack, Button, TextField } from "@mui/material";
+import Center from "./_Center";
+import { open } from "@tauri-apps/plugin-dialog";
+import { invoke } from "@tauri-apps/api/core";
+
+export default function VideoEditor() {
+  const [input, setInput] = useState("");
+  const [outputDir, setOutputDir] = useState("");
+  const [outputName, setOutputName] = useState("looped");
+  const [hours, setHours] = useState(1);
+  const [minutes, setMinutes] = useState(0);
+  const [seconds, setSeconds] = useState(0);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const pickInput = async () => {
+    const file = await open({ multiple: false });
+    if (typeof file === "string") setInput(file);
+  };
+
+  const pickOutputDir = async () => {
+    const dir = await open({ directory: true });
+    if (typeof dir === "string") setOutputDir(dir);
+  };
+
+  const handleLoop = async () => {
+    if (!input || !outputDir || !outputName.trim()) {
+      setStatus("Please select input, output folder, and name.");
+      return;
+    }
+    const total = hours * 3600 + minutes * 60 + seconds;
+    if (total <= 0) {
+      setStatus("Duration must be greater than 0.");
+      return;
+    }
+    try {
+      setStatus("Processing...");
+      const path: string = await invoke("loop_video", {
+        input,
+        outputDir,
+        outputName,
+        hours,
+        minutes,
+        seconds,
+      });
+      setStatus(`Saved to ${path}`);
+    } catch (e: any) {
+      setStatus(`Error: ${e?.message || e}`);
+    }
+  };
+
+  return (
+    <Center>
+      <Stack spacing={2} sx={{ width: "100%", maxWidth: 500 }}>
+        <Button variant="outlined" onClick={pickInput}>
+          Select Input Video
+        </Button>
+        {input && <div>Input: {input}</div>}
+        <Button variant="outlined" onClick={pickOutputDir}>
+          Choose Output Folder
+        </Button>
+        {outputDir && <div>Output: {outputDir}</div>}
+        <TextField
+          label="Output Name"
+          value={outputName}
+          onChange={(e) => setOutputName(e.target.value)}
+        />
+        <Stack direction="row" spacing={1}>
+          <TextField
+            type="number"
+            label="Hours"
+            value={hours}
+            onChange={(e) => setHours(Math.max(0, Number(e.target.value)))}
+            inputProps={{ min: 0 }}
+          />
+          <TextField
+            type="number"
+            label="Minutes"
+            value={minutes}
+            onChange={(e) =>
+              setMinutes(
+                Math.max(0, Math.min(59, Number(e.target.value)))
+              )
+            }
+            inputProps={{ min: 0, max: 59 }}
+          />
+          <TextField
+            type="number"
+            label="Seconds"
+            value={seconds}
+            onChange={(e) =>
+              setSeconds(
+                Math.max(0, Math.min(59, Number(e.target.value)))
+              )
+            }
+            inputProps={{ min: 0, max: 59 }}
+          />
+        </Stack>
+        <Button variant="contained" onClick={handleLoop}>
+          Create Loop
+        </Button>
+        {status && <div>{status}</div>}
+      </Stack>
+    </Center>
+  );
+}


### PR DESCRIPTION
## Summary
- add video editor module to feature wheel and settings
- implement looping video backend command and UI
- expose video editor page and route

## Testing
- `npx vitest run` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68affca485088325baf065e9489c3d18