### PR TITLE
feat: show selected paths in video editor fields

### DIFF
--- a/src/pages/VideoEditor.tsx
+++ b/src/pages/VideoEditor.tsx
@@ -1,5 +1,14 @@
 import { useState } from "react";
-import { Stack, Button, TextField, LinearProgress } from "@mui/material";
+import {
+  Stack,
+  Button,
+  TextField,
+  LinearProgress,
+  InputAdornment,
+  IconButton,
+} from "@mui/material";
+import FileOpenIcon from "@mui/icons-material/FileOpen";
+import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 import Center from "./_Center";
 import { open } from "@tauri-apps/plugin-dialog";
 import { invoke, convertFileSrc } from "@tauri-apps/api/core";
@@ -61,11 +70,45 @@ export default function VideoEditor() {
         <Button variant="outlined" onClick={pickInput}>
           Select Input Video
         </Button>
-        {input && <div>Input: {input}</div>}
+        {input && (
+          <TextField
+            label="Input"
+            value={input}
+            fullWidth
+            InputProps={{
+              readOnly: true,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton onClick={pickInput} edge="end">
+                    <FileOpenIcon />
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+            sx={{ textOverflow: "ellipsis" }}
+          />
+        )}
         <Button variant="outlined" onClick={pickOutputDir}>
           Choose Output Folder
         </Button>
-        {outputDir && <div>Output: {outputDir}</div>}
+        {outputDir && (
+          <TextField
+            label="Output"
+            value={outputDir}
+            fullWidth
+            InputProps={{
+              readOnly: true,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton onClick={pickOutputDir} edge="end">
+                    <FolderOpenIcon />
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+            sx={{ textOverflow: "ellipsis" }}
+          />
+        )}
         <TextField
           label="Output Name"
           value={outputName}


### PR DESCRIPTION
## Summary
- display selected input and output paths using read-only text fields with open icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b074937fdc8325b5c6b5ca8c5d5598