### PR TITLE
feat(dnd): add rule book and preview

### DIFF
--- a/src/features/dnd/RuleBook.tsx
+++ b/src/features/dnd/RuleBook.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import {
+  Box,
+  Typography,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Grid,
+} from "@mui/material";
+import { useRules } from "../../store/rules";
+
+export default function RuleBook() {
+  const rules = useRules((s) => s.rules);
+  const loadRules = useRules((s) => s.loadRules);
+  const [filter, setFilter] = useState("all");
+
+  useEffect(() => {
+    loadRules();
+  }, [loadRules]);
+
+  const filtered = rules
+    .filter((r) => {
+      if (filter === "core") return r.tags.includes("core");
+      if (filter === "custom") return !r.tags.includes("core");
+      return true;
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <Box id="rulebook">
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Rule Book
+      </Typography>
+      <FormControl sx={{ mb: 2, minWidth: 160 }} size="small">
+        <InputLabel id="rule-filter-label">Filter</InputLabel>
+        <Select
+          labelId="rule-filter-label"
+          value={filter}
+          label="Filter"
+          onChange={(e) => setFilter(e.target.value)}
+        >
+          <MenuItem value="all">All</MenuItem>
+          <MenuItem value="core">Core</MenuItem>
+          <MenuItem value="custom">Custom</MenuItem>
+        </Select>
+      </FormControl>
+      <Grid container spacing={2}>
+        {filtered.map((rule) => (
+          <Grid item xs={12} key={rule.id}>
+            <Box sx={{ p: 2, border: 1, borderColor: "divider", borderRadius: 1 }}>
+              <Typography variant="subtitle1">{rule.name}</Typography>
+              <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                {rule.description}
+              </Typography>
+            </Box>
+          </Grid>
+        ))}
+        {filtered.length === 0 && (
+          <Grid item xs={12}>
+            <Typography>No rules found.</Typography>
+          </Grid>
+        )}
+      </Grid>
+    </Box>
+  );
+}

--- a/src/features/dnd/RuleForm.tsx
+++ b/src/features/dnd/RuleForm.tsx
@@ -14,6 +14,7 @@ import { zRule } from "./schemas";
 import type { RuleData } from "./types";
 import rulesIndex from "../../../dnd/rules/index.json";
 import RulePdfUpload from "./RulePdfUpload";
+import { useRules } from "../../store/rules";
 
 const ruleFiles = import.meta.glob("../../../dnd/rules/*.md", {
   query: "?raw",
@@ -35,6 +36,7 @@ export default function RuleForm() {
   const [tags, setTags] = useState("");
   const [result, setResult] = useState<RuleData | null>(null);
   const [originalRule, setOriginalRule] = useState<RuleData | null>(null);
+  const addRule = useRules((s) => s.addRule);
 
   const handleSelect = (e: any) => {
     const id = e.target.value;
@@ -55,7 +57,7 @@ export default function RuleForm() {
     }
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const data: RuleData = {
       id: crypto.randomUUID(),
@@ -65,6 +67,7 @@ export default function RuleForm() {
       ...(originalRule ? { sourceId: originalRule.id } : {}),
     };
     const parsed = zRule.parse(data);
+    await addRule(parsed);
     setResult(parsed);
   };
 
@@ -130,11 +133,18 @@ export default function RuleForm() {
         </Grid>
         {result && (
           <Grid item xs={12}>
-            <pre style={{ marginTop: "1rem" }}>
-              {originalRule &&
-                `Original:\n${JSON.stringify(originalRule, null, 2)}\n\n`}
-              {`Custom:\n${JSON.stringify(result, null, 2)}`}
-            </pre>
+            <Box data-testid="rule-preview" sx={{ mt: 2 }}>
+              {originalRule && (
+                <Typography variant="subtitle2" color="text.secondary">
+                  Based on: {originalRule.name}
+                </Typography>
+              )}
+              <Typography variant="h6">{result.name}</Typography>
+              <Typography sx={{ whiteSpace: "pre-wrap" }}>{result.description}</Typography>
+              <Button href="#rulebook" sx={{ mt: 1 }}>
+                View Rule Book
+              </Button>
+            </Box>
           </Grid>
         )}
       </Grid>

--- a/src/features/dnd/tests/RuleForm.test.tsx
+++ b/src/features/dnd/tests/RuleForm.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn().mockResolvedValue(undefined) }));
 import RuleForm from '../RuleForm';
 
 describe('RuleForm custom rules', () => {
-  it('copies existing rule and shows original and custom', async () => {
+  it('copies existing rule and previews custom', async () => {
     render(<RuleForm />);
     const user = userEvent.setup();
 
@@ -23,9 +24,9 @@ describe('RuleForm custom rules', () => {
     await user.type(descInput, 'desc');
 
     await user.click(screen.getByRole('button', { name: /submit/i }));
-    const output = await screen.findByText(/Custom:/);
-    expect(output).toHaveTextContent('Original');
-    expect(output).toHaveTextContent('Ability Checks');
-    expect(output).toHaveTextContent('Ability Checks Custom');
+    const preview = await screen.findByTestId('rule-preview');
+    expect(preview).toHaveTextContent('Based on');
+    expect(preview).toHaveTextContent('Ability Checks Custom');
+    expect(screen.getByText(/view rule book/i)).toBeInTheDocument();
   });
 });

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -12,6 +12,7 @@ import {
   MilitaryTech,
   LibraryBooks,
   Inventory,
+  Rule,
 } from "@mui/icons-material";
 import { useState, ChangeEvent } from "react";
 import { createDndTheme } from "../theme";
@@ -26,6 +27,7 @@ import DiceRoller from "../features/dnd/DiceRoller";
 import TabletopMap from "../features/dnd/TabletopMap";
 import WarTable from "../features/dnd/WarTable";
 import WorldInventory from "./WorldInventory";
+import RuleBook from "../features/dnd/RuleBook";
 import { useWorlds } from "../store/worlds";
 import NewWorldDialog from "../components/NewWorldDialog";
 
@@ -61,7 +63,8 @@ export default function DND() {
     { icon: <MenuBook />, label: "Lore", component: <LoreForm world={world} /> },
     { icon: <TravelExplore />, label: "Quest", component: <QuestForm /> },
     { icon: <SportsKabaddi />, label: "Encounter", component: <EncounterForm /> },
-    { icon: <Gavel />, label: "Rulebook", component: <RuleForm /> },
+    { icon: <Gavel />, label: "Rule Book", component: <RuleBook /> },
+    { icon: <Rule />, label: "Add Rule", component: <RuleForm /> },
     { icon: <AutoStories />, label: "Spellbook", component: <SpellForm /> },
     { icon: <Casino />, label: "Dice", component: <DiceRoller /> },
     { icon: <Map />, label: "Tabletop", component: <TabletopMap /> },


### PR DESCRIPTION
## Summary
- add RuleBook component for browsing rules with tag filters
- show preview and link to Rule Book after submitting custom rules
- expose Rule Book and Add Rule tabs in DND navigation

## Testing
- `npm test` *(fails: Unable to load SFZ: piano.sfz; Missing required field(s): outDir, title, bpm)*
- `npm test src/features/dnd/tests/RuleForm.test.tsx`
- `pytest src-tauri/python/tests` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `cargo test` *(fails: command not found: cargo)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dd65eb1c83259283cd8ff0108e76