### PR TITLE
feat(sfz): allow midi file input

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -777,6 +777,8 @@ pub struct SongSpec {
     pub limiter_drive: Option<f32>,
     #[serde(alias = "lofiFilter", skip_serializing_if = "Option::is_none")]
     pub lofi_filter: Option<bool>,
+    #[serde(alias = "midiFile", skip_serializing_if = "Option::is_none")]
+    pub midi_file: Option<String>,
     #[serde(alias = "sfzInstrument", skip_serializing_if = "Option::is_none")]
     pub sfz_instrument: Option<String>,
 }
@@ -843,6 +845,7 @@ mod tests {
             hq_chorus: None,
             limiter_drive: None,
             lofi_filter: None,
+            midi_file: None,
             sfz_instrument: None,
         };
         let v = serde_json::to_value(&spec).unwrap();
@@ -1023,11 +1026,14 @@ pub async fn run_basic_sfz<R: Runtime>(
     let out_path = out_dir.join(file_name);
 
     // Serialize spec to JSON for Python
-    let json_spec = json!({
+    let mut json_spec = json!({
         "sfz_path": sfz,
         "key": spec.key.clone().unwrap_or_else(|| "C".to_string()),
         "bpm": spec.bpm,
     });
+    if let Some(midi_file) = spec.midi_file.clone() {
+        json_spec["midi_file"] = json!(midi_file);
+    }
     let json_str = serde_json::to_string(&json_spec).map_err(|e| e.to_string())?;
 
     // Launch Python

--- a/src/components/SFZSongForm.test.tsx
+++ b/src/components/SFZSongForm.test.tsx
@@ -140,6 +140,28 @@ describe('SFZSongForm', () => {
     expect(args.spec.sfz_instrument).toBe('/tmp/piano.sfz');
   });
 
+  it('persists chosen MIDI file and sends in spec', async () => {
+    (openDialog as any)
+      .mockResolvedValueOnce('/tmp/out')
+      .mockResolvedValueOnce('/tmp/song.mid');
+
+    render(<SFZSongForm />);
+    fireEvent.change(screen.getByLabelText('Title'), {
+      target: { value: 'Test' },
+    });
+    fireEvent.click(screen.getByText('Choose Output Folder'));
+    await screen.findByText('Output: /tmp/out');
+    await screen.findByText('Change SFZ');
+    fireEvent.click(screen.getByText('Choose MIDI File'));
+    await screen.findByText('MIDI: /tmp/song.mid');
+
+    fireEvent.click(screen.getByText('Generate'));
+    await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
+    const [, args] = enqueueTask.mock.calls[0];
+    expect(args.spec.midi_file).toBe('/tmp/song.mid');
+    expect(localStorage.getItem('midiFile')).toBe('/tmp/song.mid');
+  });
+
   it('normalizes default piano path before loading', async () => {
     render(<SFZSongForm />);
     await waitFor(() => expect(loadSfz).toHaveBeenCalled());

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -33,6 +33,7 @@ export interface SongSpec {
   limiterDrive?: number;
   lofiFilter?: boolean;
   sfzInstrument?: string;
+  midiFile?: string;
 }
 
 export type TaskCommand =


### PR DESCRIPTION
## Summary
- allow SongSpec to carry an optional `midi_file` path and forward it to Python
- add MIDI file picker in `SFZSongForm` and include the value in task specs
- cover MIDI file selection with a unit test

## Testing
- `npm test -- --run`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b4f51c2083259cdc554bb5ca0e1a