### PR TITLE
refactor: drop voice provider and preset fields

### DIFF
--- a/dnd/npcs/mara-ravensong.md
+++ b/dnd/npcs/mara-ravensong.md
@@ -12,10 +12,6 @@ traits: ["soft-spoken", "curious", "won’t hurt innocents"]
 goals: ["protect hidden archive", "repay old debt"]
 secrets: ["keeps a cursed ledger", "knows a guard captain’s vice"]
 hooks: ["needs a crew to lift a crate at midnight", "offers intel for a price"]
-voice:
-  style: "melancholy"
-  provider: "acme"
-  preset: "bard"
 statblock:
   ac: 14
   hp: 22

--- a/dnd/schemas/npc.schema.json
+++ b/dnd/schemas/npc.schema.json
@@ -54,29 +54,6 @@
           "type": "string",
           "minLength": 1
         },
-        "voice": {
-          "type": "object",
-          "properties": {
-            "style": {
-              "type": "string",
-              "minLength": 1
-            },
-            "provider": {
-              "type": "string",
-              "minLength": 1
-            },
-            "preset": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
-          "required": [
-            "style",
-            "provider",
-            "preset"
-          ],
-          "additionalProperties": false
-        },
         "voiceId": {
           "type": "string",
           "minLength": 1

--- a/src/dnd/schemas/npc.ts
+++ b/src/dnd/schemas/npc.ts
@@ -1,12 +1,6 @@
 import { z } from "zod";
 import type { Ability } from "../characters";
 
-export const zVoice = z.object({
-  style: z.string().min(1),
-  provider: z.string().min(1),
-  preset: z.string().min(1),
-});
-
 const abilities: [
   Ability,
   Ability,
@@ -36,7 +30,6 @@ export const zNpc = z.object({
   hooks: z.array(z.string()).nonempty(),
   quirks: z.array(z.string()).optional(),
   appearance: z.string().min(1).optional(),
-  voice: zVoice.optional(),
   voiceId: z.string().min(1).optional(),
   portrait: z.string().min(1).optional(),
   icon: z.string().min(1).optional(),

--- a/src/features/settings/VoiceSettings.tsx
+++ b/src/features/settings/VoiceSettings.tsx
@@ -35,27 +35,17 @@ export default function VoiceSettings() {
   }, [load]);
 
   const [id, setId] = useState("");
-  const [provider, setProvider] = useState("bark");
-  const [preset, setPreset] = useState("");
   const [tagInput, setTagInput] = useState("");
 
   const handleAdd = () => {
     const trimmedId = id.trim();
-    const trimmedPreset = preset.trim();
-    if (!trimmedId || !trimmedPreset) return;
+    if (!trimmedId) return;
     const tags = tagInput
       .split(",")
       .map((t) => t.trim())
       .filter(Boolean);
-    addVoice({
-      id: trimmedId,
-      provider: provider.trim(),
-      preset: trimmedPreset,
-      tags,
-      favorite: false,
-    });
+    addVoice({ id: trimmedId, tags });
     setId("");
-    setPreset("");
     setTagInput("");
   };
 
@@ -112,18 +102,6 @@ export default function VoiceSettings() {
           size="small"
           value={id}
           onChange={(e) => setId(e.target.value)}
-        />
-        <TextField
-          label="Provider"
-          size="small"
-          value={provider}
-          onChange={(e) => setProvider(e.target.value)}
-        />
-        <TextField
-          label="Preset"
-          size="small"
-          value={preset}
-          onChange={(e) => setPreset(e.target.value)}
         />
         <TextField
           label="Tags"

--- a/src/pages/Voices.tsx
+++ b/src/pages/Voices.tsx
@@ -110,7 +110,7 @@ export default function Voices() {
               selected={selected?.id === v.id}
               onClick={() => setSelected(v)}
             >
-              <ListItemText primary={v.preset} secondary={v.tags.join(", ")} />
+              <ListItemText primary={v.id} secondary={v.tags.join(", ")} />
             </ListItemButton>
           </ListItem>
         ))}


### PR DESCRIPTION
## Summary
- streamline `Voice` model by keeping only id, tags, and favorite
- remove provider/preset UI in voice settings and list voice ids instead of presets
- simplify NPC schema to rely solely on `voiceId`

## Testing
- `npm run schemas:generate`
- `npm test` *(fails: SFZSongForm tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f0dee22c8325977fb2cdde064482