### PR TITLE
Add DnD portrait workflow to Comfy UI

### DIFF
--- a/src/comfy/dnd_portrait.json
+++ b/src/comfy/dnd_portrait.json
@@ -1,0 +1,395 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "revision": 0,
+  "last_node_id": 7,
+  "last_link_id": 18,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "CheckpointLoaderSimple",
+      "pos": [
+        100,
+        130
+      ],
+      "size": [
+        270,
+        98
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            12
+          ]
+        },
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            10,
+            11
+          ]
+        },
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            17
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.52",
+        "Node name for S&R": "CheckpointLoaderSimple"
+      },
+      "widgets_values": [
+        "dreamshaper_8.safetensors"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "EmptyLatentImage",
+      "pos": [
+        100,
+        358
+      ],
+      "size": [
+        270,
+        106
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            15
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.52",
+        "Node name for S&R": "EmptyLatentImage"
+      },
+      "widgets_values": [
+        768,
+        1024,
+        1
+      ]
+    },
+    {
+      "id": 3,
+      "type": "CLIPTextEncode",
+      "pos": [
+        470,
+        130
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 10
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            13
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Positive Prompt)",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.52",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "portrait of a Dungeons & Dragons character, rugged male pirate with weathered skin, tri‑corner hat, bushy beard, earring and sword, wearing worn leather coat and bandana, dramatic chiaroscuro lighting, fantasy oil painting, high detail, ultra realistic"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "CLIPTextEncode",
+      "pos": [
+        470,
+        460
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 11
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            14
+          ]
+        }
+      ],
+      "title": "CLIP Text Encode (Negative Prompt)",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.52",
+        "Node name for S&R": "CLIPTextEncode"
+      },
+      "widgets_values": [
+        "blurry, low quality, bad anatomy, extra limbs, extra fingers, watermark, text, distorted face, anime, cartoon"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "KSampler",
+      "pos": [
+        970,
+        130
+      ],
+      "size": [
+        270,
+        262
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 12
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 13
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 14
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 15
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            16
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.52",
+        "Node name for S&R": "KSampler"
+      },
+      "widgets_values": [
+        455014802956840,
+        "randomize",
+        30,
+        7,
+        "euler",
+        "karras",
+        1
+      ]
+    },
+    {
+      "id": 6,
+      "type": "VAEDecode",
+      "pos": [
+        1340,
+        130
+      ],
+      "size": [
+        140,
+        46
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "samples",
+          "type": "LATENT",
+          "link": 16
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 17
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            18
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.52",
+        "Node name for S&R": "VAEDecode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 7,
+      "type": "SaveImage",
+      "pos": [
+        1580,
+        130
+      ],
+      "size": [
+        270,
+        270
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 18
+        }
+      ],
+      "outputs": [],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.52",
+        "Node name for S&R": "SaveImage"
+      },
+      "widgets_values": [
+        "dnd_portrait"
+      ]
+    }
+  ],
+  "links": [
+    [
+      10,
+      1,
+      1,
+      3,
+      0,
+      "CLIP"
+    ],
+    [
+      11,
+      1,
+      1,
+      4,
+      0,
+      "CLIP"
+    ],
+    [
+      12,
+      1,
+      0,
+      5,
+      0,
+      "MODEL"
+    ],
+    [
+      13,
+      3,
+      0,
+      5,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      14,
+      4,
+      0,
+      5,
+      2,
+      "CONDITIONING"
+    ],
+    [
+      15,
+      2,
+      0,
+      5,
+      3,
+      "LATENT"
+    ],
+    [
+      16,
+      5,
+      0,
+      6,
+      0,
+      "LATENT"
+    ],
+    [
+      17,
+      1,
+      2,
+      6,
+      1,
+      "VAE"
+    ],
+    [
+      18,
+      6,
+      0,
+      7,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.7972024500000005,
+      "offset": [
+        170.54102160624296,
+        184.02875486647076
+      ]
+    },
+    "frontendVersion": "1.25.10",
+    "VHS_latentpreview": false,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true
+  },
+  "version": 0.4
+}

--- a/src/pages/Comfy.tsx
+++ b/src/pages/Comfy.tsx
@@ -1,7 +1,26 @@
 // src/pages/Comfy.tsx
+import { useState } from "react";
 import { FaDiceD20, FaImage } from "react-icons/fa";
+import dndPortrait from "../comfy/dnd_portrait.json";
 
 export default function Comfy() {
+  const [status, setStatus] = useState("ready");
+
+  async function runWorkflow(workflow: unknown) {
+    try {
+      setStatus("running");
+      await fetch("http://127.0.0.1:8188/prompt", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: workflow }),
+      });
+      setStatus("submitted");
+    } catch (err) {
+      console.error(err);
+      setStatus("error");
+    }
+  }
+
   return (
     <div style={styles.container}>
       <div style={styles.form}>
@@ -11,7 +30,12 @@ export default function Comfy() {
             <FaDiceD20 />
           </button>
           <div style={styles.buttonGroup}>
-            <button style={styles.actionBtn}>Portrait</button>
+            <button
+              style={styles.actionBtn}
+              onClick={() => runWorkflow(dndPortrait)}
+            >
+              Portrait
+            </button>
             <button style={styles.actionBtn}>Icon</button>
             <button style={styles.actionBtn}>Sketches</button>
           </div>
@@ -28,7 +52,7 @@ export default function Comfy() {
       </div>
       <div style={styles.previewWrap}>
         <div style={styles.preview}>Preview</div>
-        <div style={styles.status}>Status: ready</div>
+        <div style={styles.status}>Status: {status}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add ComfyUI workflow for DnD portrait generation
- trigger workflow from Comfy page and show submission status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b07415ed3083258294ccdcf726cf26