### PR TITLE
feat: add reverb option to SFZ generator

### DIFF
--- a/src-tauri/python/tests/test_basic_sfz_generator.py
+++ b/src-tauri/python/tests/test_basic_sfz_generator.py
@@ -92,3 +92,25 @@ def test_render_spec_applies_gain(monkeypatch, tmp_path):
     data = recorded["data"]
     assert np.isclose(np.max(np.abs(data)), 0.35)
 
+
+def test_render_spec_reverb_alters_waveform(monkeypatch, tmp_path):
+    base = {
+        "sfz_path": "dummy.sfz",
+        "key": "C",
+        "bpm": 120,
+        "out": str(tmp_path / "dry.wav"),
+    }
+    dry_rec: dict[str, object] = {}
+    _patch_sampler_and_writer(monkeypatch, dry_rec)
+    basic_sfz_generator.render_spec(base)
+    dry = dry_rec["data"]
+
+    wet_rec: dict[str, object] = {}
+    _patch_sampler_and_writer(monkeypatch, wet_rec)
+    wet_spec = dict(base)
+    wet_spec.update({"out": str(tmp_path / "wet.wav"), "reverb": True})
+    basic_sfz_generator.render_spec(wet_spec)
+    wet = wet_rec["data"]
+
+    assert not np.allclose(dry, wet)
+

--- a/src/components/SFZSongForm.tsx
+++ b/src/components/SFZSongForm.tsx
@@ -54,6 +54,8 @@ interface SongSpec {
   sfz_instrument?: string;
   /** Enable a lofi/low‑pass coloration on the output. */
   lofi_filter: boolean;
+  /** Apply a simple reverb effect after rendering. */
+  reverb: boolean;
   /** Optional path to a MIDI file guiding the generation. */
   midi_file?: string;
   /** Overall output gain multiplier (0–1). */
@@ -74,6 +76,10 @@ export default function SFZSongForm() {
     const [status, setStatus] = useState<string | null>(null);
   const [lofiFilter, setLofiFilter] = useState(() => {
     const stored = localStorage.getItem("lofiFilter");
+    return stored === null ? false : stored === "true";
+  });
+  const [reverb, setReverb] = useState(() => {
+    const stored = localStorage.getItem("reverb");
     return stored === null ? false : stored === "true";
   });
   const [error, setError] = useState<string | null>(null);
@@ -201,6 +207,10 @@ export default function SFZSongForm() {
   }, [lofiFilter]);
 
   useEffect(() => {
+    localStorage.setItem("reverb", String(reverb));
+  }, [reverb]);
+
+  useEffect(() => {
     async function initOutDir() {
       try {
         const cfg = (await invoke("load_paths")) as {
@@ -262,10 +272,11 @@ export default function SFZSongForm() {
         drum_pattern: "", // Drum pattern descriptor (unused in current UI)
         sfz_instrument: sfzInstrument || undefined, // Selected SFZ path
         lofi_filter: lofiFilter, // Apply lofi coloration
+        reverb, // Apply simple reverb
         midi_file: midiFile || undefined, // Optional MIDI file path
         gain, // Output gain multiplier
       }),
-      [title, outDir, sfzInstrument, lofiFilter, midiFile, gain]
+      [title, outDir, sfzInstrument, lofiFilter, reverb, midiFile, gain]
     );
 
   function generate() {
@@ -343,6 +354,15 @@ export default function SFZSongForm() {
             />
           </Stack>
         </FormControl>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={reverb}
+              onChange={(e) => setReverb(e.target.checked)}
+            />
+          }
+          label="Reverb"
+        />
         <FormControlLabel
           control={
             <Checkbox

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -32,6 +32,7 @@ export interface SongSpec {
   hqChorus?: boolean;
   limiterDrive?: number;
   lofiFilter?: boolean;
+  reverb?: boolean;
   sfzInstrument?: string;
   midiFile?: string;
   gain?: number;


### PR DESCRIPTION
## Summary
- add `reverb` flag to `SongSpec` and `basic_sfz_generator`
- apply simple delay-based reverb when flag is enabled
- expose reverb toggle in `SFZSongForm` UI
- cover new branch with tests

## Testing
- `npm test -- --run`
- `pytest src-tauri/python/tests` *(fails: FAILED src-tauri/python/tests/test_determinism.py::test_deterministic_render - assert np.float64(0.057356) == 0.1113)*
- `cargo test` *(fails: error: lock file version 4 requires `-Znext-lockfile-bump`)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c05224208325bbc40e1151db25fe