### PR TITLE
feat: track combat kills

### DIFF
--- a/src-tauri/python/kill_tracker.py
+++ b/src-tauri/python/kill_tracker.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+"""Track combat kills from log lines.
+
+This module provides a :class:`KillTracker` that parses combat log lines of the
+form ``"<attacker> kills <target>"`` and maintains running kill/death tallies
+for each participant. The tracker exposes methods to query individual counts or
+retrieve a snapshot of all tallies.
+"""
+
+from collections import defaultdict
+import re
+from typing import Dict, Tuple
+
+_COMBAT_RE = re.compile(r"^(?P<attacker>.+?) kills (?P<target>.+)$")
+
+
+class KillTracker:
+    """Maintain kill/death counts for combatants."""
+
+    def __init__(self) -> None:
+        self.kills: dict[str, int] = defaultdict(int)
+        self.deaths: dict[str, int] = defaultdict(int)
+
+    def record(self, line: str) -> bool:
+        """Parse ``line`` and update tallies.
+
+        Returns ``True`` if the line matched the combat pattern, otherwise
+        returns ``False`` and leaves tallies unchanged.
+        """
+
+        match = _COMBAT_RE.match(line.strip())
+        if not match:
+            return False
+        attacker = match.group("attacker")
+        target = match.group("target")
+        self.kills[attacker] += 1
+        self.deaths[target] += 1
+        return True
+
+    def get_kills(self, entity: str) -> int:
+        """Return the number of kills recorded for ``entity``."""
+
+        return self.kills.get(entity, 0)
+
+    def get_deaths(self, entity: str) -> int:
+        """Return the number of deaths recorded for ``entity``."""
+
+        return self.deaths.get(entity, 0)
+
+    def tally(self) -> Dict[str, Tuple[int, int]]:
+        """Return a mapping of entity to ``(kills, deaths)``."""
+
+        participants = set(self.kills) | set(self.deaths)
+        return {
+            entity: (self.get_kills(entity), self.get_deaths(entity))
+            for entity in participants
+        }
+
+    def display(self) -> str:
+        """Return a human-readable representation of all tallies."""
+
+        lines = [
+            f"{entity}: {kills} kills, {deaths} deaths"
+            for entity, (kills, deaths) in sorted(self.tally().items())
+        ]
+        return "\n".join(lines)
+
+
+__all__ = ["KillTracker"]

--- a/src-tauri/python/tests/test_kill_tracker.py
+++ b/src-tauri/python/tests/test_kill_tracker.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import kill_tracker  # noqa: E402
+
+
+def test_record_and_tally():
+    tracker = kill_tracker.KillTracker()
+    lines = [
+        "Alice kills Bob",
+        "Bob kills Alice",
+        "Alice kills Goblin",
+        "Goblin kills Bob",
+        "Alice kills Bob",
+    ]
+    for line in lines:
+        assert tracker.record(line)
+
+    assert tracker.get_kills("Alice") == 3
+    assert tracker.get_kills("Bob") == 1
+    assert tracker.get_deaths("Bob") == 3
+    assert tracker.get_deaths("Alice") == 1
+    assert tracker.get_deaths("Goblin") == 1
+
+    display = tracker.display()
+    assert "Alice: 3 kills, 1 deaths" in display
+
+
+def test_non_combat_line():
+    tracker = kill_tracker.KillTracker()
+    assert not tracker.record("Alice attacks Bob")
+    assert tracker.tally() == {}


### PR DESCRIPTION
## Summary
- add KillTracker for parsing combat lines and tracking kill/death tallies
- expose tally query and display utilities
- test kill tracking logic

## Testing
- `pytest src-tauri/python/tests` *(fails: test_determinism::test_deterministic_render)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ae8756d08325a88dcc6277647daf