### PR TITLE
fix(theme): update forest theme color

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -76,7 +76,7 @@ const displayKey = (k: string) => k.replace("#", "♯").replace("b", "♭");
 const THEME_PREVIEWS: Record<Theme, string> = {
   default: "#3d0a0a",
   ocean: "#0a3d5e",
-  forest: "#0a3d1a",
+  forest: "#228B22",
   sunset: "#5e2a0a",
   sakura: "#5e0a3d",
   studio: "#000",

--- a/src/styles.css
+++ b/src/styles.css
@@ -27,19 +27,7 @@ body.theme-ocean {
   background: radial-gradient(circle at center, #0a3d5e, #082938);
 }
 body.theme-forest {
-  background: #000;
-}
-body.theme-forest::before {
-  content: "";
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  width: 100vmin;
-  height: 100vmin;
-  transform: translate(-50%, -50%);
-  background: url("/forest.svg") center/cover no-repeat;
-  pointer-events: none;
-  animation: forestFloat 60s linear infinite;
+  background: #228B22;
 }
 body.theme-sunset {
   background: radial-gradient(circle at center, #5e2a0a, #381a08);
@@ -248,18 +236,6 @@ body.theme-studio input[type="range"]::-moz-range-thumb {
   border-color: #0ff;
   box-shadow: 0 0 4px #0ff, 0 0 8px #0ff;
   animation: neonFlicker 1.5s infinite alternate;
-}
-
-@keyframes forestFloat {
-  0% {
-    transform: translate(-50%, -50%) scale(1) rotate(0deg);
-  }
-  50% {
-    transform: translate(-50%, -50%) scale(1.05) rotate(2deg);
-  }
-  100% {
-    transform: translate(-50%, -50%) scale(1) rotate(0deg);
-  }
 }
 .retro-tv-container {
   position: fixed;


### PR DESCRIPTION
## Summary
- refresh forest theme with forest-green background and remove floating overlay animation
- sync SettingsDrawer preview color with forest theme update

## Testing
- `npm test` *(fails: [vitest] There was an error when mocking a module)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*
- `cargo test` *(fails: glib-2.0 system library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2010e613c8325adab5659f44598bc