### PR TITLE
refactor: update window retrieval for tauri 2

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -66,7 +66,7 @@ fn main() {
             if let Err(e) = sync_sfz_assets() {
                 log::warn!("sfz asset sync failed: {e}");
             }
-            if let Some(window) = app.get_window("main") {
+            if let Some(window) = handle.get_webview_window("main") {
                 let win = window.clone();
                 tauri::async_runtime::spawn(async move {
                     if let Err(e) = commands::comfy_start(win, "".into()).await {


### PR DESCRIPTION
## Summary
- update main window retrieval in setup closure for Tauri 2 webview API

## Testing
- `cargo test` *(fails: The system library `javascriptcoregtk-4.1` required by crate `javascriptcore-rs-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bea57c3c8325adf215b6410253f1