### PR TITLE
feat: add basic sfz generation task

### DIFF
--- a/src-tauri/src/task_queue.rs
+++ b/src-tauri/src/task_queue.rs
@@ -527,13 +527,13 @@ impl TaskQueue {
                                                 message: "no app handle".into(),
                                             },
                                         )?;
-                                        let path = run_basic_sfz(app.clone(), spec.into())
-                                            .await
-                                            .map_err(|e| TaskError {
+                                        let path = run_basic_sfz(app.clone(), spec).await.map_err(
+                                            |e| TaskError {
                                                 code: PdfErrorCode::ExecutionFailed,
                                                 message: e,
-                                            })?;
-                                        Ok(serde_json::json!({ "path": path }))
+                                            },
+                                        )?;
+                                        Ok(Value::String(path))
                                     }
                                     TaskCommand::GenerateShort { spec } => {
                                         println!("Generating short: {:?}", spec);


### PR DESCRIPTION
## Summary
- handle `GenerateBasicSfz` task by invoking `run_basic_sfz`
- store resulting SFZ audio path directly on the task result

## Testing
- `npm test -- --run`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c08619788325b34dae456ade9262