### PR TITLE
feat: use fs plugin for file access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@react-three/fiber": "^9.3.0",
         "@tauri-apps/api": "^2.7.0",
         "@tauri-apps/plugin-dialog": "^2",
+        "@tauri-apps/plugin-fs": "^2.4.2",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-sql": "^2",
         "@tonejs/midi": "^2.0.28",
@@ -2041,9 +2042,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.7.0.tgz",
-      "integrity": "sha512-v7fVE8jqBl8xJFOcBafDzXFc8FnicoH3j8o8DNNs0tHuEBmXUDqrCOAzMRX0UkfpwqZLqvrvK0GNQ45DfnoVDg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz",
+      "integrity": "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -2274,6 +2275,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.6.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-fs": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.4.2.tgz",
+      "integrity": "sha512-YGhmYuTgXGsi6AjoV+5mh2NvicgWBfVJHHheuck6oHD+HC9bVWPaHvCP0/Aw4pHDejwrvT8hE3+zZAaWf+hrig==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@react-three/fiber": "^9.3.0",
     "@tauri-apps/api": "^2.7.0",
     "@tauri-apps/plugin-dialog": "^2",
+    "@tauri-apps/plugin-fs": "^2.4.2",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-sql": "^2",
     "@tonejs/midi": "^2.0.28",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -550,6 +550,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "tauri-plugin-fs",
  "tauri-plugin-opener",
  "tauri-plugin-sql",
  "tauri-runtime",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ env_logger = "0.11"
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-fs = "2"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -102,6 +102,7 @@ fn main() {
             Ok(())
         })
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_fs::init())
         .plugin(
             SqlBuilder::default()
                 .add_migrations(

--- a/src/components/BasicSfzGenerator.test.tsx
+++ b/src/components/BasicSfzGenerator.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import BasicSfzGenerator from './BasicSfzGenerator';
-import { readDir } from '@tauri-apps/api/fs';
+import { readDir } from '@tauri-apps/plugin-fs';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { resolveResource } from '@tauri-apps/api/path';
 

--- a/src/components/BasicSfzGenerator.tsx
+++ b/src/components/BasicSfzGenerator.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
-import { readDir } from "@tauri-apps/api/fs";
+import { readDir } from "@tauri-apps/plugin-fs";
 import { resolveResource } from "@tauri-apps/api/path";
 import {
   Button,

--- a/src/components/SFZSongForm.test.tsx
+++ b/src/components/SFZSongForm.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-vi.mock('@tauri-apps/api/fs', () => ({
-  readBinaryFile: vi.fn().mockResolvedValue(new Uint8Array()),
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  readFile: vi.fn().mockResolvedValue(new Uint8Array()),
 }));
 
 vi.mock('@tonejs/midi', () => ({
@@ -38,12 +38,10 @@ vi.mock('../store/tasks', () => ({
   generateBasicSong: vi.fn(),
 }));
 import { generateBasicSong } from '../store/tasks';
-
 import SFZSongForm from './SFZSongForm';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { convertFileSrc, invoke } from '@tauri-apps/api/core';
 import { loadSfz } from '../utils/sfzLoader';
-import { generateBasicSong } from '../store/tasks';
 
 describe('SFZSongForm', () => {
   beforeEach(() => {

--- a/src/components/SFZSongForm.tsx
+++ b/src/components/SFZSongForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { resolveResource } from "@tauri-apps/api/path";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
-import { readBinaryFile } from "@tauri-apps/api/fs";
+import { readFile } from "@tauri-apps/plugin-fs";
 import { listen } from "@tauri-apps/api/event";
 import { Midi } from "@tonejs/midi";
 import {
@@ -78,7 +78,7 @@ export default function SFZSongForm() {
     if (midiFile) {
       (async () => {
         try {
-          const data = await readBinaryFile(midiFile);
+          const data = await readFile(midiFile);
           const midi = new Midi(data);
           setMidiMeta({
             name: midiFile.split(/[/\\]/).pop() || midiFile,

--- a/test/__mocks__/tauri-fs.ts
+++ b/test/__mocks__/tauri-fs.ts
@@ -1,2 +1,3 @@
 import { vi } from 'vitest';
 export const readDir = vi.fn();
+export const readFile = vi.fn();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@tauri-apps/api/fs': path.resolve(__dirname, 'test/__mocks__/tauri-fs.ts'),
+      '@tauri-apps/plugin-fs': path.resolve(__dirname, 'test/__mocks__/tauri-fs.ts'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- migrate frontend file operations to `@tauri-apps/plugin-fs`
- register fs plugin in Tauri backend
- update vitest aliases and mocks for fs plugin

## Testing
- `npm test` *(fails: Right-hand side of 'instanceof' is not an object)*
- `cargo test` *(fails: glib-2.0 system library missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ae7ccce08325bfd1eabc1ab53cd3