### PR TITLE
Use Snackbar alerts for status messages

### DIFF
--- a/src/pages/Blender.tsx
+++ b/src/pages/Blender.tsx
@@ -1,5 +1,14 @@
 import { useState, useEffect } from "react";
-import { TextField, Button, Stack, MenuItem, Box, Typography } from "@mui/material";
+import {
+  TextField,
+  Button,
+  Stack,
+  MenuItem,
+  Box,
+  Typography,
+  Snackbar,
+  Alert,
+} from "@mui/material";
 import Editor from "@monaco-editor/react";
 import Center from "./_Center";
 import { invoke } from "@tauri-apps/api/core";
@@ -15,6 +24,13 @@ export default function Blender() {
   const [templates, setTemplates] = useState<{ name: string; code: string }[]>([]);
   const [templateName, setTemplateName] = useState("");
   const [selectedTemplate, setSelectedTemplate] = useState("");
+
+  const severity =
+    status?.startsWith("Error") || status?.startsWith("Failed")
+      ? "error"
+      : status?.startsWith("Blender finished")
+      ? "success"
+      : "info";
 
   useEffect(() => {
     (async () => {
@@ -166,7 +182,21 @@ export default function Blender() {
             Output Folder: {outputDir ?? "Not selected"}
           </div>
         </Stack>
-        {status && <div>{status}</div>}
+        <Snackbar
+          open={!!status}
+          autoHideDuration={6000}
+          onClose={() => setStatus(null)}
+        >
+          {status && (
+            <Alert
+              onClose={() => setStatus(null)}
+              severity={severity}
+              sx={{ width: "100%" }}
+            >
+              {status}
+            </Alert>
+          )}
+        </Snackbar>
         </Stack>
       </Center>
       <Box sx={systemInfoWidgetSx}>

--- a/src/pages/VideoEditor.tsx
+++ b/src/pages/VideoEditor.tsx
@@ -1,5 +1,12 @@
 import { useState } from "react";
-import { Stack, Button, TextField, LinearProgress } from "@mui/material";
+import {
+  Stack,
+  Button,
+  TextField,
+  LinearProgress,
+  Snackbar,
+  Alert,
+} from "@mui/material";
 import Center from "./_Center";
 import { open } from "@tauri-apps/plugin-dialog";
 import { invoke, convertFileSrc } from "@tauri-apps/api/core";
@@ -14,6 +21,12 @@ export default function VideoEditor() {
   const [status, setStatus] = useState<string | null>(null);
   const [processing, setProcessing] = useState(false);
   const [outputPath, setOutputPath] = useState<string | null>(null);
+
+  const severity = status?.startsWith("Error")
+    ? "error"
+    : status?.startsWith("Saved")
+    ? "success"
+    : "info";
 
   const pickInput = async () => {
     const file = await open({ multiple: false });
@@ -106,7 +119,21 @@ export default function VideoEditor() {
           Create Loop
         </Button>
         {processing && <LinearProgress />}
-        {status && <div>{status}</div>}
+        <Snackbar
+          open={!!status}
+          autoHideDuration={6000}
+          onClose={() => setStatus(null)}
+        >
+          {status && (
+            <Alert
+              onClose={() => setStatus(null)}
+              severity={severity}
+              sx={{ width: "100%" }}
+            >
+              {status}
+            </Alert>
+          )}
+        </Snackbar>
         {outputPath && (
           <video
             src={convertFileSrc(outputPath)}


### PR DESCRIPTION
## Summary
- replace raw status divs with MUI Snackbar and Alert
- show alerts with severity based on message content
- clear status when Snackbar closes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0749575ac8325aa48362d694c24e9