### PR TITLE
feat(task_queue): handle basic sfz generation

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -776,6 +776,8 @@ pub struct SongSpec {
     pub sfz_instrument: Option<String>,
 }
 
+pub type BasicSfzSpec = SongSpec;
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct AlbumRequest {


### PR DESCRIPTION
## Summary
- add `GenerateBasicSfz` task variant and route to `run_basic_sfz`
- expose `BasicSfzSpec` type alias

## Testing
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `npm test -- --run`
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1513df4a48325b51202ce34351716