### PR TITLE
Add front-end stores and JSON-backed spell/rule commands

### DIFF
--- a/src/features/dnd/RulePdfUpload.tsx
+++ b/src/features/dnd/RulePdfUpload.tsx
@@ -7,11 +7,6 @@ interface RuleRecord {
   description: string;
 }
 
-interface RuleIndexEntry {
-  id: string;
-  name: string;
-}
-
 const OFFICIAL_RULES = new Set([
   "Ability Checks",
   "Advantage and Disadvantage",
@@ -28,7 +23,7 @@ export default function RulePdfUpload() {
       description: r.description,
       tags: OFFICIAL_RULES.has(r.name) ? ["core"] : ["custom"],
     }));
-    const existing = await invoke<RuleIndexEntry[]>("list_rules");
+    const existing = await invoke<RuleData[]>("list_rules");
     for (const rule of parsed) {
       const dup = existing.find((e) => e.id === rule.id || e.name === rule.name);
       let overwrite = true;

--- a/src/features/dnd/SpellPdfUpload.tsx
+++ b/src/features/dnd/SpellPdfUpload.tsx
@@ -2,14 +2,9 @@ import { invoke } from "@tauri-apps/api/core";
 import PdfUpload from "./PdfUpload";
 import type { SpellData } from "./types";
 
-interface SpellIndexEntry {
-  id: string;
-  name: string;
-}
-
 export default function SpellPdfUpload() {
   async function handleParsed(spells: SpellData[]) {
-    const existing = await invoke<SpellIndexEntry[]>("list_spells");
+    const existing = await invoke<SpellData[]>("list_spells");
     for (const spell of spells) {
       const dup = existing.find((e) => e.id === spell.id || e.name === spell.name);
       let overwrite = true;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -7,6 +7,8 @@ import { useWarTableStore } from "./warTable";
 import { useTabletopStore } from "./tabletop";
 import { useVoices } from "./voices";
 import { useInventory } from "./inventory";
+import { useSpells } from "./spells";
+import { useRules } from "./rules";
 
 // Export individual stores for existing imports elsewhere
 export {
@@ -18,6 +20,8 @@ export {
   useTabletopStore,
   useVoices,
   useInventory,
+  useSpells,
+  useRules,
 };
 
 const slices = {
@@ -28,6 +32,8 @@ const slices = {
   warTable: useWarTableStore,
   tabletop: useTabletopStore,
   inventory: useInventory,
+  spells: useSpells,
+  rules: useRules,
 };
 
 type StoreState<T> = {

--- a/src/store/rules.ts
+++ b/src/store/rules.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { invoke } from '@tauri-apps/api/core';
+import type { RuleData } from '../features/dnd/types';
+
+interface RuleState {
+  rules: RuleData[];
+  loadRules: () => Promise<void>;
+  addRule: (rule: Omit<RuleData, 'id'> & { id?: string }) => Promise<void>;
+  removeRule: (id: string) => void;
+}
+
+export const useRules = create<RuleState>()(
+  persist(
+    (set) => ({
+      rules: [],
+      loadRules: async () => {
+        const rules = await invoke<RuleData[]>('list_rules');
+        set({ rules });
+      },
+      addRule: async (rule) => {
+        const withId: RuleData = { id: rule.id ?? crypto.randomUUID(), ...rule } as RuleData;
+        await invoke('save_rule', { rule: withId });
+        set((state) => {
+          const exists = state.rules.some((r) => r.id === withId.id);
+          const rules = exists
+            ? state.rules.map((r) => (r.id === withId.id ? withId : r))
+            : [...state.rules, withId];
+          return { rules };
+        });
+      },
+      removeRule: (id) =>
+        set((state) => ({ rules: state.rules.filter((r) => r.id !== id) })),
+    }),
+    { name: 'rule-store' }
+  )
+);
+
+export type { RuleData as Rule };

--- a/src/store/spells.ts
+++ b/src/store/spells.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { invoke } from '@tauri-apps/api/core';
+import type { SpellData } from '../features/dnd/types';
+
+interface SpellState {
+  spells: SpellData[];
+  loadSpells: () => Promise<void>;
+  addSpell: (spell: Omit<SpellData, 'id'> & { id?: string }) => Promise<void>;
+  removeSpell: (id: string) => void;
+}
+
+export const useSpells = create<SpellState>()(
+  persist(
+    (set) => ({
+      spells: [],
+      loadSpells: async () => {
+        const spells = await invoke<SpellData[]>('list_spells');
+        set({ spells });
+      },
+      addSpell: async (spell) => {
+        const withId: SpellData = { id: spell.id ?? crypto.randomUUID(), ...spell } as SpellData;
+        await invoke('save_spell', { spell: withId });
+        set((state) => {
+          const exists = state.spells.some((s) => s.id === withId.id);
+          const spells = exists
+            ? state.spells.map((s) => (s.id === withId.id ? withId : s))
+            : [...state.spells, withId];
+          return { spells };
+        });
+      },
+      removeSpell: (id) =>
+        set((state) => ({ spells: state.spells.filter((s) => s.id !== id) })),
+    }),
+    { name: 'spell-store' }
+  )
+);
+
+export type { SpellData as Spell };

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -274,3 +274,19 @@ export const useTasks = create<TasksState>((set, get) => ({
 }));
 
 export type { TasksState };
+
+export async function listSpells() {
+  return invoke<any[]>('list_spells');
+}
+
+export async function saveSpell(spell: unknown, overwrite?: boolean) {
+  return invoke<void>('save_spell', { spell, overwrite });
+}
+
+export async function listRules() {
+  return invoke<any[]>('list_rules');
+}
+
+export async function saveRule(rule: unknown, overwrite?: boolean) {
+  return invoke<void>('save_rule', { rule, overwrite });
+}


### PR DESCRIPTION
## Summary
- create persistent Zustand stores for spells and rules
- expose utility functions and PDF upload components using new spell/rule APIs
- save and read spell and rule data as JSON in the Tauri backend

## Testing
- `npm test`
- `cargo test` *(fails: system library `javascriptcoregtk-4.1` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cfcb9138832590f41015ec424d8a