### PR TITLE
Allow window maximize capability

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "dialog:default",
-    "dialog:allow-open"
+    "dialog:allow-open",
+    "core:window:allow-maximize"
   ]
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,8 @@
       "../public/sfz_sounds",
       "python/lofi",
       "python/ambience_generator.py",
-      "python/bark_tts.py"
+      "python/bark_tts.py",
+      "capabilities/default.json"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- allow window maximize in default Tauri capabilities
- bundle default capabilities file with application resources

## Testing
- `npm test`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `npm run tauri build` *(fails: Argument of type '(npcState: NpcState) => { npcs: { tags: string[]; ... }[]; }' is not assignable to parameter of type 'NpcState | Partial<NpcState> | ((state: NpcState) => NpcState | Partial<NpcState>)')*

------
https://chatgpt.com/codex/tasks/task_e_68b085cd5c9c83259f4de6cf64a53cdc