### PR TITLE
feat(users): add widget toggles

### DIFF
--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -1,6 +1,12 @@
 import { useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { useUsers, defaultModules, type ModuleKey } from "../users/useUsers";
+import {
+  useUsers,
+  defaultModules,
+  type ModuleKey,
+  defaultWidgets,
+  type WidgetKey,
+} from "../users/useUsers";
 import { shallow } from "zustand/shallow";
 
 export function useSettings() {
@@ -13,6 +19,15 @@ export function useSettings() {
     [currentModules]
   );
   const toggleModule = useUsers((state) => state.toggleModule);
+  const currentWidgets = useUsers(
+    (s) => (s.currentUserId ? s.users[s.currentUserId].widgets : defaultWidgets),
+    shallow
+  );
+  const widgets = useMemo(
+    () => ({ ...defaultWidgets, ...currentWidgets }),
+    [currentWidgets]
+  );
+  const toggleWidget = useUsers((state) => state.toggleWidget);
   const cpuLimit = useUsers((state) => {
     const id = state.currentUserId;
     return id ? state.users[id].cpuLimit : 90;
@@ -28,7 +43,16 @@ export function useSettings() {
     invoke("set_task_limits", { cpu: cpuLimit, memory: memLimit }).catch(() => {});
   }, [cpuLimit, memLimit]);
 
-  return { modules, toggleModule, cpuLimit, memLimit, setCpuLimit, setMemLimit };
+  return {
+    modules,
+    toggleModule,
+    widgets,
+    toggleWidget,
+    cpuLimit,
+    memLimit,
+    setCpuLimit,
+    setMemLimit,
+  };
 }
 
-export type { ModuleKey };
+export type { ModuleKey, WidgetKey };

--- a/src/features/users/useUsers.test.ts
+++ b/src/features/users/useUsers.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useUsers, defaultWidgets } from './useUsers';
+
+beforeEach(() => {
+  useUsers.setState({ users: {}, currentUserId: null });
+  // ensure persisted state does not leak between tests
+  useUsers.persist.clearStorage();
+});
+
+describe('useUsers widgets', () => {
+  it('initializes widgets to false', () => {
+    useUsers.getState().addUser('Alice');
+    const id = useUsers.getState().currentUserId!;
+    const user = useUsers.getState().users[id];
+    expect(user.widgets).toEqual(defaultWidgets);
+  });
+
+  it('toggleWidget flips the flag', () => {
+    useUsers.getState().addUser('Bob');
+    const id = useUsers.getState().currentUserId!;
+    expect(useUsers.getState().users[id].widgets.tasks).toBe(false);
+    useUsers.getState().toggleWidget('tasks');
+    expect(useUsers.getState().users[id].widgets.tasks).toBe(true);
+  });
+});

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -41,6 +41,15 @@ const defaultModules: ModulesState = {
   sfz: true,
 };
 
+type WidgetKey = 'homeChat' | 'systemInfo' | 'tasks';
+type WidgetsState = Record<WidgetKey, boolean>;
+
+const defaultWidgets: WidgetsState = {
+  homeChat: false,
+  systemInfo: false,
+  tasks: false,
+};
+
 interface RetroTvMedia {
   path: string;
   width: number;
@@ -53,6 +62,7 @@ interface User {
   theme: Theme;
   money: number;
   modules: ModulesState;
+  widgets: WidgetsState;
   cpuLimit: number;
   memLimit: number;
   retroTvMedia: RetroTvMedia | null;
@@ -66,6 +76,7 @@ interface UsersState {
   switchUser: (id: string) => void;
   setTheme: (theme: Theme) => void;
   toggleModule: (key: ModuleKey) => void;
+  toggleWidget: (key: WidgetKey) => void;
   setCpuLimit: (limit: number) => void;
   setMemLimit: (limit: number) => void;
   setRetroTvMedia: (media: RetroTvMedia) => void;
@@ -89,6 +100,7 @@ export const useUsers = create<UsersState>()(
               theme: state.globalTheme,
               money: 5000,
               modules: { ...defaultModules },
+              widgets: { ...defaultWidgets },
               cpuLimit: 90,
               memLimit: 90,
               retroTvMedia: null,
@@ -122,6 +134,22 @@ export const useUsers = create<UsersState>()(
                 [id]: {
                   ...user,
                   modules: { ...user.modules, [key]: !user.modules[key] },
+                },
+              },
+            };
+          });
+        },
+        toggleWidget: (key) => {
+          const id = get().currentUserId;
+          if (!id) return;
+          set((state) => {
+            const user = state.users[id];
+            return {
+              users: {
+                ...state.users,
+                [id]: {
+                  ...user,
+                  widgets: { ...user.widgets, [key]: !user.widgets[key] },
                 },
               },
             };
@@ -179,4 +207,12 @@ useUsers.persist.onFinishHydration((state) => {
   }
 });
 
-export { type ModuleKey, type ModulesState, defaultModules, type RetroTvMedia };
+export {
+  type ModuleKey,
+  type ModulesState,
+  defaultModules,
+  type WidgetKey,
+  type WidgetsState,
+  defaultWidgets,
+  type RetroTvMedia,
+};


### PR DESCRIPTION
## Summary
- add `widgets` state with `toggleWidget` action for users
- expose widgets via `useSettings`
- test widget defaults and toggle behavior

## Testing
- `npm test -- --run` (fails: Error: Missing required field(s): outDir, title, bpm... but all tests pass? Wait there were unhandled error but tests pass)


------
https://chatgpt.com/codex/tasks/task_e_68b209fa0a4c8325a1d189f73c6eec02