### PR TITLE
Verify SFZ sample URLs before loading

### DIFF
--- a/src/utils/sfzLoader.test.ts
+++ b/src/utils/sfzLoader.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('tone', () => ({
   Frequency: (midi: number) => ({ toNote: () => `midi-${midi}` }),
@@ -8,10 +8,18 @@ vi.mock('tone', () => ({
   loaded: () => Promise.resolve(),
 }));
 
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
 import { parseSfz } from './sfzLoader';
 
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({ ok: true });
+});
+
 describe('parseSfz', () => {
-  it('parses regions and opcodes', () => {
+  it('parses regions and opcodes', async () => {
     const sfz = `
 <region>
 sample=kick.wav
@@ -19,7 +27,7 @@ lokey=36
 hikey=36
 pitch_keycenter=36
 `;
-    const regions = parseSfz(sfz);
+    const regions = await parseSfz(sfz);
     expect(regions).toHaveLength(1);
     expect(regions[0].sample).toBe('kick.wav');
     expect(regions[0].lokey).toBe(36);
@@ -27,24 +35,32 @@ pitch_keycenter=36
     expect(regions[0].pitch_keycenter).toBe(36);
   });
 
-  it('resolves sample paths relative to basePath', () => {
+  it('resolves sample paths relative to basePath', async () => {
     const sfz = `\n<region>\nsample=snare.wav`;
-    const regions = parseSfz(sfz, '/audio/');
+    const regions = await parseSfz(sfz, '/audio/');
     expect(regions).toHaveLength(1);
     expect(regions[0].sample).toBe('/audio/snare.wav');
   });
 
-  it('ignores unsupported sections and unknown opcodes', () => {
+  it('ignores unsupported sections and unknown opcodes', async () => {
     const sfz = `\n<group>\nfoo=bar\n<region>\nsample=hat.wav\nunknown=42`;
-    const regions = parseSfz(sfz);
+    const regions = await parseSfz(sfz);
     expect(regions).toHaveLength(1);
     expect(regions[0].sample).toBe('hat.wav');
     expect((regions[0] as any).unknown).toBe(42);
   });
 
-  it('preserves order of multiple regions', () => {
+  it('preserves order of multiple regions', async () => {
     const sfz = `\n<region>\nsample=one.wav\n<region>\nsample=two.wav`;
-    const regions = parseSfz(sfz);
+    const regions = await parseSfz(sfz);
     expect(regions.map((r) => r.sample)).toEqual(['one.wav', 'two.wav']);
+  });
+
+  it('throws if a sample is missing', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false });
+    const sfz = `\n<region>\nsample=missing.wav`;
+    await expect(parseSfz(sfz)).rejects.toThrow(
+      'Missing samples: missing.wav',
+    );
   });
 });

--- a/src/utils/sfzLoader.ts
+++ b/src/utils/sfzLoader.ts
@@ -14,7 +14,10 @@ export interface SfzInstrument {
   sampler: Tone.Sampler;
 }
 
-export function parseSfz(text: string, basePath = ''): SfzRegion[] {
+export async function parseSfz(
+  text: string,
+  basePath = '',
+): Promise<SfzRegion[]> {
   const lines = text.split(/\r?\n/);
   const regions: SfzRegion[] = [];
   let current: SfzRegion | null = null;
@@ -52,7 +55,23 @@ export function parseSfz(text: string, basePath = ''): SfzRegion[] {
     }
   }
 
-  return regions.filter((r) => r.sample);
+  const filtered = regions.filter((r) => r.sample);
+  const uniqueSamples = Array.from(new Set(filtered.map((r) => r.sample)));
+  const missing: string[] = [];
+  await Promise.all(
+    uniqueSamples.map(async (url) => {
+      try {
+        const res = await fetch(url, { method: 'HEAD' });
+        if (!res.ok) missing.push(url);
+      } catch {
+        missing.push(url);
+      }
+    }),
+  );
+  if (missing.length) {
+    throw new Error(`Missing samples: ${missing.join(', ')}`);
+  }
+  return filtered;
 }
 
 export async function loadSfz(
@@ -67,7 +86,7 @@ export async function loadSfz(
   const basePath = path.includes('/')
     ? path.substring(0, path.lastIndexOf('/') + 1)
     : '';
-  const regions = parseSfz(text, basePath);
+  const regions = await parseSfz(text, basePath);
 
   const urls: Record<string, string> = {};
   for (const region of regions) {


### PR DESCRIPTION
## Summary
- validate sample URLs in `parseSfz` using `fetch` HEAD requests
- abort with descriptive error if any sample file is missing
- add tests covering URL verification and missing sample handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b095b230388325911e2c8d2360f429