### PR TITLE
refactor: simplify voice settings interface

### DIFF
--- a/src/features/settings/VoiceSettings.tsx
+++ b/src/features/settings/VoiceSettings.tsx
@@ -35,27 +35,20 @@ export default function VoiceSettings() {
   }, [load]);
 
   const [id, setId] = useState("");
-  const [provider, setProvider] = useState("bark");
-  const [preset, setPreset] = useState("");
   const [tagInput, setTagInput] = useState("");
 
   const handleAdd = () => {
     const trimmedId = id.trim();
-    const trimmedPreset = preset.trim();
-    if (!trimmedId || !trimmedPreset) return;
+    if (!trimmedId) return;
     const tags = tagInput
       .split(",")
       .map((t) => t.trim())
       .filter(Boolean);
     addVoice({
       id: trimmedId,
-      provider: provider.trim(),
-      preset: trimmedPreset,
       tags,
-      favorite: false,
     });
     setId("");
-    setPreset("");
     setTagInput("");
   };
 
@@ -69,7 +62,7 @@ export default function VoiceSettings() {
 
   return (
     <Box id="voice-settings">
-      <Typography variant="subtitle1">Bark Voices</Typography>
+      <Typography variant="subtitle1">Voices</Typography>
       <FormControlLabel
         control={
           <Checkbox
@@ -112,18 +105,6 @@ export default function VoiceSettings() {
           size="small"
           value={id}
           onChange={(e) => setId(e.target.value)}
-        />
-        <TextField
-          label="Provider"
-          size="small"
-          value={provider}
-          onChange={(e) => setProvider(e.target.value)}
-        />
-        <TextField
-          label="Preset"
-          size="small"
-          value={preset}
-          onChange={(e) => setPreset(e.target.value)}
         />
         <TextField
           label="Tags"

--- a/src/pages/Voices.tsx
+++ b/src/pages/Voices.tsx
@@ -110,7 +110,7 @@ export default function Voices() {
               selected={selected?.id === v.id}
               onClick={() => setSelected(v)}
             >
-              <ListItemText primary={v.preset} secondary={v.tags.join(", ")} />
+              <ListItemText primary={v.id} secondary={v.tags.join(", ")} />
             </ListItemButton>
           </ListItem>
         ))}

--- a/src/store/voices.ts
+++ b/src/store/voices.ts
@@ -3,8 +3,6 @@ import { saveState, loadState } from "../utils/persist";
 
 export interface Voice {
   id: string;
-  provider: string;
-  preset: string;
   tags: string[];
   favorite: boolean;
 }
@@ -12,7 +10,7 @@ export interface Voice {
 interface VoiceState {
   voices: Voice[];
   filter: (v: Voice) => boolean;
-  addVoice: (voice: Voice) => Promise<void>;
+  addVoice: (voice: Omit<Voice, "favorite">) => Promise<void>;
   removeVoice: (id: string) => Promise<void>;
   setTags: (id: string, tags: string[]) => Promise<void>;
   toggleFavorite: (id: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- streamline voice settings to use a generic heading and minimal fields
- drop provider/preset inputs and add voices by id and tags
- show voice id in voice list

## Testing
- `npm test` *(fails: Unable to load SFZ and other test errors)*
- `cargo test` *(fails: system library `glib-2.0` not found)*
- `pytest src-tauri/python/tests` *(fails: missing modules pydub, fpdf, pdfplumber)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f23481308325821466c82ade3a12