### PR TITLE
feat: enqueue basic sfz generation from song form

### DIFF
--- a/src/components/SFZSongForm.test.tsx
+++ b/src/components/SFZSongForm.test.tsx
@@ -56,7 +56,7 @@ describe('SFZSongForm', () => {
     expect(lofi).not.toBeChecked();
   });
 
-  it('enqueues GenerateSong with default lofi filter', async () => {
+  it('enqueues GenerateBasicSfz with default lofi filter', async () => {
     (openDialog as any).mockResolvedValueOnce('/tmp/out');
 
     render(<SFZSongForm />);
@@ -68,7 +68,7 @@ describe('SFZSongForm', () => {
     fireEvent.click(screen.getByText('Generate'));
     await waitFor(() => expect(enqueueTask).toHaveBeenCalled());
     const [, args] = enqueueTask.mock.calls[0];
-    expect(args.id).toBe('GenerateSong');
+    expect(args.id).toBe('GenerateBasicSfz');
     expect(args.spec.instruments).toEqual([]);
     expect(args.spec.ambience).toEqual([]);
     expect(args.spec.bpm).toBe(64);

--- a/src/components/SFZSongForm.tsx
+++ b/src/components/SFZSongForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { resolveResource } from "@tauri-apps/api/path";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
@@ -62,6 +62,17 @@ interface SongSpec {
   gain?: number;
   /** Optional RNG seed for reproducible generation. */
   seed?: number;
+}
+
+export function generateBasicSong(
+  tasks: ReturnType<typeof useTasks>,
+  spec: SongSpec,
+) {
+  const seed = Math.floor(Math.random() * 2 ** 32);
+  tasks.enqueueTask("Music Generation", {
+    id: "GenerateBasicSfz",
+    spec: { ...spec, seed },
+  });
 }
 
 export default function SFZSongForm() {
@@ -261,29 +272,20 @@ export default function SFZSongForm() {
     };
   }, []);
 
-  const spec = useMemo(
-      (): SongSpec => ({
-        title, // Song title
-        outDir, // Output directory for generated files
-        bpm: 64, // Tempo in BPM (fixed for now)
-        structure: [{ name: "A", bars: 8, chords: ["Cmaj7"] }], // Sections + harmony
-        instruments: [], // Additional instrument layers (unused in current UI)
-        ambience: [], // Ambient textures (unused in current UI)
-        drum_pattern: "", // Drum pattern descriptor (unused in current UI)
-        sfz_instrument: sfzInstrument || undefined, // Selected SFZ path
-        lofi_filter: lofiFilter, // Apply lofi coloration
-        reverb, // Apply simple reverb
-        midi_file: midiFile || undefined, // Optional MIDI file path
-        gain, // Output gain multiplier
-      }),
-      [title, outDir, sfzInstrument, lofiFilter, reverb, midiFile, gain]
-    );
-
   function generate() {
-    const seed = Math.floor(Math.random() * 2 ** 32);
-    tasks.enqueueTask("Music Generation", {
-      id: "GenerateSong",
-      spec: { ...spec, seed },
+    generateBasicSong(tasks, {
+      title,
+      outDir,
+      bpm: 64,
+      structure: [{ name: "A", bars: 8, chords: ["Cmaj7"] }],
+      instruments: [],
+      ambience: [],
+      drum_pattern: "",
+      sfz_instrument: sfzInstrument || undefined,
+      lofi_filter: lofiFilter,
+      reverb,
+      midi_file: midiFile || undefined,
+      gain,
     });
   }
 


### PR DESCRIPTION
## Summary
- export `generateBasicSong` to enqueue `GenerateBasicSfz`
- update SFZSongForm to use new helper
- ensure `run_basic_sfz` command is registered

## Testing
- `npm test`
- `cargo test` *(fails: javascriptcoregtk-4.1 missing)*
- `pytest src-tauri/python/tests` *(fails: test_deterministic_render)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e6c27d90832585744d8cfa21ca34