### PR TITLE
test: add Home widget visibility tests

### DIFF
--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import Home from './Home';
+import { useCalendar } from '../features/calendar/useCalendar';
+
+const widgets = { homeChat: false, systemInfo: false, tasks: false };
+
+vi.mock('../features/settings/useSettings', () => ({
+  useSettings: () => ({ widgets }),
+}));
+
+vi.mock('../features/theme/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'default' }),
+}));
+
+vi.mock('../components/HomeChat', () => ({
+  default: () => <div>HomeChatWidget</div>,
+}));
+
+vi.mock('../components/SystemInfoWidget', () => ({
+  default: () => <div>SystemInfoWidget</div>,
+}));
+
+vi.mock('../components/FeatureNav', () => ({
+  default: () => <div>FeatureNav</div>,
+}));
+
+vi.mock('../components/HoverCircle', () => ({
+  default: () => <div>HoverCircle</div>,
+}));
+
+vi.mock('../components/VersionBadge', () => ({
+  default: () => <div>VersionBadge</div>,
+}));
+
+describe('Home widgets', () => {
+  beforeEach(() => {
+    widgets.homeChat = false;
+    widgets.systemInfo = false;
+    widgets.tasks = false;
+    useCalendar.setState({ events: [], selectedCountdownId: null, tagTotals: {} });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useCalendar.setState({ events: [], selectedCountdownId: null, tagTotals: {} });
+  });
+
+  it('hides all widgets when flags are false', () => {
+    render(<Home />);
+    expect(screen.queryByText('HomeChatWidget')).toBeNull();
+    expect(screen.queryByText('SystemInfoWidget')).toBeNull();
+    expect(screen.queryByText(/No tasks today!/i)).toBeNull();
+  });
+
+  it('shows HomeChat when enabled', () => {
+    widgets.homeChat = true;
+    render(<Home />);
+    expect(screen.getByText('HomeChatWidget')).toBeInTheDocument();
+  });
+
+  it('shows SystemInfoWidget when enabled', () => {
+    widgets.systemInfo = true;
+    render(<Home />);
+    expect(screen.getByText('SystemInfoWidget')).toBeInTheDocument();
+  });
+
+  it('shows TasksWidget and empty message when enabled without events', () => {
+    widgets.tasks = true;
+    render(<Home />);
+    expect(screen.getByText('No tasks today!')).toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for Home widget flags and empty tasks state

## Testing
- `npm test -- --run`
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*
- `cd src-tauri && cargo test` *(fails: system library `gobject-2.0` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b27cd7fa688325aa14380c6e6f9cda