### PR TITLE
feat(voices): add belinda and goblin samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,5 @@ dist-ssr
 *.sln
 *.sw?
 
-# Ignore generated ambience audio
-src-tauri/python/samples/ambience/*.wav
+# Ignore example voice and ambience audio files
+src-tauri/python/samples/**/*.wav

--- a/src-tauri/python/higgs_tts.py
+++ b/src-tauri/python/higgs_tts.py
@@ -20,6 +20,7 @@ AUDIO_TOKENIZER_PATH = os.environ.get("HIGGS_AUDIO_TOKENIZER_PATH", "HIGGS_AUDIO
 # distributed separately. Users can supply a path directly via --ref_audio.
 EXAMPLE_VOICES: Dict[str, str] = {
     "belinda": os.path.join(os.path.dirname(__file__), "samples", "belinda.wav"),
+    "goblin": os.path.join(os.path.dirname(__file__), "samples", "goblin.wav"),
 }
 
 


### PR DESCRIPTION
## Summary
- expose Belinda and Goblin example voices in Higgs TTS
- remove committed audio samples and ignore future WAV files

## Testing
- `npm test -- --run`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b1fed2d3908325aa094ae75ab5ef85