### PR TITLE
feat: persist SFZ output directory across sessions

### DIFF
--- a/src-tauri/tests/higgs_tts_errors.rs
+++ b/src-tauri/tests/higgs_tts_errors.rs
@@ -28,7 +28,7 @@ async fn higgs_tts_reports_missing_python_and_script() {
 
     // case: script missing
     let py = which("python3").unwrap();
-    save_paths(Some(py.to_string_lossy().to_string()), None)
+    save_paths(Some(py.to_string_lossy().to_string()), None, None)
         .await
         .unwrap();
     let temp_dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary
- extend Tauri AppConfig and save_paths/load_paths to handle `sfz_out_dir`
- wire SFZSongForm to prefill and persist the output directory via Tauri config and localStorage
- adjust Higgs TTS test for new `save_paths` signature

## Testing
- `npm test -- --run`
- `cd src-tauri && cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b1bbc7e7c083259482b76763bb3c9b