### PR TITLE
Improve SFZ loader error handling

### DIFF
--- a/src/components/SFZSongForm.test.tsx
+++ b/src/components/SFZSongForm.test.tsx
@@ -131,5 +131,13 @@ describe('SFZSongForm', () => {
       expect.any(Function)
     );
   });
+
+  it('maps loader errors to friendly message', async () => {
+    vi.mocked(loadSfz).mockRejectedValueOnce(
+      new Error('Unable to load SFZ: piano.sfz (HTTP 404)')
+    );
+    render(<SFZSongForm />);
+    await screen.findByText('SFZ file not found');
+  });
 });
 

--- a/src/components/SFZSongForm.tsx
+++ b/src/components/SFZSongForm.tsx
@@ -39,13 +39,32 @@ export default function SFZSongForm() {
   const [error, setError] = useState<string | null>(null);
   const tasks = useTasks();
 
+  function mapLoaderError(e: unknown): string {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("Unable to load SFZ")) {
+      const status = msg.match(/HTTP (\d+)/)?.[1];
+      if (msg.includes("file not found") || status === "404") {
+        return "SFZ file not found";
+      }
+      return status ? `Failed to load SFZ (HTTP ${status})` : "Failed to load SFZ";
+    }
+    if (msg.includes("Failed to load sample")) {
+      return "Failed to load a sample file referenced by the SFZ";
+    }
+    return msg;
+  }
+
+  function handleError(e: unknown) {
+    console.error(e);
+    setError(mapLoaderError(e));
+  }
+
   async function pickFolder() {
     try {
       const dir = await openDialog({ directory: true, multiple: false });
       if (dir) setOutDir(dir as string);
     } catch (e) {
-      console.error(e);
-      setError(String(e));
+      handleError(e);
     }
   }
 
@@ -62,8 +81,7 @@ export default function SFZSongForm() {
       localStorage.setItem("sfzInstrument", normalized);
       setStatus(`Loaded instrument: ${normalized}`);
     } catch (e) {
-      console.error(e);
-      setError(String(e));
+      handleError(e);
     } finally {
       setLoading(false);
     }
@@ -79,8 +97,7 @@ export default function SFZSongForm() {
         await loadInstrument(file as string);
       }
     } catch (e) {
-      console.error(e);
-      setError(String(e));
+      handleError(e);
     }
   }
 
@@ -91,8 +108,7 @@ export default function SFZSongForm() {
       );
       await loadInstrument(path);
     } catch (e) {
-      console.error(e);
-      setError(String(e));
+      handleError(e);
     }
   }
 

--- a/src/utils/sfzLoader.ts
+++ b/src/utils/sfzLoader.ts
@@ -59,9 +59,14 @@ export async function loadSfz(
   path: string,
   onProgress?: (loaded: number, total: number) => void,
 ): Promise<SfzInstrument> {
-  const res = await fetch(path);
+  let res: Response;
+  try {
+    res = await fetch(path);
+  } catch {
+    throw new Error(`Unable to load SFZ: ${path} (file not found)`);
+  }
   if (!res.ok) {
-    throw new Error(`Unable to load SFZ: ${path}`);
+    throw new Error(`Unable to load SFZ: ${path} (HTTP ${res.status})`);
   }
   const text = await res.text();
   const basePath = path.includes('/')


### PR DESCRIPTION
## Summary
- include HTTP status or 'file not found' hints when `loadSfz` fetches fail
- translate loader errors into user-friendly messages in `SFZSongForm`
- test friendly error mapping in `SFZSongForm`

## Testing
- `npx vitest run src/components/SFZSongForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b095afc78883258f90379e7eabf851