### PR TITLE
Allow ComfyUI startup via app handle

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -67,9 +67,9 @@ fn main() {
                 log::warn!("sfz asset sync failed: {e}");
             }
             if let Some(window) = handle.get_webview_window("main") {
-                let win = window.clone();
+                let app = window.app_handle().clone();
                 tauri::async_runtime::spawn(async move {
-                    if let Err(e) = commands::comfy_start(win, "".into()).await {
+                    if let Err(e) = commands::comfy_start(app, "".into()).await {
                         log::warn!("failed to start ComfyUI: {e}");
                     }
                 });

--- a/src-tauri/tests/comfy_start_stop.rs
+++ b/src-tauri/tests/comfy_start_stop.rs
@@ -1,6 +1,7 @@
 use blossom_lib::commands::{comfy_start, comfy_stop, __has_comfy_child};
 use std::{env, fs};
 use which::which;
+use tauri::Manager;
 
 #[tokio::test]
 async fn start_and_stop_comfy() {
@@ -22,9 +23,12 @@ async fn start_and_stop_comfy() {
     env::set_var("BLOSSOM_PYTHON_PATH", which("python3").unwrap());
 
     assert!(!__has_comfy_child());
-    comfy_start(window, dir.path().to_string_lossy().to_string())
-        .await
-        .unwrap();
+    comfy_start(
+        window.app_handle().clone(),
+        dir.path().to_string_lossy().to_string(),
+    )
+    .await
+    .unwrap();
     assert!(__has_comfy_child());
     comfy_stop().await.unwrap();
     assert!(!__has_comfy_child());


### PR DESCRIPTION
## Summary
- implement `LogEmitter` for `AppHandle`
- start ComfyUI with an `AppHandle` instead of a window
- update setup and tests to pass the app handle

## Testing
- `cargo check`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_68b0c1c3746c832592c7fff63ab2c15d