### PR TITLE
refactor(tts): switch bark to higgs

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2341,9 +2341,9 @@ fn dj_mix_script_path<R: Runtime>(app: &AppHandle<R>) -> PathBuf {
         .join("dj_mix.py")
 }
 
-fn bark_tts_script_path<R: Runtime>(app: &AppHandle<R>) -> PathBuf {
+fn higgs_tts_script_path<R: Runtime>(app: &AppHandle<R>) -> PathBuf {
     if let Ok(cwd) = std::env::current_dir() {
-        let dev = cwd.join("src-tauri").join("python").join("bark_tts.py");
+        let dev = cwd.join("src-tauri").join("python").join("higgs_tts.py");
         if dev.exists() {
             return dev;
         }
@@ -2352,7 +2352,7 @@ fn bark_tts_script_path<R: Runtime>(app: &AppHandle<R>) -> PathBuf {
         .resource_dir()
         .expect("resource dir")
         .join("python")
-        .join("bark_tts.py")
+        .join("higgs_tts.py")
 }
 
 fn run_transcribe_script<R: Runtime>(app: &AppHandle<R>, audio: &Path) -> Result<String, String> {
@@ -2425,7 +2425,7 @@ pub async fn transcribe_audio<R: Runtime>(
 }
 
 #[tauri::command]
-pub async fn bark_tts<R: Runtime>(
+pub async fn higgs_tts<R: Runtime>(
     app: AppHandle<R>,
     text: String,
     speaker: String,
@@ -2434,7 +2434,7 @@ pub async fn bark_tts<R: Runtime>(
     if !py.exists() {
         return Err(format!("Python not found at {}", py.display()));
     }
-    let script = bark_tts_script_path(&app);
+    let script = higgs_tts_script_path(&app);
     if !script.exists() {
         return Err(format!("Script not found at {}", script.display()));
     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -140,7 +140,7 @@ fn main() {
             commands::generate_ambience,
             commands::sfz_convert_flac_to_wav,
             commands::set_sfz_convert_on_start,
-            commands::bark_tts,
+            commands::higgs_tts,
             // ComfyUI:
             commands::comfy_status,
             commands::comfy_start,

--- a/src-tauri/tests/higgs_tts_errors.rs
+++ b/src-tauri/tests/higgs_tts_errors.rs
@@ -1,12 +1,12 @@
 use std::{env, fs};
 
-use blossom_lib::commands::{bark_tts, save_paths};
+use blossom_lib::commands::{higgs_tts, save_paths};
 use tempfile::tempdir;
 use tauri::{test::mock_app, Manager};
 use which::which;
 
 #[tokio::test]
-async fn bark_tts_reports_missing_python_and_script() {
+async fn higgs_tts_reports_missing_python_and_script() {
     // isolate configuration
     let temp_home = tempdir().unwrap();
     env::set_var("HOME", temp_home.path());
@@ -15,7 +15,7 @@ async fn bark_tts_reports_missing_python_and_script() {
     let temp_repo = tempdir().unwrap();
     let script_dir = temp_repo.path().join("src-tauri").join("python");
     fs::create_dir_all(&script_dir).unwrap();
-    fs::write(script_dir.join("bark_tts.py"), "").unwrap();
+    fs::write(script_dir.join("higgs_tts.py"), "").unwrap();
     env::set_current_dir(temp_repo.path()).unwrap();
 
     // case: python missing
@@ -23,7 +23,7 @@ async fn bark_tts_reports_missing_python_and_script() {
     let handle = app.app_handle().clone();
     let missing = temp_home.path().join("no_python_here");
     env::set_var("BLOSSOM_PYTHON_PATH", missing.to_string_lossy().to_string());
-    let err = bark_tts(handle, "hi".into(), "spk".into()).await.unwrap_err();
+    let err = higgs_tts(handle, "hi".into(), "spk".into()).await.unwrap_err();
     assert!(err.contains("Python not found"));
 
     // case: script missing
@@ -35,6 +35,6 @@ async fn bark_tts_reports_missing_python_and_script() {
     env::set_current_dir(&temp_dir).unwrap();
     let app = mock_app();
     let handle = app.app_handle().clone();
-    let err = bark_tts(handle, "hi".into(), "spk".into()).await.unwrap_err();
+    let err = higgs_tts(handle, "hi".into(), "spk".into()).await.unwrap_err();
     assert!(err.contains("Script not found"));
 }

--- a/src/features/settings/VoiceSettings.tsx
+++ b/src/features/settings/VoiceSettings.tsx
@@ -59,7 +59,7 @@ export default function VoiceSettings() {
 
   return (
     <Box id="voice-settings">
-      <Typography variant="subtitle1">Bark Voices</Typography>
+      <Typography variant="subtitle1">Higgs Voices</Typography>
       <FormControlLabel
         control={
           <Checkbox


### PR DESCRIPTION
## Summary
- switch UI to "Higgs Voices"
- replace bark_tts command with higgs_tts
- update tests for new higgs_tts name

## Testing
- `npm test` *(fails: Vitest errors)*
- `cargo test` *(fails: missing gobject-2.0)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1560dba548325920e47212724e654