### PR TITLE
feat: add AI music page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Objects from "./pages/Objects";
 import Blender from "./pages/Blender";
 import Music from "./pages/Music";
 import SFZMusic from "./pages/SFZMusic";
+import AIMusic from "./pages/AIMusic";
 import Calendar from "./pages/Calendar";
 import Comfy from "./pages/Comfy";
 import Assistant from "./pages/Assistant";
@@ -69,6 +70,7 @@ export default function App() {
           <Route path="/objects" element={<Objects />} />
           <Route path="/objects/blender" element={<Blender />} />
           <Route path="/music" element={<Music />} />
+          <Route path="/ai-music" element={<AIMusic />} />
           <Route path="/sfz-music" element={<SFZMusic />} />
           <Route path="/calendar" element={<Calendar />} />
           <Route path="/comfy" element={<Comfy />} />

--- a/src/components/FeatureNav.tsx
+++ b/src/components/FeatureNav.tsx
@@ -41,6 +41,7 @@ type Item = {
 export const ITEMS: Item[] = [
   { key: "objects", icon: <FaCubes />, label: "3D Object", path: "/objects", color: "rgba(165,216,255,0.55)" },
   { key: "music", icon: <FaMusic />, label: "Music", path: "/music", color: "rgba(245,176,194,0.55)" },
+  { key: "aimusic", icon: <FaRobot />, label: "AI Music", path: "/ai-music", color: "rgba(200,180,255,0.55)" },
   { key: "sfz", icon: <FaMusic />, label: "SFZ Music", path: "/sfz-music", color: "rgba(200,150,200,0.55)" },
   { key: "calendar", icon: <FaCalendarAlt />, label: "Calendar", path: "/calendar", color: "rgba(211,200,255,0.55)" },
   { key: "comfy", icon: <FaCameraRetro />, label: "ComfyUI", path: "/comfy", color: "rgba(255,213,165,0.55)" },

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -135,6 +135,7 @@ const THEME_GROUPS: { label: string; options: { value: Theme; label: string }[] 
 const MODULE_LABELS: Record<ModuleKey, string> = {
   objects: "3D Object",
   music: "Lo‑Fi Music",
+  aimusic: "AI Music",
   calendar: "Calendar",
   comfy: "ComfyUI",
   assistant: "AI Assistant",

--- a/src/features/users/useUsers.ts
+++ b/src/features/users/useUsers.ts
@@ -5,6 +5,7 @@ import type { Theme } from '../theme/ThemeContext';
 type ModuleKey =
   | 'objects'
   | 'music'
+  | 'aimusic'
   | 'calendar'
   | 'comfy'
   | 'assistant'
@@ -25,6 +26,7 @@ type ModulesState = Record<ModuleKey, boolean>;
 const defaultModules: ModulesState = {
   objects: true,
   music: true,
+  aimusic: true,
   calendar: true,
   comfy: true,
   assistant: true,

--- a/src/pages/AIMusic.tsx
+++ b/src/pages/AIMusic.tsx
@@ -1,0 +1,6 @@
+import Center from "./_Center";
+
+export default function AIMusic() {
+  return <Center>AI Music Coming Soon</Center>;
+}
+


### PR DESCRIPTION
## Summary
- add placeholder AI Music page
- wire up route and feature wheel entry
- expose AI Music module in settings

## Testing
- `npm test` *(fails: Failed to resolve import "@tonejs/midi")*
- `cargo test` *(fails: The system library `gobject-2.0` required by crate `gobject-sys` was not found)*
- `pytest src-tauri/python/tests` *(fails: RuntimeError: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b28daa53348325b21540926403c091