### PR TITLE
chore: remove bark dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,11 @@ Install JavaScript and Python dependencies:
 ```bash
 npm install
 # create/activate a Python environment, then
-pip install -r requirements.txt  # base dependencies including Bark
+pip install -r requirements.txt
 ```
 
 `audioop-lts` is included in the requirements and will be installed automatically on
 Python 3.13+ to replace the removed `audioop` module.
-
-`bark` (>=0.1.6) provides text‑to‑speech support and depends on `torch` (>=2.8.0)
-and `soundfile` (>=0.13.1). These packages are included in `requirements.txt`, or
-install them separately with:
-
-```bash
-pip install bark>=0.1.6 torch>=2.8.0 soundfile>=0.13.1
-```
 
 ## Running the Tauri app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,4 @@ fpdf2>=2.7
 requests>=2.32.0
 vosk>=0.3.45
 audioop-lts ; python_version >= "3.13"  # audioop module for Python 3.13+
-bark>=0.1.6
-torch>=2.8.0
 soundfile>=0.13.1


### PR DESCRIPTION
## Summary
- drop bark and torch from Python requirements
- remove Bark installation instructions from README

## Testing
- `npm test` *(fails: SFZSongForm tests)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*
- `cargo test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0eca0a36c8325a95ba3882c053c71