### PR TITLE
Start ComfyUI automatically on launch

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -66,6 +66,14 @@ fn main() {
             if let Err(e) = sync_sfz_assets() {
                 log::warn!("sfz asset sync failed: {e}");
             }
+            if let Some(window) = app.get_window("main") {
+                let win = window.clone();
+                tauri::async_runtime::spawn(async move {
+                    if let Err(e) = commands::comfy_start(win, "".into()).await {
+                        log::warn!("failed to start ComfyUI: {e}");
+                    }
+                });
+            }
             Ok(())
         })
         .plugin(tauri_plugin_dialog::init())


### PR DESCRIPTION
## Summary
- Start ComfyUI in the background when the app launches

## Testing
- `npm test -- --run` *(fails: process terminated before completion)*
- `cargo test` *(fails: missing system dependency `glib-2.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a68ddb788325bfe6e9af70570159