### PR TITLE
fix(theme): use full viewport for galaxy background

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -65,11 +65,13 @@ body.theme-galaxy::before {
   position: fixed;
   top: 50%;
   left: 50%;
-  width: 100vmin;
-  height: 100vmin;
+  width: 100vw;
+  height: 100vh;
   transform: translate(-50%, -50%);
-  background: url("/galaxy.svg") center/contain no-repeat;
+  background: url("/galaxy.svg") center no-repeat;
+  background-size: cover;
   pointer-events: none;
+  z-index: -1;
 }
 
 body.theme-retro {


### PR DESCRIPTION
## Summary
- ensure galaxy theme SVG covers entire viewport and stays behind UI

## Testing
- `npm test -- --run` *(fails: Errors 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b1120e948325957a37a397af849d