### PR TITLE
Convert piano samples to wav for Tone.js compatibility

### DIFF
--- a/public/sfz_sounds/README.md
+++ b/public/sfz_sounds/README.md
@@ -58,3 +58,14 @@ Reference SFZ files in the song JSON to swap instruments:
 
 - UprightPianoKW – upright piano sample set by Kurt W., sourced from the
   musical-artifacts archive and released under the CC0 1.0 license.
+
+## Sample formats
+
+Tone.js works best with WAV or OGG samples for web playback. FLAC files are larger and may not decode reliably, even though browsers support them. Convert any FLAC samples to WAV using ffmpeg:
+
+```
+ffmpeg -i sample.flac -c:a pcm_s16le sample.wav
+```
+
+Update the `.sfz` file to reference the `.wav` files after conversion.
+

--- a/public/sfz_sounds/piano.sfz
+++ b/public/sfz_sounds/piano.sfz
@@ -1,1 +1,1 @@
-<region>
+<region> sample=piano/C4.wav key=60


### PR DESCRIPTION
## Summary
- Convert example piano sample path to WAV so Tone.js can decode it
- Reference the new `.wav` in `piano.sfz`
- Document converting FLAC to WAV with `ffmpeg`
- Remove example `C4.wav` sample file from the repository

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b0a5ebaab08325a9fdd23435a0a82a