### PR TITLE
feat(sfz): show MIDI file metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ When a user uploads a video, it plays automatically on an endless loop.
 - **SFZ instruments:** Supply custom samples in the song JSON with
   `sfz_instrument` for leads or `sfz_chords`, `sfz_pads`, and `sfz_bass` for
   chords, pads, and bass lines.
+- **MIDI seeding:** Choose a MIDI file in the SFZ Music form to seed note data.
+  The selection is persisted, included in the song spec, and its name and
+  length are shown for confirmation.
 - **Song form:** Structure songs with through‑composed templates (e.g.
   `Intro–A–B–C–D–E–F–Outro`) and use odd bar lengths like 5 or 7 bars for
   asymmetrical phrases.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@tauri-apps/plugin-dialog": "^2",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-sql": "^2",
+        "@tonejs/midi": "^2.0.28",
         "better-sqlite3": "^12.2.0",
         "monaco-editor": "^0.52.2",
         "nanoid": "^5.1.5",
@@ -2201,6 +2202,16 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tonejs/midi": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/@tonejs/midi/-/midi-2.0.28.tgz",
+      "integrity": "sha512-RII6YpInPsOZ5t3Si/20QKpNqB1lZ2OCFJSOzJxz38YdY/3zqDr3uaml4JuCWkdixuPqP1/TBnXzhQ39csyoVg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-flatten": "^3.0.0",
+        "midi-file": "^1.2.2"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -2642,6 +2653,12 @@
       "dependencies": {
         "dequal": "^2.0.3"
       }
+    },
+    "node_modules/array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -5666,6 +5683,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/midi-file": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/midi-file/-/midi-file-1.2.4.tgz",
+      "integrity": "sha512-B5SnBC6i2bwJIXTY9MElIydJwAmnKx+r5eJ1jknTLetzLflEl0GWveuBB6ACrQpecSRkOB6fhTx1PwXk2BVxnA==",
+      "license": "MIT"
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@tauri-apps/plugin-dialog": "^2",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-sql": "^2",
+    "@tonejs/midi": "^2.0.28",
     "better-sqlite3": "^12.2.0",
     "monaco-editor": "^0.52.2",
     "nanoid": "^5.1.5",
@@ -69,4 +70,3 @@
     "zod-to-json-schema": "^3.23.5"
   }
 }
-

--- a/src/components/SFZSongForm.tsx
+++ b/src/components/SFZSongForm.tsx
@@ -2,7 +2,9 @@ import { useEffect, useMemo, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { resolveResource } from "@tauri-apps/api/path";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
+import { readBinaryFile } from "@tauri-apps/api/fs";
 import { listen } from "@tauri-apps/api/event";
+import { Midi } from "@tonejs/midi";
 import {
   Alert,
   Snackbar,
@@ -36,6 +38,15 @@ interface Section {
  * Contains all configurable properties for rendering a song.
  */
 
+function formatDuration(seconds: number): string {
+  if (!isFinite(seconds)) return "0:00";
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.round(seconds % 60)
+    .toString()
+    .padStart(2, "0");
+  return `${mins}:${secs}`;
+}
+
 export default function SFZSongForm() {
   const [title, setTitle] = useState("");
   const [outDir, setOutDir] = useState("");
@@ -45,9 +56,10 @@ export default function SFZSongForm() {
   const [midiFile, setMidiFile] = useState<string | null>(
       () => localStorage.getItem("midiFile")
     );
-    const [loading, setLoading] = useState(false);
-    const [progress, setProgress] = useState(0);
-    const [status, setStatus] = useState<string | null>(null);
+  const [midiMeta, setMidiMeta] = useState<{ name: string; duration: number } | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [status, setStatus] = useState<string | null>(null);
   const [lofiFilter, setLofiFilter] = useState(() => {
     const stored = localStorage.getItem("lofiFilter");
     return stored === null ? false : stored === "true";
@@ -61,6 +73,26 @@ export default function SFZSongForm() {
   const [toast, setToast] = useState<
     { message: string; severity: "success" | "error" } | null
   >(null);
+
+  useEffect(() => {
+    if (midiFile) {
+      (async () => {
+        try {
+          const data = await readBinaryFile(midiFile);
+          const midi = new Midi(data);
+          setMidiMeta({
+            name: midiFile.split(/[/\\]/).pop() || midiFile,
+            duration: midi.duration,
+          });
+        } catch (e) {
+          console.warn(e);
+          setMidiMeta(null);
+        }
+      })();
+    } else {
+      setMidiMeta(null);
+    }
+  }, [midiFile]);
 
   function mapLoaderError(e: unknown): string {
     const msg = e instanceof Error ? e.message : String(e);
@@ -277,7 +309,11 @@ export default function SFZSongForm() {
         </FormControl>
         <FormControl>
           <Button variant="outlined" onClick={pickMidiFile} fullWidth>
-            {midiFile ? `MIDI: ${midiFile}` : "Choose MIDI File"}
+            {midiMeta
+              ? `MIDI: ${midiMeta.name} (${formatDuration(midiMeta.duration)})`
+              : midiFile
+              ? `MIDI: ${midiFile}`
+              : "Choose MIDI File"}
           </Button>
         </FormControl>
         <FormControl fullWidth>


### PR DESCRIPTION
## Summary
- display selected MIDI file name and duration after picking a file
- persist chosen MIDI file path in localStorage and include in spec
- document MIDI seeding in the SFZ Music section

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b200d11e248325b1ca8e7ea62d9434