### PR TITLE
Refactor SFZ song form with MUI components

### DIFF
--- a/src/components/SFZSongForm.test.tsx
+++ b/src/components/SFZSongForm.test.tsx
@@ -38,7 +38,7 @@ describe('SFZSongForm', () => {
 
   it('renders form with lofi filter off', async () => {
     render(<SFZSongForm />);
-    expect(screen.getByPlaceholderText('Title')).toBeInTheDocument();
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
     expect(screen.getByText('Choose Output Folder')).toBeInTheDocument();
     await screen.findByText('Change SFZ');
     const lofi = screen.getByLabelText('Lofi Filter');
@@ -49,7 +49,7 @@ describe('SFZSongForm', () => {
     (openDialog as any).mockResolvedValueOnce('/tmp/out');
 
     render(<SFZSongForm />);
-    fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Test' } });
     fireEvent.click(screen.getByText('Choose Output Folder'));
     await screen.findByText('Output: /tmp/out');
     await screen.findByText('Change SFZ');
@@ -70,7 +70,7 @@ describe('SFZSongForm', () => {
     (openDialog as any).mockResolvedValueOnce('/tmp/out');
 
     render(<SFZSongForm />);
-    fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Test' } });
     fireEvent.click(screen.getByText('Choose Output Folder'));
     await screen.findByText('Output: /tmp/out');
     await screen.findByText('Change SFZ');
@@ -93,7 +93,7 @@ describe('SFZSongForm', () => {
 
     (openDialog as any).mockResolvedValueOnce('/tmp/out');
     render(<SFZSongForm />);
-    fireEvent.change(screen.getByPlaceholderText('Title'), { target: { value: 'Test' } });
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Test' } });
     fireEvent.click(screen.getByText('Choose Output Folder'));
     await screen.findByText('Output: /tmp/out');
     fireEvent.click(screen.getByText('Generate'));

--- a/src/components/SFZSongForm.tsx
+++ b/src/components/SFZSongForm.tsx
@@ -2,7 +2,18 @@ import { useEffect, useMemo, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { resolveResource } from "@tauri-apps/api/path";
 import { convertFileSrc } from "@tauri-apps/api/core";
-import { Alert, Snackbar, LinearProgress } from "@mui/material";
+import {
+  Alert,
+  Snackbar,
+  LinearProgress,
+  Button,
+  TextField,
+  Stack,
+  FormControl,
+  FormControlLabel,
+  Checkbox,
+  Divider,
+} from "@mui/material";
 import { loadSfz } from "../utils/sfzLoader";
 import { useTasks } from "../store/tasks";
 
@@ -133,43 +144,71 @@ export default function SFZSongForm() {
   }
 
   return (
-    <div>
-      <input
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        placeholder="Title"
-      />
-      <button onClick={pickFolder}>
-        {outDir ? `Output: ${outDir}` : "Choose Output Folder"}
-      </button>
-      <button onClick={pickSfzInstrument} disabled={loading}>
-        {sfzInstrument ? "Change SFZ" : "Pick SFZ Instrument"}
-      </button>
-      <button onClick={loadAcousticGrand} disabled={loading}>
-        Load Acoustic Grand
-      </button>
-      {loading && (
-        <LinearProgress
-          variant="determinate"
-          value={progress * 100}
-          sx={{ my: 1 }}
+    <Stack spacing={3} divider={<Divider flexItem />}>
+      <Stack spacing={2}>
+        <FormControl fullWidth>
+          <TextField
+            label="Title"
+            placeholder="Enter song title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            fullWidth
+          />
+        </FormControl>
+        <FormControl>
+          <Button variant="outlined" onClick={pickFolder} fullWidth>
+            {outDir ? `Output: ${outDir}` : "Choose Output Folder"}
+          </Button>
+        </FormControl>
+      </Stack>
+
+      <Stack spacing={2}>
+        <Stack spacing={1} direction={{ xs: "column", sm: "row" }}>
+          <Button
+            variant="outlined"
+            onClick={pickSfzInstrument}
+            disabled={loading}
+            fullWidth
+          >
+            {sfzInstrument ? "Change SFZ" : "Pick SFZ Instrument"}
+          </Button>
+          <Button
+            variant="outlined"
+            onClick={loadAcousticGrand}
+            disabled={loading}
+            fullWidth
+          >
+            Load Acoustic Grand
+          </Button>
+        </Stack>
+        {loading && (
+          <LinearProgress
+            variant="determinate"
+            value={progress * 100}
+            sx={{ my: 1 }}
+          />
+        )}
+        {!loading && status && <div>{status}</div>}
+      </Stack>
+
+      <Stack spacing={2}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={lofiFilter}
+              onChange={(e) => setLofiFilter(e.target.checked)}
+            />
+          }
+          label="Lofi Filter"
         />
-      )}
-      {!loading && status && <div>{status}</div>}
-      <label>
-        <input
-          type="checkbox"
-          checked={lofiFilter}
-          onChange={(e) => setLofiFilter(e.target.checked)}
-        />
-        Lofi Filter
-      </label>
-      <button
-        onClick={generate}
-        disabled={!title || !outDir || !sfzInstrument || loading}
-      >
-        Generate
-      </button>
+        <Button
+          variant="contained"
+          onClick={generate}
+          disabled={!title || !outDir || !sfzInstrument || loading}
+        >
+          Generate
+        </Button>
+      </Stack>
       <Snackbar
         open={!!error}
         autoHideDuration={6000}
@@ -183,7 +222,7 @@ export default function SFZSongForm() {
           {error}
         </Alert>
       </Snackbar>
-    </div>
+    </Stack>
   );
 }
 


### PR DESCRIPTION
## Summary
- replace raw inputs/buttons in SFZSongForm with MUI TextField, Button and other controls
- arrange form sections using Stack/Divider and update tests

## Testing
- `npx vitest run src/components/SFZSongForm.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b095a7d2b883258166505a90bce1c0