### PR TITLE
feat(voices): add text-to-speech controls

### DIFF
--- a/src/pages/Voices.tsx
+++ b/src/pages/Voices.tsx
@@ -1,9 +1,13 @@
 import { useState } from "react";
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, TextField, Button } from "@mui/material";
 import VoiceSelect from "../features/voice/VoiceSelect";
+import { useHiggsVoice } from "../features/voice/useHiggsVoice";
 
 export default function Voices() {
   const [selected, setSelected] = useState<string>("");
+  const [text, setText] = useState<string>("");
+  const { speak, status, error } = useHiggsVoice();
+
   return (
     <Box
       sx={{
@@ -16,8 +20,30 @@ export default function Voices() {
       }}
     >
       <VoiceSelect selected={selected} onSelect={setSelected} />
+      <TextField
+        label="Text to speak"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        multiline
+        fullWidth
+      />
+      <Button
+        variant="contained"
+        disabled={!text || !selected || status === "loading" || status === "playing"}
+        onClick={() => speak(text, selected)}
+      >
+        Speak
+      </Button>
       {selected && (
         <Typography variant="body2">Selected: {selected}</Typography>
+      )}
+      {status !== "idle" && (
+        <Typography variant="body2">Status: {status}</Typography>
+      )}
+      {error && (
+        <Typography color="error" variant="body2">
+          {error}
+        </Typography>
       )}
     </Box>
   );


### PR DESCRIPTION
## Summary
- allow typing custom text and speaking with selected Higgs voice
- show current playback state and errors

## Testing
- `npm test` *(fails: [vitest] error mocking generateBasicSong)*
- `cargo test` *(fails: glib-2.0 not found)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b200f89bb88325b45c390b2feb83c3