### PR TITLE
fix: prevent NPC load loop in WorldInventory

### DIFF
--- a/src/pages/WorldInventory.tsx
+++ b/src/pages/WorldInventory.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Table,
   TableBody,
@@ -22,13 +22,17 @@ type OrderBy = 'name' | 'value';
 export default function WorldInventory() {
   const items = useInventory((s) => Object.values(s.items));
   const npcs = useNPCs((s) => s.npcs);
-  const loadNPCs = useCallback(useNPCs.getState().loadNPCs, []);
+  const loadNPCs = useNPCs((s) => s.loadNPCs);
   const world = useWorlds((s) => s.currentWorld);
   const { hash } = useLocation();
 
+  const lastWorld = useRef<string>();
   useEffect(() => {
-    if (world) loadNPCs(world);
-  }, [world]);
+    if (world && world !== lastWorld.current) {
+      loadNPCs(world);
+      lastWorld.current = world;
+    }
+  }, [world, loadNPCs]);
 
   const lastHash = useRef<string>();
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid recreating NPC loader in WorldInventory by selecting `loadNPCs` from store
- reload NPCs when world changes, guarding against duplicate calls

## Testing
- `npm test -- --run` *(fails: SFZSongForm tests fail, unhandled error)*
- `cargo test` *(fails: gobject-2.0/glib-2.0 not found)*
- `pytest src-tauri/python/tests` *(fails: missing pydub, fpdf, pdfplumber dependencies)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b0e73176f4832596e36ba7ae5396c0