### PR TITLE
feat: support basic SFZ generation

### DIFF
--- a/src/components/BasicSfzGenerator.test.tsx
+++ b/src/components/BasicSfzGenerator.test.tsx
@@ -82,13 +82,13 @@ describe('BasicSfzGenerator', () => {
 
     await waitFor(() => {
       expect(enqueueTask).toHaveBeenCalledWith('Music Generation', {
-        id: 'GenerateSong',
+        id: 'GenerateBasicSfz',
         spec: {
           title: 'Basic',
           outDir: '/tmp/output',
           bpm: 150,
           key: 'D#',
-          sfz_instrument: '/sfz_sounds/guitar.sfz',
+          sfzInstrument: '/sfz_sounds/guitar.sfz',
         },
       });
     });

--- a/src/components/BasicSfzGenerator.tsx
+++ b/src/components/BasicSfzGenerator.tsx
@@ -77,13 +77,13 @@ export default function BasicSfzGenerator() {
   function generate() {
     if (!instrument || !outDir) return;
     tasks.enqueueTask("Music Generation", {
-      id: "GenerateSong",
+      id: "GenerateBasicSfz",
       spec: {
         title: "Basic",
         outDir,
         bpm: tempo,
         key,
-        sfz_instrument: instrument,
+        sfzInstrument: instrument,
       },
     });
   }

--- a/src/store/tasks.test.ts
+++ b/src/store/tasks.test.ts
@@ -83,4 +83,12 @@ describe('enqueueTask validation', () => {
       useTasks.getState().enqueueTask('GenerateSong', { spec: {} as any }),
     ).rejects.toThrow(/Missing required field\(s\)/);
   });
+
+  it('throws when required fields are missing for GenerateBasicSfz', async () => {
+    await expect(
+      useTasks
+        .getState()
+        .enqueueTask('GenerateBasicSfz', { spec: {} as any }),
+    ).rejects.toThrow(/Missing required field\(s\)/);
+  });
 });

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -51,6 +51,7 @@ export type TaskCommand =
   | { id: 'ParseRulePdf'; py?: string; script?: string; path: string }
   | { id: 'ParseLorePdf'; py?: string; script?: string; path: string; world: string }
   | { id: 'GenerateSong'; spec: SongSpec }
+  | { id: 'GenerateBasicSfz'; spec: SongSpec }
   | { id: 'GenerateAlbum'; meta: any }
   | { id: 'GenerateShort'; spec: any };
 
@@ -63,6 +64,7 @@ const TASK_IDS: TaskCommand['id'][] = [
   'ParseRulePdf',
   'ParseLorePdf',
   'GenerateSong',
+  'GenerateBasicSfz',
   'GenerateAlbum',
   'GenerateShort',
 ];
@@ -148,18 +150,15 @@ export const useTasks = create<TasksState>((set, get) => ({
       } else {
         throw new Error(`Task command for ${label} is missing id: ${JSON.stringify(command)}`);
       }
-      if (cmd.id === 'GenerateSong') {
-        const spec = (cmd as Extract<TaskCommand, { id: 'GenerateSong' }>).spec;
-        const required: (keyof SongSpec)[] = [
-          'outDir',
-          'title',
-          'bpm',
-          // 'key',
-          // 'mood',
-          // 'instruments',
-          // 'ambience',
-          // 'seed',
-        ];
+      if (cmd.id === 'GenerateSong' || cmd.id === 'GenerateBasicSfz') {
+        const spec = (cmd as Extract<
+          TaskCommand,
+          { id: 'GenerateSong' | 'GenerateBasicSfz' }
+        >).spec;
+        const required: (keyof SongSpec)[] = ['outDir', 'title', 'bpm'];
+        if (cmd.id === 'GenerateBasicSfz') {
+          required.push('sfzInstrument');
+        }
         const missing = required.filter((field) => {
           const value = spec[field];
           return (


### PR DESCRIPTION
## Summary
- add GenerateBasicSfz to task system with required field validation
- wire BasicSfzGenerator to use new command
- show task completion/failure messages in TaskList

## Testing
- `npx vitest run src/store/tasks.test.ts src/components/BasicSfzGenerator.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68b153c052cc8325b265d5dd92acfc3c