### PR TITLE
feat: make Comfy API URL configurable

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+STOCKS_PROVIDER=twelvedata
+TWELVEDATA_API_KEY=your_key_here
+# Base URL for the ComfyUI API (defaults to http://127.0.0.1:8188)
+VITE_COMFY_API_URL=http://127.0.0.1:8188

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@
 # Free tier allows up to 800 requests per day and 8 requests per minute.
 STOCKS_PROVIDER=twelvedata
 TWELVEDATA_API_KEY=your_key_here
+# Base URL for the ComfyUI API (defaults to http://127.0.0.1:8188)
+VITE_COMFY_API_URL=http://127.0.0.1:8188

--- a/src/pages/Comfy.tsx
+++ b/src/pages/Comfy.tsx
@@ -14,20 +14,30 @@ export default function Comfy() {
     ]);
   }
 
+  const COMFY_API_URL =
+    import.meta.env.VITE_COMFY_API_URL || "http://127.0.0.1:8188";
+
   async function runWorkflow(workflow: unknown) {
     try {
       appendLog("Submitting workflow");
       setStatus("running");
-      await fetch("http://127.0.0.1:8188/prompt", {
+      const res = await fetch(`${COMFY_API_URL}/prompt`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ prompt: workflow }),
       });
+
+      if (!res.ok) {
+        throw new Error(`Request failed: ${res.status} ${res.statusText}`);
+      }
+
       appendLog("Workflow submitted");
       setStatus("submitted");
     } catch (err) {
       console.error(err);
-      appendLog(`Error: ${(err as Error).message}`);
+      appendLog(
+        `Error contacting Comfy API at ${COMFY_API_URL}: ${(err as Error).message}`,
+      );
       setStatus("error");
     }
   }


### PR DESCRIPTION
## Summary
- allow Comfy page to use `VITE_COMFY_API_URL` environment variable with default localhost
- document `VITE_COMFY_API_URL` in `.env` and `.env.example`

## Testing
- `npx vitest run` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b096ceebc88325b54ca23f973df016