### PR TITLE
fix: preload SFZ output directory from localStorage

### DIFF
--- a/src/components/SFZSongForm.test.tsx
+++ b/src/components/SFZSongForm.test.tsx
@@ -30,10 +30,10 @@ vi.mock('../utils/sfzLoader', () => ({
   }),
 }));
 
-const generateBasicSong = vi.fn();
 vi.mock('../store/tasks', () => ({
-  generateBasicSong,
+  generateBasicSong: vi.fn(),
 }));
+import { generateBasicSong } from '../store/tasks';
 
 describe('SFZSongForm', () => {
   beforeEach(() => {
@@ -123,6 +123,15 @@ describe('SFZSongForm', () => {
     render(<SFZSongForm />);
     await screen.findByText('Change SFZ');
     expect(screen.getByText('Output: /saved/out')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(localStorage.getItem('sfzOutDir')).toBe('/saved/out')
+    );
+    await waitFor(() =>
+      expect(vi.mocked(invoke).mock.calls).toContainEqual([
+        'save_paths',
+        { sfz_out_dir: '/saved/out' },
+      ])
+    );
   });
 
   it('prefills output directory from localStorage when config missing', async () => {
@@ -130,6 +139,12 @@ describe('SFZSongForm', () => {
     render(<SFZSongForm />);
     await screen.findByText('Change SFZ');
     expect(screen.getByText('Output: /stored/out')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(vi.mocked(invoke).mock.calls).toContainEqual([
+        'save_paths',
+        { sfz_out_dir: '/stored/out' },
+      ])
+    );
   });
 
   it('persists chosen folder', async () => {
@@ -138,11 +153,15 @@ describe('SFZSongForm', () => {
     await screen.findByText('Change SFZ');
     fireEvent.click(screen.getByText('Choose Output Folder'));
     await screen.findByText('Output: /tmp/out');
-    expect(localStorage.getItem('sfzOutDir')).toBe('/tmp/out');
-    expect(vi.mocked(invoke).mock.calls).toContainEqual([
-      'save_paths',
-      { sfz_out_dir: '/tmp/out' },
-    ]);
+    await waitFor(() =>
+      expect(localStorage.getItem('sfzOutDir')).toBe('/tmp/out')
+    );
+    await waitFor(() =>
+      expect(vi.mocked(invoke).mock.calls).toContainEqual([
+        'save_paths',
+        { sfz_out_dir: '/tmp/out' },
+      ])
+    );
   });
 
   it('remembers chosen SFZ instrument', async () => {

--- a/src/components/SFZSongForm.tsx
+++ b/src/components/SFZSongForm.tsx
@@ -38,7 +38,7 @@ interface Section {
 
 export default function SFZSongForm() {
   const [title, setTitle] = useState("");
-  const [outDir, setOutDir] = useState("");
+  const [outDir, setOutDir] = useState(() => localStorage.getItem("sfzOutDir") || "");
   const [bpm, setBpm] = useState(100);
   const [key, setKey] = useState("C");
   const [sfzInstrument, setSfzInstrument] = useState<string | null>(null);
@@ -88,10 +88,6 @@ export default function SFZSongForm() {
       if (dir) {
         const chosen = dir as string;
         setOutDir(chosen);
-        localStorage.setItem("sfzOutDir", chosen);
-        invoke("save_paths", { sfz_out_dir: chosen }).catch((e) =>
-          console.error(e)
-        );
       }
     } catch (e) {
       handleError(e);
@@ -184,21 +180,23 @@ export default function SFZSongForm() {
   }, [reverb]);
 
   useEffect(() => {
+    if (outDir) {
+      localStorage.setItem("sfzOutDir", outDir);
+      invoke("save_paths", { sfz_out_dir: outDir }).catch((e) =>
+        console.error(e)
+      );
+    }
+  }, [outDir]);
+
+  useEffect(() => {
     async function initOutDir() {
       try {
-        const cfg = (await invoke("load_paths")) as {
-          sfz_out_dir?: string;
-        };
+        const cfg = (await invoke("load_paths")) as { sfz_out_dir?: string };
         if (cfg.sfz_out_dir) {
           setOutDir(cfg.sfz_out_dir);
-          localStorage.setItem("sfzOutDir", cfg.sfz_out_dir);
-        } else {
-          const stored = localStorage.getItem("sfzOutDir");
-          if (stored) setOutDir(stored);
         }
-      } catch {
-        const stored = localStorage.getItem("sfzOutDir");
-        if (stored) setOutDir(stored);
+      } catch (e) {
+        console.error(e);
       }
     }
     initOutDir();


### PR DESCRIPTION
## Summary
- initialize SFZ output directory from localStorage to avoid initial flicker
- persist output directory changes to localStorage and backend path config
- adjust tests for new persistence behavior

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b200bf6ab88325b2e37d35d8fa3a9d