### PR TITLE
docs: document SFZ generator spec

### DIFF
--- a/src-tauri/python/basic_sfz_generator.py
+++ b/src-tauri/python/basic_sfz_generator.py
@@ -1,4 +1,17 @@
-"""Generate audio from an SFZ instrument given a JSON spec."""
+"""Generate audio from an SFZ instrument given a JSON spec.
+
+The expected spec structure is:
+
+```
+{
+    "sfz_path": "instrument.sfz",  # path to the SFZ definition
+    "key": "C",                    # musical key used for default notes
+    "bpm": 120,                     # tempo for note durations
+    "midi_file": "phrase.mid",     # optional MIDI file with note data
+    "out": "render.wav"            # output WAV file path
+}
+```
+"""
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary
- document the JSON spec structure for the SFZ generator script

## Testing
- `pytest src-tauri/python/tests/test_basic_sfz_generator.py -q`
- `pytest src-tauri/python/tests -q` *(fails: assert np.float64(0.057356) == 0.1113)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b46398e0832590ea14a9536e12e5