### PR TITLE
fix(renderer): disable lofi filter by default

### DIFF
--- a/src-tauri/python/lofi/renderer.py
+++ b/src-tauri/python/lofi/renderer.py
@@ -1830,7 +1830,7 @@ def render_from_spec(spec: Dict[str, Any]) -> Tuple[AudioSegment, int]:
     logger.info({"stage": "post", "message": "cleaning audio"})
     post_rng = np.random.default_rng((seed ^ 0x5A5A5A5A) & 0xFFFFFFFF)
     wow_cfg = spec.get("wow_flutter")
-    if spec.get("lofi_filter", True):
+    if spec.get("lofi_filter", False):
         song = enhanced_post_process_chain(
             song,
             rng=post_rng,


### PR DESCRIPTION
## Summary
- avoid lofi post-processing unless explicitly requested

## Testing
- `npm test` *(fails: expected "spy" to be called with arguments)*
- `python -m pytest src-tauri/python/tests` *(fails: ModuleNotFoundError: No module named 'pdfplumber')*


------
https://chatgpt.com/codex/tasks/task_e_68b0e71166f88325a234bb2bebb05aea