### PR TITLE
refactor: remove deprecated DnD theme

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -144,7 +144,6 @@ const MODULE_LABELS: Record<ModuleKey, string> = {
   laser: "Laser Lab",
   fusion: "Fusion",
   simulation: "Simulation",
-  dnd: "D&D",
   voices: "Voices",
   stocks: "Stocks",
   shorts: "Shorts",

--- a/src/features/theme/ThemeContext.tsx
+++ b/src/features/theme/ThemeContext.tsx
@@ -22,8 +22,7 @@ export type Theme =
   | "rainy"
   | "pastel"
   | "mono"
-  | "eclipse"
-  | "dnd";
+  | "eclipse";
 
 interface ThemeContextType {
   theme: Theme;
@@ -55,7 +54,6 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       "theme-pastel",
       "theme-mono",
       "theme-eclipse",
-      "theme-dnd",
     ];
     document.body.classList.remove(...classes);
     document.body.classList.add(`theme-${theme}`);

--- a/src/pages/DND.tsx
+++ b/src/pages/DND.tsx
@@ -1,5 +1,4 @@
 import { Box, TextField, MenuItem, Tabs, Tab } from "@mui/material";
-import { ThemeProvider } from "@mui/material/styles";
 import {
   Person,
   MenuBook,
@@ -16,7 +15,6 @@ import {
   Rule,
 } from "@mui/icons-material";
 import { useState, ChangeEvent } from "react";
-import { createDndTheme } from "../theme";
 import NpcForm from "../features/dnd/NpcForm";
 import LoreForm from "../features/dnd/LoreForm";
 import NPCList from "./NPCList";
@@ -74,8 +72,7 @@ export default function DND() {
     { icon: <MilitaryTech />, label: "War Table", component: <WarTable /> },
   ];
   return (
-    <ThemeProvider theme={createDndTheme()}>
-      <Box sx={{ p: 2 }}>
+    <Box sx={{ p: 2 }}>
       <Box
         data-testid="world-selector"
         sx={{ mt: 4, mb: 2, ml: 2, maxWidth: 200 }}
@@ -117,6 +114,5 @@ export default function DND() {
         </>
       )}
       </Box>
-    </ThemeProvider>
   );
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -15,19 +15,6 @@ export const colors = {
 
 export const spacing = 8;
 
-export const dndColors = {
-  primary: '#8b0000',
-  secondary: '#d4af37',
-  background: '#2a1a1f',
-  surface: '#3e2723',
-};
-
-export const dndTypography = {
-  fontFamily: `'Cinzel', serif`,
-  h1: { fontFamily: `'Cinzel', serif` },
-  h2: { fontFamily: `'Cinzel', serif` },
-};
-
 export const createAppTheme = () =>
   createTheme({
     palette: {
@@ -36,20 +23,5 @@ export const createAppTheme = () =>
       secondary: { main: colors.secondary },
       background: { default: colors.background, paper: colors.surface },
     },
-    spacing,
-  });
-
-export const createDndTheme = () =>
-  createTheme({
-    palette: {
-      mode: 'dark',
-      primary: { main: dndColors.primary },
-      secondary: { main: dndColors.secondary },
-      background: {
-        default: dndColors.background,
-        paper: dndColors.surface,
-      },
-    },
-    typography: dndTypography,
     spacing,
   });


### PR DESCRIPTION
## Summary
- remove DnD variant from theme context and body class management
- drop DnD-specific theme utilities and use default theme in DND page
- clean up Settings drawer module list

## Testing
- `npm test` *(fails: ReferenceError in SFZSongForm test)*
- `cargo test` *(fails: gdk-3.0 library missing)*
- `pytest src-tauri/python/tests` *(fails: deterministic render assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68b20111d3d48325ae8dd7a31bdba6e7