### PR TITLE
Normalize SFZ path separators before loading

### DIFF
--- a/src/components/SFZSongForm.test.tsx
+++ b/src/components/SFZSongForm.test.tsx
@@ -6,8 +6,13 @@ import { convertFileSrc } from '@tauri-apps/api/core';
 import { loadSfz } from '../utils/sfzLoader';
 
 vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
-vi.mock('@tauri-apps/api/path', () => ({ resolveResource: (p: string) => Promise.resolve(p) }));
-vi.mock('@tauri-apps/api/core', () => ({ convertFileSrc: vi.fn((p: string) => `converted:${p}`) }));
+vi.mock('@tauri-apps/api/path', () => ({
+  resolveResource: (p: string) =>
+    Promise.resolve(`C:/Blossom/resources/${p}`.replace(/\//g, '\\')),
+}));
+vi.mock('@tauri-apps/api/core', () => ({
+  convertFileSrc: vi.fn((p: string) => `http://asset.localhost/${p}`),
+}));
 
 vi.mock('../utils/sfzLoader', () => ({
   loadSfz: vi.fn((_path: string, onProgress?: (l: number, t: number) => void) => {
@@ -97,18 +102,20 @@ describe('SFZSongForm', () => {
     expect(args.spec.sfz_instrument).toBe('/tmp/piano.sfz');
   });
 
-  it('converts default piano path before loading', async () => {
+  it('normalizes default piano path before loading', async () => {
     render(<SFZSongForm />);
     await waitFor(() => expect(loadSfz).toHaveBeenCalled());
-    expect(convertFileSrc).toHaveBeenCalledWith('sfz_sounds/UprightPianoKW-20220221.sfz');
+    expect(convertFileSrc).toHaveBeenCalledWith(
+      'C:/Blossom/resources/sfz_sounds/UprightPianoKW-20220221.sfz'
+    );
     expect(loadSfz).toHaveBeenCalledWith(
-      'converted:sfz_sounds/UprightPianoKW-20220221.sfz',
+      'http://asset.localhost/C:/Blossom/resources/sfz_sounds/UprightPianoKW-20220221.sfz',
       expect.any(Function)
     );
   });
 
-  it('converts user selected file before loading', async () => {
-    (openDialog as any).mockResolvedValueOnce('/tmp/piano.sfz');
+  it('normalizes user selected file before loading', async () => {
+    (openDialog as any).mockResolvedValueOnce('C:\\tmp\\piano.sfz');
 
     render(<SFZSongForm />);
     await screen.findByText('Change SFZ');
@@ -118,9 +125,9 @@ describe('SFZSongForm', () => {
     fireEvent.click(screen.getByText('Change SFZ'));
 
     await waitFor(() => expect(loadSfz).toHaveBeenCalled());
-    expect(convertFileSrc).toHaveBeenCalledWith('/tmp/piano.sfz');
+    expect(convertFileSrc).toHaveBeenCalledWith('C:/tmp/piano.sfz');
     expect(loadSfz).toHaveBeenCalledWith(
-      'converted:/tmp/piano.sfz',
+      'http://asset.localhost/C:/tmp/piano.sfz',
       expect.any(Function)
     );
   });

--- a/src/components/SFZSongForm.tsx
+++ b/src/components/SFZSongForm.tsx
@@ -50,16 +50,17 @@ export default function SFZSongForm() {
   }
 
   async function loadInstrument(path: string) {
+    const normalized = path.replace(/\\/g, "/");
     setLoading(true);
     setProgress(0);
     setStatus(null);
     try {
-      await loadSfz(convertFileSrc(path), (loaded, total) => {
+      await loadSfz(convertFileSrc(normalized), (loaded, total) => {
         setProgress(total ? loaded / total : 0);
       });
-      setSfzInstrument(path);
-      localStorage.setItem("sfzInstrument", path);
-      setStatus(`Loaded instrument: ${path}`);
+      setSfzInstrument(normalized);
+      localStorage.setItem("sfzInstrument", normalized);
+      setStatus(`Loaded instrument: ${normalized}`);
     } catch (e) {
       console.error(e);
       setError(String(e));


### PR DESCRIPTION
## Summary
- Normalize SFZ instrument paths to use forward slashes before converting to Tauri asset URLs
- Ensure loadSfz receives full asset URLs for both bundled and user-selected SFZ files
- Add tests covering path normalization and asset URL generation

## Testing
- `npx vitest run src/components/SFZSongForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b08e67c01483258f34951e6b545734