### PR TITLE
Add SFZ picker and lofi filter settings

### DIFF
--- a/src/components/PolishControls.tsx
+++ b/src/components/PolishControls.tsx
@@ -18,6 +18,9 @@ interface Props {
   setDither: (val: boolean) => void;
   lofiFilter: boolean;
   setLofiFilter: (val: boolean) => void;
+  sfzInstrument: string | null;
+  pickSfzInstrument: () => void;
+  loadAcousticGrand: () => void;
 }
 
 export default function PolishControls({
@@ -35,14 +38,30 @@ export default function PolishControls({
   setDither,
   lofiFilter,
   setLofiFilter,
+  sfzInstrument,
+  pickSfzInstrument,
+  loadAcousticGrand,
 }: Props) {
   return (
     <div className={clsx(styles.panel, "mt-3")}>
-      <details open>
+      <details open data-testid="sfz-section">
           <summary className="cursor-pointer text-xs opacity-80">
             Polish <HelpIcon text="Optional mix polish effects" />
           </summary>
         <div className="mt-2">
+          <div className="mt-2 flex items-center gap-2">
+            <button className={styles.btn} onClick={pickSfzInstrument}>
+              Choose SFZ
+            </button>
+            <button className={styles.btn} onClick={loadAcousticGrand}>
+              Acoustic Grand Piano
+            </button>
+            <span className={styles.small}>
+              {sfzInstrument
+                ? sfzInstrument.split(/[\\/]/).pop()
+                : "none selected"}
+            </span>
+          </div>
           <div className={styles.optionGrid}>
             <label className={styles.optionCard}>
               <span>
@@ -91,7 +110,7 @@ export default function PolishControls({
             <label className={styles.optionCard}>
               <span>
                 Lofi Filter
-                <HelpIcon text="Applies lofi low-pass filter (default on)" />
+                <HelpIcon text="Applies lofi low-pass filter (default off)" />
               </span>
               <input
                 type="checkbox"

--- a/src/components/SongForm.test.tsx
+++ b/src/components/SongForm.test.tsx
@@ -33,8 +33,11 @@ vi.mock('../store/tasks', () => ({
 }));
 
 function openSection(id: string) {
-  const summary = screen.getByTestId(id).querySelector('summary') as HTMLElement;
-  fireEvent.click(summary);
+  const details = screen.getByTestId(id) as HTMLDetailsElement;
+  if (!details.open) {
+    const summary = details.querySelector('summary') as HTMLElement;
+    fireEvent.click(summary);
+  }
 }
 
 function openDetails(title: string) {

--- a/src/components/SongForm.tsx
+++ b/src/components/SongForm.tsx
@@ -179,7 +179,9 @@ export default function SongForm() {
   const [leadInstrument, setLeadInstrument] = useState<string>(() =>
     inferLeadInstrument(defaultInstruments)
   );
-  const [sfzInstrument, setSfzInstrument] = useState<string | null>(null);
+  const [sfzInstrument, setSfzInstrument] = useState<string | null>(() =>
+    localStorage.getItem("sfzInstrument")
+  );
   const [ambience, setAmbience] = useState<string[]>(["rain"]);
   const [ambienceLevel, setAmbienceLevel] = useState(0.5);
   const [templates, setTemplates] = useState<Record<string, TemplateSpec>>(() => {
@@ -342,7 +344,7 @@ export default function SongForm() {
   });
   const [lofiFilter, setLofiFilter] = useState(() => {
     const stored = localStorage.getItem("lofiFilter");
-    return stored === null ? true : stored === "true";
+    return stored === "true";
   });
 
   // UI state
@@ -407,6 +409,16 @@ export default function SongForm() {
   useEffect(() => {
     localStorage.setItem("lofiFilter", String(lofiFilter));
   }, [lofiFilter]);
+
+  useEffect(() => {
+    if (sfzInstrument) {
+      localStorage.setItem("sfzInstrument", sfzInstrument);
+      setPreviewSfzInstrument(convertFileSrc(sfzInstrument));
+    } else {
+      localStorage.removeItem("sfzInstrument");
+      setPreviewSfzInstrument(undefined);
+    }
+  }, [sfzInstrument, setPreviewSfzInstrument]);
 
   const tasks = useTasks((s) => s.tasks);
   const enqueueTask = useTasks((s) => s.enqueueTask);
@@ -474,7 +486,6 @@ export default function SongForm() {
       if (file) {
         const rawPath = file as string;
         setSfzInstrument(rawPath);
-        setPreviewSfzInstrument(convertFileSrc(rawPath));
       }
     } catch (e: any) {
       setErr(e?.message || String(e));
@@ -489,7 +500,6 @@ export default function SongForm() {
         "sfz_sounds/UprightPianoKW-20220221.sfz"
       );
       setSfzInstrument(path);
-      setPreviewSfzInstrument(convertFileSrc(path));
     } catch (e: any) {
       setErr(e?.message || String(e));
     }
@@ -1261,24 +1271,6 @@ export default function SongForm() {
             />
           </div>
         </details>
-        {/* sfz instrument selector */}
-        <details className="mt-3" data-testid="sfz-section">
-          <summary className="cursor-pointer text-xs opacity-80">
-            Select SFZ instrument
-          </summary>
-          <div className="mt-2 flex items-center gap-2">
-            <button className={styles.btn} onClick={pickSfzInstrument}>
-              Choose SFZ
-            </button>
-            <button className={styles.btn} onClick={loadAcousticGrand}>
-              Acoustic Grand Piano
-            </button>
-            <span className={styles.small}>
-              {sfzInstrument ? sfzInstrument.split(/[\\/]/).pop() : "none selected"}
-            </span>
-          </div>
-        </details>
-
         {/* rhythm & feel */}
         <details className="mt-3" data-testid="rhythm-section">
           <summary className="cursor-pointer text-xs opacity-80">Rhythm</summary>
@@ -1311,6 +1303,9 @@ export default function SongForm() {
           setDither={setDither}
           lofiFilter={lofiFilter}
           setLofiFilter={setLofiFilter}
+          sfzInstrument={sfzInstrument}
+          pickSfzInstrument={pickSfzInstrument}
+          loadAcousticGrand={loadAcousticGrand}
         />
         {/* album mode toggle */}
         <div className={styles.panel}>

--- a/src/components/__snapshots__/SongForm.test.tsx.snap
+++ b/src/components/__snapshots__/SongForm.test.tsx.snap
@@ -2144,35 +2144,6 @@ exports[`SongForm > renders default form 1`] = `
       </details>
       <details
         class="mt-3"
-        data-testid="sfz-section"
-      >
-        <summary
-          class="cursor-pointer text-xs opacity-80"
-        >
-          Select SFZ instrument
-        </summary>
-        <div
-          class="mt-2 flex items-center gap-2"
-        >
-          <button
-            class="_btn_913096"
-          >
-            Choose SFZ
-          </button>
-          <button
-            class="_btn_913096"
-          >
-            Acoustic Grand Piano
-          </button>
-          <span
-            class="_small_913096"
-          >
-            none selected
-          </span>
-        </div>
-      </details>
-      <details
-        class="mt-3"
         data-testid="rhythm-section"
       >
         <summary
@@ -2371,6 +2342,7 @@ exports[`SongForm > renders default form 1`] = `
         class="_panel_913096 mt-3"
       >
         <details
+          data-testid="sfz-section"
           open=""
         >
           <summary
@@ -2403,6 +2375,25 @@ exports[`SongForm > renders default form 1`] = `
           <div
             class="mt-2"
           >
+            <div
+              class="mt-2 flex items-center gap-2"
+            >
+              <button
+                class="_btn_913096"
+              >
+                Choose SFZ
+              </button>
+              <button
+                class="_btn_913096"
+              >
+                Acoustic Grand Piano
+              </button>
+              <span
+                class="_small_913096"
+              >
+                none selected
+              </span>
+            </div>
             <div
               class="_optionGrid_913096"
             >
@@ -2567,7 +2558,6 @@ exports[`SongForm > renders default form 1`] = `
                   </button>
                 </span>
                 <input
-                  checked=""
                   type="checkbox"
                 />
               </label>


### PR DESCRIPTION
## Summary
- allow selecting an SFZ instrument and remember the choice
- expose a lofi filter toggle that is off by default

## Testing
- `npx vitest run src/components/SongForm.test.tsx src/components/SFZSongForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b072ef76f08325ab0ab33ef43697ff