### PR TITLE
feat(sfz): persist output dir across sessions

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -322,6 +322,7 @@ pub struct AppConfig {
     pub comfy_path: Option<String>,
     pub alphavantage_api_key: Option<String>,
     pub sfz_convert_on_start: Option<bool>,
+    pub sfz_out_dir: Option<String>,
 }
 
 fn config_path() -> PathBuf {
@@ -370,6 +371,7 @@ pub async fn load_paths() -> Result<AppConfig, String> {
 pub async fn save_paths(
     python_path: Option<String>,
     comfy_path: Option<String>,
+    sfz_out_dir: Option<String>,
 ) -> Result<(), String> {
     let mut cfg = load_config();
     if python_path.is_some() {
@@ -377,6 +379,9 @@ pub async fn save_paths(
     }
     if comfy_path.is_some() {
         cfg.comfy_path = comfy_path;
+    }
+    if sfz_out_dir.is_some() {
+        cfg.sfz_out_dir = sfz_out_dir;
     }
     save_config(&cfg)
 }

--- a/src-tauri/tests/save_paths.rs
+++ b/src-tauri/tests/save_paths.rs
@@ -1,16 +1,18 @@
-use blossom_lib::commands::save_paths;
+use blossom_lib::commands::{load_paths, save_paths};
 use serde_json::Value;
 use std::{env, fs};
 
 #[tokio::test]
 async fn save_paths_writes_config() {
-    let _rt = <tauri::test::MockRuntime as tauri_runtime::Runtime<()>>::new(Default::default()).unwrap();
+    let _rt =
+        <tauri::test::MockRuntime as tauri_runtime::Runtime<()>>::new(Default::default()).unwrap();
     let dir = tempfile::tempdir().unwrap();
     env::set_var("HOME", dir.path());
 
     save_paths(
         Some("python".into()),
         Some("comfy".into()),
+        Some("out".into()),
     )
     .await
     .unwrap();
@@ -19,4 +21,8 @@ async fn save_paths_writes_config() {
     let data: Value = serde_json::from_str(&fs::read_to_string(cfg_path).unwrap()).unwrap();
     assert_eq!(data["python_path"], "python");
     assert_eq!(data["comfy_path"], "comfy");
+    assert_eq!(data["sfz_out_dir"], "out");
+
+    let cfg = load_paths().await.unwrap();
+    assert_eq!(cfg.sfz_out_dir.as_deref(), Some("out"));
 }


### PR DESCRIPTION
## Summary
- store `sfz_out_dir` in Tauri app config
- prefill and persist SFZ output folder in SFZSongForm
- test config and UI folder restoration

## Testing
- `npm test -- --run` *(fails: interrupted after 35/49 files)*
- `cargo test` *(fails: glib-2.0 library missing)*
- `pytest python/tests` *(fails: FFmpeg not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b159159e188325bea19558080d2405