### PR TITLE
feat: show sfz loading progress

### DIFF
--- a/src/components/SFZSongForm.test.tsx
+++ b/src/components/SFZSongForm.test.tsx
@@ -6,6 +6,13 @@ import { open as openDialog } from '@tauri-apps/plugin-dialog';
 vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
 vi.mock('@tauri-apps/api/path', () => ({ resolveResource: (p: string) => Promise.resolve(p) }));
 
+vi.mock('../utils/sfzLoader', () => ({
+  loadSfz: vi.fn((_path: string, onProgress?: (l: number, t: number) => void) => {
+    onProgress?.(1, 1);
+    return Promise.resolve({ regions: [], sampler: {} } as any);
+  }),
+}));
+
 const enqueueTask = vi.fn();
 vi.mock('../store/tasks', () => ({
   useTasks: () => ({ enqueueTask }),


### PR DESCRIPTION
## Summary
- add progress callback to sfz loader and surface sample load failures
- show progress bar and status message when loading SFZ instruments
- adjust tests to mock sfz loading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b07f2f39b88325b0551047e952dc74