### PR TITLE
feat: add logging for voice tests

### DIFF
--- a/src/features/voice/bark.ts
+++ b/src/features/voice/bark.ts
@@ -6,9 +6,14 @@ import * as Tone from "tone";
  *
  * @param text Text to speak
  * @param speaker Voice identifier
+ * @param onStatus Optional callback for status updates
  * @returns A ToneAudioBuffer containing the spoken audio
  */
-export async function generateAudio(text: string, speaker: string): Promise<Tone.ToneAudioBuffer> {
+export async function generateAudio(
+  text: string,
+  speaker: string,
+  onStatus?: (msg: string) => void
+): Promise<Tone.ToneAudioBuffer> {
   if (!text.trim()) {
     throw new Error("Bark TTS requires non-empty text");
   }
@@ -18,9 +23,13 @@ export async function generateAudio(text: string, speaker: string): Promise<Tone
 
   let data: Uint8Array;
   try {
+    onStatus?.("Invoking Bark TTS backend…");
     data = await invoke<Uint8Array>("bark_tts", { text, speaker });
+    onStatus?.("Bark TTS invocation complete");
   } catch (err) {
-    throw new Error(`Bark TTS invocation failed: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(
+      `Bark TTS invocation failed: ${err instanceof Error ? err.message : String(err)}`
+    );
   }
 
   const ctx = Tone.getContext();
@@ -28,9 +37,13 @@ export async function generateAudio(text: string, speaker: string): Promise<Tone
 
   let audioBuffer: AudioBuffer;
   try {
+    onStatus?.("Decoding audio data…");
     audioBuffer = await ctx.decodeAudioData(arrayBuffer);
+    onStatus?.("Decoding complete");
   } catch (err) {
-    throw new Error(`Bark TTS audio decode failed: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(
+      `Bark TTS audio decode failed: ${err instanceof Error ? err.message : String(err)}`
+    );
   }
 
   return new Tone.ToneAudioBuffer(audioBuffer);


### PR DESCRIPTION
## Summary
- log voice test progress inside Voices page
- allow Bark voice generation to report status updates

## Testing
- `npm test -- --run` *(fails: Missing required field(s): outDir, title, bpm)*

------
https://chatgpt.com/codex/tasks/task_e_68b09a6ba8e88325bf9165843f5087b0