### PR TITLE
fix(dnd): make map images cover container

### DIFF
--- a/src/features/dnd/TabletopMap.tsx
+++ b/src/features/dnd/TabletopMap.tsx
@@ -59,7 +59,7 @@ export default function TabletopMap() {
           height: 500,
           width: "100%",
           backgroundImage: image ? `url(${image})` : "none",
-          backgroundSize: "contain",
+          backgroundSize: "cover",
           backgroundRepeat: "no-repeat",
           backgroundPosition: "center",
         }}

--- a/src/features/dnd/WarTable.tsx
+++ b/src/features/dnd/WarTable.tsx
@@ -84,7 +84,7 @@ export default function WarTable() {
           height: 500,
           width: "100%",
           backgroundImage: mapImage ? `url(${mapImage})` : "none",
-          backgroundSize: "contain",
+          backgroundSize: "cover",
           backgroundRepeat: "no-repeat",
           backgroundPosition: "center",
           overflow: "hidden",


### PR DESCRIPTION
## Summary
- ensure tabletop map and war table background images cover their container to avoid empty borders

## Testing
- `npm test -- --run`
- `npm run a11y` *(fails: npm run build failed with code 2)*
- `cargo test` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*
- `pytest src-tauri/python/tests` *(fails: assert np.float64(0.057356) == 0.1113)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b11d94ec8325af039b4214b2707a