### PR TITLE
refactor: remove Bark test UI from voices list

### DIFF
--- a/src/pages/Voices.tsx
+++ b/src/pages/Voices.tsx
@@ -1,23 +1,18 @@
 import { useEffect, useState } from "react";
 import {
   Box,
-  Button,
   List,
   ListItem,
-  ListItemButton,
   ListItemText,
   IconButton,
   TextField,
   FormControlLabel,
   Checkbox,
-  Snackbar,
-  Alert,
-  LinearProgress,
 } from "@mui/material";
 import Star from "@mui/icons-material/Star";
 import StarBorder from "@mui/icons-material/StarBorder";
 import { useShallow } from "zustand/react/shallow";
-import { useVoices, Voice } from "../store/voices";
+import { useVoices } from "../store/voices";
 
 export default function Voices() {
   const { voices, load, toggleFavorite } = useVoices(
@@ -28,15 +23,8 @@ export default function Voices() {
     }))
   );
 
-  const [text, setText] = useState("");
-  const [selected, setSelected] = useState<Voice | null>(null);
   const [favoriteOnly, setFavoriteOnly] = useState(false);
   const [tagFilter, setTagFilter] = useState("");
-  const [status, setStatus] = useState<
-    "idle" | "testing" | "success" | "error"
-  >("idle");
-  const [error, setError] = useState<string | null>(null);
-  const [log, setLog] = useState<string[]>([]);
 
   useEffect(() => {
     load();
@@ -52,13 +40,6 @@ export default function Voices() {
     return true;
   });
 
-  const handleTest = () => {
-    if (!selected) return;
-    setLog(["Audio generation is unavailable"]);
-    setStatus("error");
-    setError("Audio generation is unavailable");
-  };
-
   return (
     <Box
       sx={{
@@ -70,14 +51,6 @@ export default function Voices() {
         gap: 2,
       }}
     >
-      {status === "testing" && <LinearProgress />}
-      <TextField
-        label="Text to speak"
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        fullWidth
-        sx={{ input: { color: "#fff" }, label: { color: "#fff" } }}
-      />
       <Box sx={{ display: "flex", gap: 2, alignItems: "center" }}>
         <TextField
           label="Filter by tag"
@@ -99,64 +72,16 @@ export default function Voices() {
         {filteredVoices.map((v) => (
           <ListItem
             key={v.id}
-            disablePadding
             secondaryAction={
               <IconButton edge="end" onClick={() => toggleFavorite(v.id)}>
                 {v.favorite ? <Star /> : <StarBorder />}
               </IconButton>
             }
           >
-            <ListItemButton
-              selected={selected?.id === v.id}
-              onClick={() => setSelected(v)}
-            >
-              <ListItemText primary={v.id} secondary={v.tags.join(", ")} />
-            </ListItemButton>
+            <ListItemText primary={v.name ?? v.id} secondary={v.tags.join(", ")} />
           </ListItem>
         ))}
       </List>
-      <Button
-        variant="contained"
-        onClick={handleTest}
-        disabled={!selected || !text.trim()}
-      >
-        Test
-      </Button>
-      <Box sx={{ maxHeight: 200, overflow: "auto" }}>
-        <List>
-          {log.map((m, i) => (
-            <ListItem key={i}>
-              <ListItemText primary={m} />
-            </ListItem>
-          ))}
-        </List>
-      </Box>
-      <Snackbar
-        open={status !== "idle"}
-        autoHideDuration={status === "testing" ? null : 3000}
-        onClose={() => {
-          setStatus("idle");
-          setError(null);
-        }}
-        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-      >
-        <Alert
-          severity={
-            status === "testing"
-              ? "info"
-              : status === "success"
-                ? "success"
-                : "error"
-          }
-          sx={{ width: "100%" }}
-        >
-          {status === "testing"
-            ? "Testing voice..."
-            : status === "success"
-              ? "Voice playback started."
-              : error}
-        </Alert>
-      </Snackbar>
     </Box>
   );
 }

--- a/src/store/voices.ts
+++ b/src/store/voices.ts
@@ -3,6 +3,7 @@ import { saveState, loadState } from "../utils/persist";
 
 export interface Voice {
   id: string;
+  name?: string;
   tags: string[];
   favorite: boolean;
 }
@@ -23,8 +24,8 @@ const STORAGE_KEY = "voices";
 export const useVoices = create<VoiceState>((set, get) => ({
   voices: [],
   filter: () => true,
-  addVoice: async ({ id, tags }) => {
-    const withFavorite: Voice = { id, tags, favorite: false };
+  addVoice: async ({ id, name, tags }) => {
+    const withFavorite: Voice = { id, name, tags, favorite: false };
     const existing = get().voices.filter((v) => v.id !== id);
     const voices = [...existing, withFavorite];
     set({ voices });
@@ -52,8 +53,9 @@ export const useVoices = create<VoiceState>((set, get) => ({
     const voices = await loadState<Voice[]>(STORAGE_KEY);
     if (voices && voices.length) {
       set({
-        voices: voices.map(({ id, tags = [], favorite = false }) => ({
+        voices: voices.map(({ id, name, tags = [], favorite = false }) => ({
           id,
+          name,
           tags,
           favorite,
         })),


### PR DESCRIPTION
## Summary
- show voice name or id in list instead of preset
- remove Bark "Test" button and associated status/log UI
- support optional `name` field in voice store

## Testing
- `npm test -- --run` *(fails: Missing SFZ assets)*
- `cargo test` *(fails: glib-2.0 library missing)*
- `pytest src-tauri/python/tests` *(fails: ModuleNotFoundError: pdfplumber)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f3147e1c8325b4df676fe6431c10