### PR TITLE
feat: remember sfz instrument with lofi filter toggle

### DIFF
--- a/src/components/SFZSongForm.test.tsx
+++ b/src/components/SFZSongForm.test.tsx
@@ -14,20 +14,23 @@ vi.mock('../store/tasks', () => ({
 describe('SFZSongForm', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    localStorage.clear();
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it('renders title, output folder, and sfz selector', () => {
+  it('renders form with lofi filter off', async () => {
     render(<SFZSongForm />);
     expect(screen.getByPlaceholderText('Title')).toBeInTheDocument();
     expect(screen.getByText('Choose Output Folder')).toBeInTheDocument();
-    expect(screen.getByText('Pick SFZ Instrument')).toBeInTheDocument();
+    await screen.findByText('Change SFZ');
+    const lofi = screen.getByLabelText('Lofi Filter');
+    expect(lofi).not.toBeChecked();
   });
 
-  it('enqueues GenerateSong with empty arrays', async () => {
+  it('enqueues GenerateSong with default lofi filter', async () => {
     (openDialog as any).mockResolvedValueOnce('/tmp/out');
 
     render(<SFZSongForm />);
@@ -43,8 +46,45 @@ describe('SFZSongForm', () => {
     expect(args.spec.instruments).toEqual([]);
     expect(args.spec.ambience).toEqual([]);
     expect(args.spec.bpm).toBe(64);
+    expect(args.spec.lofi_filter).toBe(false);
     expect(typeof args.spec.seed).toBe('number');
     expect(args.spec.seed).toBeLessThan(2 ** 32);
+  });
+
+  it('includes lofi filter when toggled', async () => {
+    (openDialog as any).mockResolvedValueOnce('/tmp/out');
+
+    render(<SFZSongForm />);
+    fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'Test' } });
+    fireEvent.click(screen.getByText('Choose Output Folder'));
+    await screen.findByText('Output: /tmp/out');
+    await screen.findByText('Change SFZ');
+    fireEvent.click(screen.getByLabelText('Lofi Filter'));
+
+    fireEvent.click(screen.getByText('Generate'));
+    await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
+    const [, args] = enqueueTask.mock.calls[0];
+    expect(args.spec.lofi_filter).toBe(true);
+  });
+
+  it('remembers chosen SFZ instrument', async () => {
+    (openDialog as any).mockResolvedValueOnce('/tmp/piano.sfz');
+
+    const { unmount } = render(<SFZSongForm />);
+    await screen.findByText('Change SFZ');
+    fireEvent.click(screen.getByText('Change SFZ'));
+    await waitFor(() => expect(localStorage.getItem('sfzInstrument')).toBe('/tmp/piano.sfz'));
+    unmount();
+
+    (openDialog as any).mockResolvedValueOnce('/tmp/out');
+    render(<SFZSongForm />);
+    fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'Test' } });
+    fireEvent.click(screen.getByText('Choose Output Folder'));
+    await screen.findByText('Output: /tmp/out');
+    fireEvent.click(screen.getByText('Generate'));
+    await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
+    const [, args] = enqueueTask.mock.calls[0];
+    expect(args.spec.sfz_instrument).toBe('/tmp/piano.sfz');
   });
 });
 


### PR DESCRIPTION
## Summary
- remember last selected SFZ instrument
- add lofi filter toggle to SFZ song form

## Testing
- `npm test` *(fails: ReferenceError window is not defined)*
- `npx vitest run src/components/SFZSongForm.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b07cdfd2cc8325b1b50b69227905b6