### PR TITLE
feat: allow multiline backstory

### DIFF
--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -710,6 +710,9 @@ export default function NpcForm({ world }: Props) {
                 }
                 fullWidth
                 margin="normal"
+                multiline
+                minRows={4}
+                maxRows={12}
               />
             </Grid>
             <Grid item xs={12}>


### PR DESCRIPTION
## Summary
- allow longer NPC backstories by making the Backstory field multiline

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b08cef9d5083259905b4b091f1174b