### PR TITLE
feat: summarize transcripts via LLM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,10 @@ setup(
     version='0.1.8',
     packages=find_packages(where="src-tauri/python"),
     package_dir={"": "src-tauri/python"},
+    py_modules=["summarize_session"],
+    entry_points={
+        "console_scripts": ["summarize-session=summarize_session:main"],
+    },
     install_requires=[
         'scipy>=1.9.0',
         'pyloudnorm>=0.1.0',

--- a/src-tauri/python/summarize_session.py
+++ b/src-tauri/python/summarize_session.py
@@ -1,0 +1,85 @@
+"""Summarize a transcript session into a journal entry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Callable, Iterable, List, Dict
+
+import requests
+
+
+Transcript = Dict[str, str]
+
+
+def load_session(path: str, session_id: str) -> List[Transcript]:
+    """Load transcript entries matching ``session_id`` from ``path``.
+
+    ``path`` is expected to be a JSON Lines file where each line is a
+    ``Transcript`` object. Unknown lines are ignored.
+    """
+
+    entries: List[Transcript] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if obj.get("session_id") == session_id:
+                entries.append(obj)
+    return entries
+
+
+def _local_llm(prompt: str) -> str:
+    """Send ``prompt`` to a local LLM and return its response."""
+
+    url = os.environ.get("LOCAL_LLM_URL", "http://localhost:11434/api/generate")
+    model = os.environ.get("LOCAL_LLM_MODEL", "llama2")
+    try:
+        resp = requests.post(
+            url, json={"model": model, "prompt": prompt, "stream": False}, timeout=30
+        )
+        if resp.ok:
+            data = resp.json()
+            if isinstance(data, dict):
+                if "response" in data:
+                    return data["response"]
+                if "choices" in data and data["choices"]:
+                    return data["choices"][0].get("text", "")
+    except Exception:
+        pass
+    return ""
+
+
+def summarize_session(
+    entries: Iterable[Transcript], llm: Callable[[str], str] = _local_llm
+) -> str:
+    """Generate a markdown/HTML journal summary of ``entries`` using ``llm``."""
+
+    transcript = "\n".join(f"{e['speaker_id']}: {e['text']}" for e in entries)
+    prompt = (
+        "Summarize the following conversation into a short first-person journal "
+        "entry. Include key events and emotions.\n\n" + transcript
+    )
+    return llm(prompt)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Summarize a transcript session")
+    parser.add_argument("jsonl", help="Path to transcripts JSONL file")
+    parser.add_argument("session_id", help="Session ID to summarize")
+    args = parser.parse_args()
+
+    entries = load_session(args.jsonl, args.session_id)
+    summary = summarize_session(entries)
+    print(summary)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/src-tauri/python/tests/test_summarize_session.py
+++ b/src-tauri/python/tests/test_summarize_session.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+
+from summarize_session import load_session, summarize_session
+
+
+def test_summarize_session(tmp_path):
+    jsonl = tmp_path / "transcripts.jsonl"
+    data = [
+        {"session_id": "s1", "speaker_id": "A", "start": 0, "end": 1, "text": "Hello"},
+        {"session_id": "s1", "speaker_id": "B", "start": 1, "end": 2, "text": "Hi"},
+        {"session_id": "s2", "speaker_id": "C", "start": 0, "end": 1, "text": "Other"},
+    ]
+    with open(jsonl, "w", encoding="utf-8") as f:
+        for obj in data:
+            f.write(json.dumps(obj) + "\n")
+
+    entries = load_session(str(jsonl), "s1")
+
+    def fake_llm(prompt: str) -> str:
+        assert "A: Hello" in prompt
+        assert "B: Hi" in prompt
+        assert "C: Other" not in prompt
+        return "<p>summary</p>"
+
+    summary = summarize_session(entries, llm=fake_llm)
+    assert summary == "<p>summary</p>"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -192,6 +192,7 @@ fn main() {
             // Transcription:
             commands::load_transcripts,
             commands::transcribe_audio,
+            commands::summarize_session,
             commands::system_info,
             commands::enqueue_task,
             commands::task_status,


### PR DESCRIPTION
## Summary
- summarize session transcripts via a Python script
- expose new `summarize_session` Tauri command
- add console entry `summarize-session`

## Testing
- `pytest src-tauri/python/tests -q` *(fails: FFmpeg is required but was not found)*
- `npm test -- --run`
- `cargo test` *(fails: system library `gobject-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3adbf716c8325b6bf343b9c3eef7f