### PR TITLE
feat: rename NPC inventory label to include equipment

### DIFF
--- a/src/features/dnd/NpcForm.tsx
+++ b/src/features/dnd/NpcForm.tsx
@@ -666,11 +666,11 @@ export default function NpcForm({ world }: Props) {
               <StyledTextField
                 id="inventory"
                 label={
-                  <Tooltip title="Example: torch, rope">
-                    <span>Inventory (comma separated)</span>
+                  <Tooltip title="Example: torch, rope, shield">
+                    <span>Inventory/Equipment (comma separated)</span>
                   </Tooltip>
                 }
-                placeholder="torch, rope"
+                placeholder="torch, rope, shield"
                 value={state.inventory}
                 onChange={(e) => {
                   dispatch({ type: "SET_FIELD", field: "inventory", value: e.target.value });


### PR DESCRIPTION
## Summary
- rename NPC inventory field label to "Inventory/Equipment"
- update tooltip and placeholder example to show equipment

## Testing
- `npm test -- --run` *(fails: SongForm > remembers last used template)*

------
https://chatgpt.com/codex/tasks/task_e_68b08e27cebc8325b2f6f812acb5dec5