### PR TITLE
feat(voice): add Higgs voice hook

### DIFF
--- a/src/features/voice/useHiggsVoice.ts
+++ b/src/features/voice/useHiggsVoice.ts
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import * as Tone from "tone";
+
+interface UseHiggsVoice {
+  speak: (text: string, voiceId: string) => Promise<void>;
+  status: "idle" | "loading" | "playing" | "error";
+  error: string | null;
+}
+
+export function useHiggsVoice(): UseHiggsVoice {
+  const [status, setStatus] = useState<"idle" | "loading" | "playing" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const speak = async (text: string, voiceId: string) => {
+    setStatus("loading");
+    setError(null);
+    try {
+      const wav = (await invoke("higgs_tts", { text, speaker: voiceId })) as number[] | Uint8Array;
+      const uint8 = wav instanceof Uint8Array ? wav : new Uint8Array(wav);
+      const audioBuffer = await Tone.context.decodeAudioData(uint8.buffer);
+      const player = new Tone.Player().toDestination();
+      player.buffer = audioBuffer;
+      player.onstop = () => setStatus("idle");
+      await Tone.start();
+      player.start();
+      setStatus("playing");
+    } catch (err) {
+      setError(String(err));
+      setStatus("error");
+    }
+  };
+
+  return { speak, status, error };
+}
+
+export type { UseHiggsVoice };


### PR DESCRIPTION
## Summary
- add `useHiggsVoice` hook to request speech from backend and play with Tone.js

## Testing
- `npm test -- --run`
- `cargo test` *(fails: webkit2gtk-4.1 not found / long build)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ddfb332083259cc75001fff943fd