### PR TITLE
Adjust world selector spacing

### DIFF
--- a/src/pages/DND.test.tsx
+++ b/src/pages/DND.test.tsx
@@ -29,4 +29,21 @@ describe("DND world selector", () => {
     expect(useWorlds.getState().worlds).toContain("Eberron");
     expect(useWorlds.getState().currentWorld).toBe("Eberron");
   });
+
+  it("positions the world selector away from the retro TV across screen sizes", () => {
+    render(<DND />);
+    const container = screen.getByTestId("world-selector");
+    const checkMargins = () => {
+      const style = window.getComputedStyle(container);
+      expect(style.marginTop).toBe("32px");
+      expect(style.marginLeft).toBe("16px");
+    };
+    checkMargins();
+    window.innerWidth = 360;
+    window.dispatchEvent(new Event("resize"));
+    checkMargins();
+    window.innerWidth = 1280;
+    window.dispatchEvent(new Event("resize"));
+    checkMargins();
+  });
 });

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -73,7 +73,10 @@ export default function DND() {
   return (
     <ThemeProvider theme={createDndTheme()}>
       <Box sx={{ p: 2 }}>
-      <Box sx={{ my: 2, maxWidth: 200, mx: "auto" }}>
+      <Box
+        data-testid="world-selector"
+        sx={{ mt: 4, mb: 2, ml: 2, maxWidth: 200 }}
+      >
         <TextField
           select
           label="World"


### PR DESCRIPTION
## Summary
- reposition DND world selector with top/left margins to avoid overlapping retro TV
- test world selector margins across different viewport widths

## Testing
- `npm test -- --run src/pages/DND.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b08e2aa2c88325be4390e2fe32533f