### PR TITLE
feat(sfz): show progress snackbars for SFZ generation

### DIFF
--- a/src/components/SFZSongForm.test.tsx
+++ b/src/components/SFZSongForm.test.tsx
@@ -229,7 +229,9 @@ describe('SFZSongForm', () => {
     listeners['basic_sfz_progress']?.({
       payload: '{"stage":"done","message":"saved"}',
     });
-    await screen.findByText('saved');
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('saved');
+    expect(alert).toHaveClass('MuiAlert-standardSuccess');
     await waitFor(() => expect(screen.queryByText('working')).toBeNull());
   });
 
@@ -243,7 +245,9 @@ describe('SFZSongForm', () => {
     listeners['basic_sfz_progress']?.({
       payload: '{"stage":"error","message":"oops"}',
     });
-    await screen.findByText('oops');
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('oops');
+    expect(alert).toHaveClass('MuiAlert-standardError');
     await waitFor(() => expect(screen.queryByText('working')).toBeNull());
   });
 });

--- a/src/components/SFZSongForm.tsx
+++ b/src/components/SFZSongForm.tsx
@@ -230,11 +230,11 @@ export default function SFZSongForm() {
             const data = JSON.parse(e.payload);
             const { stage, message } = data;
             if (stage === "done") {
+              setStatus(null);
               setToast({ message, severity: "success" });
-              setStatus(null);
             } else if (stage === "error") {
-              setToast({ message, severity: "error" });
               setStatus(null);
+              setToast({ message, severity: "error" });
             } else {
               setStatus(message);
             }


### PR DESCRIPTION
## Summary
- handle `basic_sfz_progress` events to clear status and surface success/error snackbars
- add tests for progress event success and failure paths

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b1c055a3f883259c12277163fc8795