### PR TITLE
feat: add tasks widget and conditional home widgets

### DIFF
--- a/src/components/TasksWidget.test.tsx
+++ b/src/components/TasksWidget.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import TasksWidget from "./TasksWidget";
+import { useCalendar } from "../features/calendar/useCalendar";
+
+describe("TasksWidget", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-10T00:00:00"));
+    useCalendar.setState({ events: [], selectedCountdownId: null, tagTotals: {} });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    useCalendar.setState({ events: [], selectedCountdownId: null, tagTotals: {} });
+  });
+
+  it("filters events to only show tasks", () => {
+    useCalendar.setState({
+      events: [
+        {
+          id: "1",
+          title: "Task Today",
+          date: "2024-01-10T09:00:00",
+          end: "2024-01-10T10:00:00",
+          tags: ["task"],
+          status: "scheduled",
+          hasCountdown: false,
+        },
+        {
+          id: "2",
+          title: "Not Task",
+          date: "2024-01-10T11:00:00",
+          end: "2024-01-10T12:00:00",
+          tags: [],
+          status: "scheduled",
+          hasCountdown: false,
+        },
+        {
+          id: "3",
+          title: "Task Tomorrow",
+          date: "2024-01-11T09:00:00",
+          end: "2024-01-11T10:00:00",
+          tags: ["task"],
+          status: "scheduled",
+          hasCountdown: false,
+        },
+      ],
+      selectedCountdownId: null,
+      tagTotals: {},
+    });
+    render(<TasksWidget />);
+    expect(screen.getByText("Task Today")).toBeInTheDocument();
+    expect(screen.queryByText("Not Task")).toBeNull();
+    expect(screen.queryByText("Task Tomorrow")).toBeNull();
+  });
+
+  it("shows empty state when no tasks today", () => {
+    render(<TasksWidget />);
+    expect(screen.getByText("No tasks today!")).toBeInTheDocument();
+  });
+
+  it("switches between views", () => {
+    useCalendar.setState({
+      events: [
+        {
+          id: "1",
+          title: "Task Today",
+          date: "2024-01-10T09:00:00",
+          end: "2024-01-10T10:00:00",
+          tags: ["task"],
+          status: "scheduled",
+          hasCountdown: false,
+        },
+        {
+          id: "2",
+          title: "Task This Week",
+          date: "2024-01-12T09:00:00",
+          end: "2024-01-12T10:00:00",
+          tags: ["task"],
+          status: "scheduled",
+          hasCountdown: false,
+        },
+        {
+          id: "3",
+          title: "Task This Month",
+          date: "2024-01-25T09:00:00",
+          end: "2024-01-25T10:00:00",
+          tags: ["task"],
+          status: "scheduled",
+          hasCountdown: false,
+        },
+      ],
+      selectedCountdownId: null,
+      tagTotals: {},
+    });
+    render(<TasksWidget />);
+    expect(screen.getByText("Task Today")).toBeInTheDocument();
+    expect(screen.queryByText("Task This Week")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /week/i }));
+    expect(screen.getByText("Task This Week")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /month/i }));
+    expect(screen.getByText("Task This Month")).toBeInTheDocument();
+  });
+});
+

