### PR TITLE
feat: add basic sfz generation command

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -131,6 +131,7 @@ fn main() {
         )
         .invoke_handler(tauri::generate_handler![
             commands::lofi_generate_gpu,
+            commands::run_basic_sfz,
             commands::run_lofi_song,
             commands::generate_song,
             commands::generate_album,
@@ -201,4 +202,3 @@ fn main() {
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
-


### PR DESCRIPTION
## Summary
- add `run_basic_sfz` Rust command to spawn Python SFZ generator and stream logs
- expose new command to the Tauri frontend

## Testing
- `npm test` *(passes, ran in watch mode)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: gobject-2.0.pc not found)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b14e1762188325a581c5c93665f0d4