### PR TITLE
feat(voices): add runtime log for voice tests

### DIFF
--- a/src/features/voice/bark.test.ts
+++ b/src/features/voice/bark.test.ts
@@ -38,4 +38,13 @@ describe('generateAudio', () => {
       'Bark TTS invocation failed: boom',
     );
   });
+
+  it('calls onStatus callback with progress updates', async () => {
+    (invoke as any).mockResolvedValue(new Uint8Array([1, 2, 3]));
+    const cb = vi.fn();
+    await generateAudio('hello', 'speaker', cb);
+    expect(cb).toHaveBeenNthCalledWith(1, 'Invoking Bark TTS...');
+    expect(cb).toHaveBeenNthCalledWith(2, 'Bark TTS invocation complete.');
+    expect(cb).toHaveBeenNthCalledWith(3, 'Decoding audio...');
+  });
 });

--- a/src/features/voice/bark.ts
+++ b/src/features/voice/bark.ts
@@ -8,7 +8,11 @@ import * as Tone from "tone";
  * @param speaker Voice identifier
  * @returns A ToneAudioBuffer containing the spoken audio
  */
-export async function generateAudio(text: string, speaker: string): Promise<Tone.ToneAudioBuffer> {
+export async function generateAudio(
+  text: string,
+  speaker: string,
+  onStatus?: (msg: string) => void,
+): Promise<Tone.ToneAudioBuffer> {
   if (!text.trim()) {
     throw new Error("Bark TTS requires non-empty text");
   }
@@ -18,7 +22,9 @@ export async function generateAudio(text: string, speaker: string): Promise<Tone
 
   let data: Uint8Array;
   try {
+    onStatus?.("Invoking Bark TTS...");
     data = await invoke<Uint8Array>("bark_tts", { text, speaker });
+    onStatus?.("Bark TTS invocation complete.");
   } catch (err) {
     throw new Error(`Bark TTS invocation failed: ${err instanceof Error ? err.message : String(err)}`);
   }
@@ -28,6 +34,7 @@ export async function generateAudio(text: string, speaker: string): Promise<Tone
 
   let audioBuffer: AudioBuffer;
   try {
+    onStatus?.("Decoding audio...");
     audioBuffer = await ctx.decodeAudioData(arrayBuffer);
   } catch (err) {
     throw new Error(`Bark TTS audio decode failed: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## Summary
- add step-by-step log to Voices test UI
- expose onStatus callback from bark.generateAudio for progress updates
- cover status callback with new unit tests

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b096bb45008325bfb00e87d94431ea