--- a/src/components/TasksWidget.tsx
+++ b/src/components/TasksWidget.tsx
@@ -1,0 +1,74 @@
+import { useState, useMemo } from "react";
+import { Box, Button, ButtonGroup, List, ListItem, Typography } from "@mui/material";
+import { useCalendar } from "../features/calendar/useCalendar";
+
+export default function TasksWidget() {
+  const { events } = useCalendar();
+  const [view, setView] = useState<"day" | "week" | "month">("day");
+
+  const [rangeStart, rangeEnd] = useMemo(() => {
+    const now = new Date();
+    const start = new Date(now);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(start);
+    if (view === "day") {
+      end.setDate(start.getDate() + 1);
+    } else if (view === "week") {
+      start.setDate(start.getDate() - start.getDay());
+      end.setDate(start.getDate() + 7);
+    } else {
+      start.setDate(1);
+      end.setMonth(start.getMonth() + 1);
+    }
+    return [start, end];
+  }, [view]);
+
+  const tasks = useMemo(() => {
+    return events.filter((e) => {
+      if (!e.tags.includes("task")) return false;
+      const evStart = new Date(e.date).getTime();
+      const evEnd = new Date(e.end).getTime();
+      return evStart < rangeEnd.getTime() && evEnd > rangeStart.getTime();
+    });
+  }, [events, rangeStart, rangeEnd]);
+
+  return (
+    <Box
+      sx={{
+        backgroundColor: "rgba(255,255,255,0.22)",
+        color: "#fff",
+        px: 2,
+        py: 1,
+        borderRadius: "0.5rem",
+        minWidth: "12rem",
+      }}
+    >
+      <ButtonGroup size="small" sx={{ mb: 1 }}>
+        {(["day", "week", "month"] as const).map((v) => (
+          <Button
+            key={v}
+            variant={view === v ? "contained" : "outlined"}
+            onClick={() => setView(v)}
+            sx={{ textTransform: "capitalize" }}
+          >
+            {v}
+          </Button>
+        ))}
+      </ButtonGroup>
+      {tasks.length === 0 ? (
+        <Typography variant="body2">
+          {view === "day" ? "No tasks today!" : "No tasks"}
+        </Typography>
+      ) : (
+        <List dense sx={{ p: 0 }}>
+          {tasks.map((ev) => (
+            <ListItem key={ev.id} sx={{ py: 0 }}>
+              <Typography variant="body2">{ev.title}</Typography>
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+}
+

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,15 +9,19 @@ import VersionBadge from "../components/VersionBadge";
 import { Theme, useTheme } from "../features/theme/ThemeContext";
 import HomeChat from "../components/HomeChat";
 import SystemInfoWidget from "../components/SystemInfoWidget";
+import TasksWidget from "../components/TasksWidget";
+import { useSettings } from "../features/settings/useSettings";
 import {
   countdownContainerSx,
   countdownTextSx,
   versionBadgeContainerSx,
   systemInfoWidgetSx,
+  tasksWidgetSx,
 } from "./homeStyles";
 
 export default function Home() {
   const { theme } = useTheme();
+  const { widgets } = useSettings();
   const themeColors: Record<Theme, string> = {
     default: "rgba(255,255,255,0.22)",
     forest: "rgba(0,255,150,0.22)",
@@ -69,12 +73,21 @@ export default function Home() {
       <FeatureNav onHoverColor={setHoverColor} />
 
       {/* Floating chat box */}
-      <HomeChat />
+      {widgets.homeChat && <HomeChat />}
 
       {/* System info widget */}
-      <Box sx={systemInfoWidgetSx}>
-        <SystemInfoWidget />
-      </Box>
+      {widgets.systemInfo && (
+        <Box sx={systemInfoWidgetSx}>
+          <SystemInfoWidget />
+        </Box>
+      )}
+
+      {/* Tasks widget */}
+      {widgets.tasks && (
+        <Box sx={tasksWidgetSx}>
+          <TasksWidget />
+        </Box>
+      )}
     </>
   );
 }

--- a/src/pages/homeStyles.ts
+++ b/src/pages/homeStyles.ts
@@ -30,3 +30,10 @@ export const systemInfoWidgetSx: SxProps<Theme> = {
   left: { xs: "1rem", sm: "1.5rem" },
   zIndex: 50,
 };
+
+export const tasksWidgetSx: SxProps<Theme> = {
+  position: "absolute",
+  bottom: { xs: "1rem", sm: "1.5rem" },
+  right: { xs: "1rem", sm: "1.5rem" },
+  zIndex: 50,
+};


### PR DESCRIPTION
## Summary
- show task-tagged calendar events with daily, weekly, or monthly view
- test TasksWidget filtering, empty state, and view switching
- render Home widgets only when enabled

## Testing
- `npm test -- --run`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b211fb3f808325a3d396b8ffcc6bd7