### PR TITLE
feat(dnd): add spell book view

### DIFF
--- a/src/features/dnd/SpellBook.tsx
+++ b/src/features/dnd/SpellBook.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useMemo, useState } from "react";
+import { Box, Chip, List, ListItem, ListItemText, MenuItem, TextField, Typography } from "@mui/material";
+import { useSpells } from "../../store/spells";
+
+export default function SpellBook() {
+  const spells = useSpells((s) => s.spells);
+  const loadSpells = useSpells((s) => s.loadSpells);
+
+  useEffect(() => {
+    loadSpells();
+  }, [loadSpells]);
+
+  const [search, setSearch] = useState("");
+  const [tag, setTag] = useState("");
+
+  const tags = useMemo(
+    () => Array.from(new Set(spells.flatMap((s) => s.tags))).sort(),
+    [spells]
+  );
+
+  const filtered = useMemo(
+    () =>
+      spells.filter(
+        (s) =>
+          s.name.toLowerCase().includes(search.toLowerCase()) &&
+          (tag ? s.tags.includes(tag) : true)
+      ),
+    [spells, search, tag]
+  );
+
+  return (
+    <Box>
+      <Box sx={{ display: "flex", gap: 2, mb: 2 }}>
+        <TextField
+          label="Search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <TextField
+          select
+          label="Tag"
+          value={tag}
+          onChange={(e) => setTag(e.target.value)}
+          sx={{ minWidth: 120 }}
+        >
+          <MenuItem value="">All</MenuItem>
+          {tags.map((t) => (
+            <MenuItem key={t} value={t}>
+              {t}
+            </MenuItem>
+          ))}
+        </TextField>
+      </Box>
+      <List>
+        {filtered.length === 0 && (
+          <ListItem>
+            <ListItemText primary="No spells found" />
+          </ListItem>
+        )}
+        {filtered.map((spell) => (
+          <ListItem key={spell.id} alignItems="flex-start">
+            <ListItemText
+              primary={`${spell.name} (Level ${spell.level} ${spell.school})`}
+              secondary={
+                <>
+                  <Typography component="span" variant="body2">
+                    {spell.description}
+                  </Typography>
+                  <Box sx={{ mt: 1 }}>
+                    {spell.tags.map((t) => (
+                      <Chip key={t} label={t} size="small" sx={{ mr: 0.5 }} />
+                    ))}
+                  </Box>
+                </>
+              }
+            />
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+}
+

--- a/src/features/dnd/SpellForm.tsx
+++ b/src/features/dnd/SpellForm.tsx
@@ -4,6 +4,8 @@ import StyledTextField from "./StyledTextField";
 import SpellPdfUpload from "./SpellPdfUpload";
 import { zSpell } from "./schemas";
 import type { SpellData } from "./types";
+import SpellBook from "./SpellBook";
+import { useSpells } from "../../store/spells";
 
 export default function SpellForm() {
   const [name, setName] = useState("");
@@ -15,9 +17,9 @@ export default function SpellForm() {
   const [duration, setDuration] = useState("");
   const [description, setDescription] = useState("");
   const [tags, setTags] = useState("");
-  const [result, setResult] = useState<SpellData | null>(null);
+  const addSpell = useSpells((s) => s.addSpell);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const data: SpellData = {
       id: crypto.randomUUID(),
@@ -26,13 +28,16 @@ export default function SpellForm() {
       school,
       castingTime,
       range,
-      components: components.split(",").map((c) => c.trim()).filter(Boolean),
+      components: components
+        .split(",")
+        .map((c) => c.trim())
+        .filter(Boolean),
       duration,
       description,
       tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
     };
     const parsed = zSpell.parse(data);
-    setResult(parsed);
+    await addSpell(parsed);
   };
 
   return (
@@ -131,11 +136,9 @@ export default function SpellForm() {
             Submit
           </Button>
         </Grid>
-        {result && (
-          <Grid item xs={12}>
-            <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>
-          </Grid>
-        )}
+        <Grid item xs={12}>
+          <SpellBook />
+        </Grid>
       </Grid>
     </Box>
   );

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -22,6 +22,7 @@ import QuestForm from "../features/dnd/QuestForm";
 import EncounterForm from "../features/dnd/EncounterForm";
 import RuleForm from "../features/dnd/RuleForm";
 import SpellForm from "../features/dnd/SpellForm";
+import SpellBook from "../features/dnd/SpellBook";
 import DiceRoller from "../features/dnd/DiceRoller";
 import TabletopMap from "../features/dnd/TabletopMap";
 import WarTable from "../features/dnd/WarTable";
@@ -62,7 +63,8 @@ export default function DND() {
     { icon: <TravelExplore />, label: "Quest", component: <QuestForm /> },
     { icon: <SportsKabaddi />, label: "Encounter", component: <EncounterForm /> },
     { icon: <Gavel />, label: "Rulebook", component: <RuleForm /> },
-    { icon: <AutoStories />, label: "Spellbook", component: <SpellForm /> },
+    { icon: <AutoStories />, label: "Spell Form", component: <SpellForm /> },
+    { icon: <AutoStories />, label: "Spell Book", component: <SpellBook /> },
     { icon: <Casino />, label: "Dice", component: <DiceRoller /> },
     { icon: <Map />, label: "Tabletop", component: <TabletopMap /> },
     { icon: <MilitaryTech />, label: "War Table", component: <WarTable /> },


### PR DESCRIPTION
## Summary
- add SpellBook component with search and tag filtering
- show stored spells in SpellForm and store them on submit
- expose SpellBook via new tab in DND navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0dd21ee2083258395b709d8a357e4