### PR TITLE
fix: layer hover circle behind interactive elements

### DIFF
--- a/src/components/HoverCircle.tsx
+++ b/src/components/HoverCircle.tsx
@@ -34,7 +34,7 @@ export default function HoverCircle({
     filter: "blur(28px)",
     pointerEvents: "none",
     transition: "background 200ms ease",
-    zIndex: 0,
+    zIndex: -1,
     "--audio-alpha": alpha,
   };
 


### PR DESCRIPTION
## Summary
- allow UI elements to stay clickable by lowering HoverCircle z-index

## Testing
- `npm test -- --run`
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required)*
- `cd src-tauri && cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b11508bc8325b59fce8aef4e1102