### PR TITLE
feat(python): add Higgs TTS wrapper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,7 @@ vosk>=0.3.45
 audioop-lts ; python_version >= "3.13"  # audioop module for Python 3.13+
 soundfile>=0.13.1
 mido>=1.3.0
+torchaudio>=2.0.0
+higgs>=0.0.6
+librosa>=0.10.0
+loguru>=0.7.0

--- a/src-tauri/python/higgs_tts.py
+++ b/src-tauri/python/higgs_tts.py
@@ -1,0 +1,81 @@
+"""Minimal Higgs TTS wrapper.
+
+This script exposes a command line interface around the Higgs audio model.
+It accepts text input and an optional reference audio sample to control the
+speaker characteristics. Generated audio is written as a WAV file to stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from io import BytesIO
+from typing import Dict, Optional
+
+MODEL_PATH = os.environ.get("HIGGS_MODEL_PATH", "HIGGS_MODEL_PATH")
+AUDIO_TOKENIZER_PATH = os.environ.get("HIGGS_AUDIO_TOKENIZER_PATH", "HIGGS_AUDIO_TOKENIZER_PATH")
+
+# Example built-in voices. These point to example audio files that may be
+# distributed separately. Users can supply a path directly via --ref_audio.
+EXAMPLE_VOICES: Dict[str, str] = {
+    "belinda": os.path.join(os.path.dirname(__file__), "samples", "belinda.wav"),
+}
+
+
+def resolve_ref_audio(ref_audio: Optional[str]) -> Optional[str]:
+    """Return the resolved audio path for a reference voice.
+
+    Parameters
+    ----------
+    ref_audio:
+        Either a key from :data:`EXAMPLE_VOICES` or a file path.
+    """
+
+    if not ref_audio:
+        return None
+
+    path = EXAMPLE_VOICES.get(ref_audio, ref_audio)
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"reference audio not found: {path}")
+    return path
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate speech with Higgs TTS")
+    parser.add_argument("--text", required=True, help="Text to synthesize")
+    parser.add_argument(
+        "--ref_audio",
+        help="Voice name (e.g. 'belinda') or path to reference audio",
+    )
+    args = parser.parse_args(argv)
+
+    import torch
+    import torchaudio
+    from higgs.data_types import AudioContent, ChatMLSample, Message, TextContent
+    from higgs.serve.serve_engine import HiggsAudioServeEngine
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    engine = HiggsAudioServeEngine(MODEL_PATH, AUDIO_TOKENIZER_PATH, device=device)
+
+    ref_audio_path = resolve_ref_audio(args.ref_audio)
+    contents = []
+    if ref_audio_path is not None:
+        contents.append(AudioContent(audio_url=ref_audio_path))
+    contents.append(TextContent(text=args.text))
+    sample = ChatMLSample(messages=[Message(role="user", content=contents)])
+
+    response = engine.generate(sample, max_new_tokens=4096, force_audio_gen=True)
+    if response.audio is None or response.sampling_rate is None:
+        print("no audio generated", file=sys.stderr)
+        return 1
+
+    audio_tensor = torch.tensor(response.audio).unsqueeze(0)
+    buffer = BytesIO()
+    torchaudio.save(buffer, audio_tensor, response.sampling_rate, format="wav")
+    sys.stdout.buffer.write(buffer.getvalue())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src-tauri/python/tests/test_higgs_tts.py
+++ b/src-tauri/python/tests/test_higgs_tts.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import higgs_tts  # noqa: E402
+
+
+def test_resolve_ref_audio(monkeypatch, tmp_path):
+    ref = tmp_path / "voice.wav"
+    ref.write_bytes(b"00")
+    monkeypatch.setitem(higgs_tts.EXAMPLE_VOICES, "belinda", str(ref))
+    assert higgs_tts.resolve_ref_audio("belinda") == str(ref)
+    assert higgs_tts.resolve_ref_audio(str(ref)) == str(ref)


### PR DESCRIPTION
## Summary
- add `higgs_tts.py` CLI to synthesize speech with optional reference audio
- expose example voice map and reference audio resolution helper
- document required deps for Higgs TTS

## Testing
- `pytest src-tauri/python/tests/test_higgs_tts.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1b4be10648325b9c99f6139108d4a