### PR TITLE
feat(dnd): add spellbook with filtering

### DIFF
--- a/src/features/dnd/SpellBook.tsx
+++ b/src/features/dnd/SpellBook.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+import { Box, TextField, Chip, Grid, Typography } from "@mui/material";
+import { useSpells } from "../../store/spells";
+
+export default function SpellBook() {
+  const spells = useSpells((s) => s.spells);
+  const loadSpells = useSpells((s) => s.loadSpells);
+  const [search, setSearch] = useState("");
+  const [tag, setTag] = useState("");
+
+  useEffect(() => {
+    loadSpells();
+  }, [loadSpells]);
+
+  const allTags = Array.from(new Set(spells.flatMap((s) => s.tags))).sort();
+
+  const filtered = spells.filter((s) => {
+    const matchesSearch =
+      s.name.toLowerCase().includes(search.toLowerCase()) ||
+      s.description.toLowerCase().includes(search.toLowerCase());
+    const matchesTag = !tag || s.tags.includes(tag);
+    return matchesSearch && matchesTag;
+  });
+
+  return (
+    <Box>
+      <TextField
+        label="Search"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        fullWidth
+        margin="normal"
+      />
+      <Box sx={{ mb: 2 }}>
+        {allTags.map((t) => (
+          <Chip
+            key={t}
+            label={t}
+            onClick={() => setTag(t === tag ? "" : t)}
+            color={t === tag ? "primary" : "default"}
+            sx={{ mr: 1, mb: 1 }}
+          />
+        ))}
+      </Box>
+      <Grid container spacing={2}>
+        {filtered.map((spell) => (
+          <Grid item xs={12} md={6} key={spell.id}>
+            <Box sx={{ p: 2, border: 1, borderRadius: 1 }}>
+              <Typography variant="h6">{spell.name}</Typography>
+              <Typography variant="subtitle2" gutterBottom>
+                Level {spell.level} {spell.school}
+              </Typography>
+              <Typography variant="body2" sx={{ whiteSpace: "pre-wrap" }}>
+                {spell.description}
+              </Typography>
+              <Box sx={{ mt: 1 }}>
+                {spell.tags.map((tg) => (
+                  <Chip key={tg} size="small" label={tg} sx={{ mr: 1, mb: 1 }} />
+                ))}
+              </Box>
+            </Box>
+          </Grid>
+        ))}
+        {filtered.length === 0 && (
+          <Grid item xs={12}>
+            <Typography>No spells found.</Typography>
+          </Grid>
+        )}
+      </Grid>
+    </Box>
+  );
+}

--- a/src/features/dnd/SpellForm.tsx
+++ b/src/features/dnd/SpellForm.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
-import { Typography, Button, Grid, Box } from "@mui/material";
+import { useState, useEffect } from "react";
+import { Typography, Button, Grid, Box, List, ListItem, ListItemText } from "@mui/material";
 import StyledTextField from "./StyledTextField";
 import SpellPdfUpload from "./SpellPdfUpload";
 import { zSpell } from "./schemas";
 import type { SpellData } from "./types";
+import { useSpells } from "../../store/spells";
 
 export default function SpellForm() {
   const [name, setName] = useState("");
@@ -16,6 +17,13 @@ export default function SpellForm() {
   const [description, setDescription] = useState("");
   const [tags, setTags] = useState("");
   const [result, setResult] = useState<SpellData | null>(null);
+  const spells = useSpells((s) => s.spells);
+  const addSpell = useSpells((s) => s.addSpell);
+  const loadSpells = useSpells((s) => s.loadSpells);
+
+  useEffect(() => {
+    loadSpells();
+  }, [loadSpells]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -32,6 +40,7 @@ export default function SpellForm() {
       tags: tags.split(",").map((t) => t.trim()).filter(Boolean),
     };
     const parsed = zSpell.parse(data);
+    addSpell(parsed);
     setResult(parsed);
   };
 
@@ -134,6 +143,20 @@ export default function SpellForm() {
         {result && (
           <Grid item xs={12}>
             <pre style={{ marginTop: "1rem" }}>{JSON.stringify(result, null, 2)}</pre>
+          </Grid>
+        )}
+        {spells.length > 0 && (
+          <Grid item xs={12}>
+            <Typography variant="h6" sx={{ mt: 2 }}>
+              Stored Spells
+            </Typography>
+            <List>
+              {spells.map((s) => (
+                <ListItem key={s.id} disablePadding>
+                  <ListItemText primary={s.name} secondary={s.tags.join(", ")} />
+                </ListItem>
+              ))}
+            </List>
           </Grid>
         )}
       </Grid>

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -7,6 +7,7 @@ import {
   SportsKabaddi,
   Gavel,
   AutoStories,
+  LibraryAdd,
   Casino,
   Map,
   MilitaryTech,
@@ -23,6 +24,7 @@ import QuestForm from "../features/dnd/QuestForm";
 import EncounterForm from "../features/dnd/EncounterForm";
 import RuleForm from "../features/dnd/RuleForm";
 import SpellForm from "../features/dnd/SpellForm";
+import SpellBook from "../features/dnd/SpellBook";
 import DiceRoller from "../features/dnd/DiceRoller";
 import TabletopMap from "../features/dnd/TabletopMap";
 import WarTable from "../features/dnd/WarTable";
@@ -65,7 +67,8 @@ export default function DND() {
     { icon: <SportsKabaddi />, label: "Encounter", component: <EncounterForm /> },
     { icon: <Gavel />, label: "Rule Book", component: <RuleBook /> },
     { icon: <Rule />, label: "Add Rule", component: <RuleForm /> },
-    { icon: <AutoStories />, label: "Spellbook", component: <SpellForm /> },
+    { icon: <LibraryAdd />, label: "Add Spell", component: <SpellForm /> },
+    { icon: <AutoStories />, label: "Spellbook", component: <SpellBook /> },
     { icon: <Casino />, label: "Dice", component: <DiceRoller /> },
     { icon: <Map />, label: "Tabletop", component: <TabletopMap /> },
     { icon: <MilitaryTech />, label: "War Table", component: <WarTable /> },


### PR DESCRIPTION
## Summary
- store spells via form and display saved entries
- add searchable, tag-filterable SpellBook view
- expose SpellBook and Add Spell tabs in DND navigation

## Testing
- `npm test -- --run` *(fails: Unable to load SFZ: piano.sfz)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dfcb3408832592f06e9451a56dcd