### PR TITLE
feat(theme): refresh forest style

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -75,7 +75,7 @@ const displayKey = (k: string) => k.replace("#", "♯").replace("b", "♭");
 
 const THEME_PREVIEWS: Record<Theme, string> = {
   default: "#3d0a0a",
-  forest: "#0a3d1a",
+  forest: "#228b22",
   sunset: "#5e2a0a",
   sakura: "#5e0a3d",
   studio: "#000",

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,19 +24,7 @@ body.theme-default {
   background: radial-gradient(circle at center, #3d0a0a, #290808);
 }
 body.theme-forest {
-  background: #000;
-}
-body.theme-forest::before {
-  content: "";
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  width: 100vmin;
-  height: 100vmin;
-  transform: translate(-50%, -50%);
-  background: url("/forest.svg") center/cover no-repeat;
-  pointer-events: none;
-  animation: forestFloat 60s linear infinite;
+  background: #228b22;
 }
 body.theme-sunset {
   background: radial-gradient(circle at center, #5e2a0a, #381a08);
@@ -245,18 +233,6 @@ body.theme-studio input[type="range"]::-moz-range-thumb {
   border-color: #0ff;
   box-shadow: 0 0 4px #0ff, 0 0 8px #0ff;
   animation: neonFlicker 1.5s infinite alternate;
-}
-
-@keyframes forestFloat {
-  0% {
-    transform: translate(-50%, -50%) scale(1) rotate(0deg);
-  }
-  50% {
-    transform: translate(-50%, -50%) scale(1.05) rotate(2deg);
-  }
-  100% {
-    transform: translate(-50%, -50%) scale(1) rotate(0deg);
-  }
 }
 .retro-tv-container {
   position: fixed;


### PR DESCRIPTION
## Summary
- restyle forest theme with forest green backdrop and remove floating overlay
- update SettingsDrawer preview swatch to match forest theme

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b209d605288325b71a3f91401828b8