### PR TITLE
feat: preview generated videos

### DIFF
--- a/src/pages/VideoEditor.test.tsx
+++ b/src/pages/VideoEditor.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import VideoEditor from './VideoEditor';
+import { open } from '@tauri-apps/plugin-dialog';
+import { invoke, convertFileSrc } from '@tauri-apps/api/core';
+
+type Mock = ReturnType<typeof vi.fn>;
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(), convertFileSrc: vi.fn() }));
+
+describe('VideoEditor', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders preview video when outputPath is set', async () => {
+    (open as Mock).mockResolvedValueOnce('input.mp4');
+    (open as Mock).mockResolvedValueOnce('/out');
+    (invoke as Mock).mockResolvedValue('/out/looped.mp4');
+    (convertFileSrc as Mock).mockImplementation((p: string) => `converted:${p}`);
+
+    const { container } = render(<VideoEditor />);
+
+    fireEvent.click(screen.getByRole('button', { name: /select input video/i }));
+    await waitFor(() => expect(open).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: /choose output folder/i }));
+    await waitFor(() => expect(open).toHaveBeenCalledTimes(2));
+
+    fireEvent.click(screen.getByRole('button', { name: /create loop/i }));
+
+    await waitFor(() => {
+      const video = container.querySelector('video');
+      expect(video).toBeInTheDocument();
+      expect(video?.getAttribute('src')).toBe('converted:/out/looped.mp4');
+    });
+    expect(convertFileSrc).toHaveBeenCalledWith('/out/looped.mp4');
+  });
+});

--- a/src/pages/VideoEditor.tsx
+++ b/src/pages/VideoEditor.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Stack, Button, TextField, LinearProgress } from "@mui/material";
 import Center from "./_Center";
 import { open } from "@tauri-apps/plugin-dialog";
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, convertFileSrc } from "@tauri-apps/api/core";
 
 export default function VideoEditor() {
   const [input, setInput] = useState("");
@@ -13,6 +13,7 @@ export default function VideoEditor() {
   const [seconds, setSeconds] = useState(0);
   const [status, setStatus] = useState<string | null>(null);
   const [processing, setProcessing] = useState(false);
+  const [outputPath, setOutputPath] = useState<string | null>(null);
 
   const pickInput = async () => {
     const file = await open({ multiple: false });
@@ -45,6 +46,7 @@ export default function VideoEditor() {
         minutes,
         seconds,
       });
+      setOutputPath(path);
       setStatus(`Saved to ${path}`);
     } catch (e: any) {
       setStatus(`Error: ${e?.message || e}`);
@@ -105,6 +107,13 @@ export default function VideoEditor() {
         </Button>
         {processing && <LinearProgress />}
         {status && <div>{status}</div>}
+        {outputPath && (
+          <video
+            src={convertFileSrc(outputPath)}
+            controls
+            loop
+          />
+        )}
       </Stack>
     </Center>
   );


### PR DESCRIPTION
## Summary
- add video preview for generated loops
- store output path and convert to file URL
- add unit test ensuring preview renders with converted source

## Testing
- `npx vitest run src/pages/VideoEditor.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b068966e548325aeac4ffa79b4f00e