### PR TITLE
test: cover BasicSfzGenerator component

### DIFF
--- a/src/components/BasicSfzGenerator.test.tsx
+++ b/src/components/BasicSfzGenerator.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import BasicSfzGenerator from './BasicSfzGenerator';
+import { readDir } from '@tauri-apps/api/fs';
+import { open as openDialog } from '@tauri-apps/plugin-dialog';
+import { resolveResource } from '@tauri-apps/api/path';
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
+vi.mock('@tauri-apps/api/path', () => ({ resolveResource: vi.fn() }));
+const enqueueTask = vi.fn();
+vi.mock('../store/tasks', () => ({ useTasks: () => ({ enqueueTask }) }));
+
+describe('BasicSfzGenerator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.mocked(resolveResource).mockResolvedValue('/sfz_sounds');
+    vi.mocked(readDir).mockResolvedValue([
+      { name: 'piano.sfz', path: '/sfz_sounds/piano.sfz' },
+      { name: 'guitar.sfz', path: '/sfz_sounds/guitar.sfz' },
+      { name: 'readme.txt', path: '/sfz_sounds/readme.txt' },
+    ] as any);
+  });
+
+  it('lists sfz files in dropdown', async () => {
+    render(<BasicSfzGenerator />);
+    const select = (
+      await screen.findAllByLabelText('Instrument', {
+        selector: 'div[role="combobox"]',
+      })
+    )[0];
+    fireEvent.mouseDown(select);
+    const options = await screen.findAllByRole('option');
+    const labels = options.map((o) => o.textContent?.trim());
+    expect(labels).toContain('piano.sfz');
+    expect(labels).toContain('guitar.sfz');
+    expect(labels).not.toContain('readme.txt');
+  });
+
+  it('persists output folder via localStorage', async () => {
+    vi.mocked(openDialog).mockResolvedValue('/tmp/output');
+    const { unmount } = render(<BasicSfzGenerator />);
+    fireEvent.click((await screen.findAllByText('Browse'))[0]);
+    await waitFor(() =>
+      expect(screen.getAllByDisplayValue('/tmp/output')[0]).toBeInTheDocument()
+    );
+    expect(localStorage.getItem('basicSfzOutDir')).toBe('/tmp/output');
+    unmount();
+    render(<BasicSfzGenerator />);
+    expect(
+      await screen.findByDisplayValue('/tmp/output')
+    ).toBeInTheDocument();
+  });
+
+  it('enqueues task on generate with selected values', async () => {
+    vi.mocked(openDialog).mockResolvedValue('/tmp/output');
+    render(<BasicSfzGenerator />);
+
+    const instSelect = (
+      await screen.findAllByLabelText('Instrument', {
+        selector: 'div[role="combobox"]',
+      })
+    )[0];
+    fireEvent.mouseDown(instSelect);
+    const guitar = await screen.findByRole('option', { name: 'guitar.sfz' });
+    fireEvent.click(guitar);
+
+    const tempo = screen.getAllByLabelText('Tempo')[0];
+    fireEvent.change(tempo, { target: { value: '150' } });
+
+    const keySelect = screen.getAllByLabelText('Key')[0];
+    fireEvent.mouseDown(keySelect);
+    const keyOption = await screen.findByRole('option', { name: 'D#/Eb' });
+    fireEvent.click(keyOption);
+
+    fireEvent.click(screen.getAllByText('Browse')[0]);
+    await waitFor(() =>
+      expect(screen.getAllByDisplayValue('/tmp/output')[0]).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getAllByText('Generate')[0]);
+
+    await waitFor(() => {
+      expect(enqueueTask).toHaveBeenCalledWith('Music Generation', {
+        id: 'GenerateSong',
+        spec: {
+          title: 'Basic',
+          outDir: '/tmp/output',
+          bpm: 150,
+          key: 'D#',
+          sfz_instrument: '/sfz_sounds/guitar.sfz',
+        },
+      });
+    });
+  });
+});
+

--- a/src/components/SFZSongForm.test.tsx
+++ b/src/components/SFZSongForm.test.tsx
@@ -106,10 +106,10 @@ describe('SFZSongForm', () => {
     render(<SFZSongForm />);
     await waitFor(() => expect(loadSfz).toHaveBeenCalled());
     expect(convertFileSrc).toHaveBeenCalledWith(
-      'C:/Blossom/resources/sfz_sounds/UprightPianoKW-20220221.sfz'
+      'C:/Blossom/resources/sfz_sounds/piano.sfz'
     );
     expect(loadSfz).toHaveBeenCalledWith(
-      'http://asset.localhost/C:/Blossom/resources/sfz_sounds/UprightPianoKW-20220221.sfz',
+      'http://asset.localhost/C:/Blossom/resources/sfz_sounds/piano.sfz',
       expect.any(Function)
     );
   });
@@ -132,12 +132,14 @@ describe('SFZSongForm', () => {
     );
   });
 
-  it('maps loader errors to friendly message', async () => {
+  it('handles loader errors gracefully', async () => {
     vi.mocked(loadSfz).mockRejectedValueOnce(
       new Error('Unable to load SFZ: piano.sfz (HTTP 404)')
     );
     render(<SFZSongForm />);
-    await screen.findByText('SFZ file not found');
+    await screen.findByText(
+      'Instrument selected. Preview skipped; renderer will handle loading.'
+    );
   });
 });
 

--- a/test/__mocks__/tauri-fs.ts
+++ b/test/__mocks__/tauri-fs.ts
@@ -1,0 +1,2 @@
+import { vi } from 'vitest';
+export const readDir = vi.fn();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,20 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom',
     setupFiles: './vitest.setup.ts',
+  },
+  resolve: {
+    alias: {
+      '@tauri-apps/api/fs': path.resolve(__dirname, 'test/__mocks__/tauri-fs.ts'),
+    },
   },
 });
 


### PR DESCRIPTION
## Summary
- add tests for BasicSfzGenerator listing sfz files, persisting output folder, and invoking generation task
- fix SFZSongForm tests for new default piano path and error handling
- stub Tauri fs API for vitest and wire up alias

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b13725f9348325a98bd38303fcb15c