### PR TITLE
fix: guard fs plugin for web builds

### DIFF
--- a/src/components/BasicSfzGenerator.test.tsx
+++ b/src/components/BasicSfzGenerator.test.tsx
@@ -14,6 +14,7 @@ describe('BasicSfzGenerator', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    (window as any).__TAURI__ = {};
     vi.mocked(resolveResource).mockResolvedValue('/sfz_sounds');
     vi.mocked(readDir).mockResolvedValue([
       { name: 'piano.sfz', path: '/sfz_sounds/piano.sfz' },

--- a/src/components/BasicSfzGenerator.tsx
+++ b/src/components/BasicSfzGenerator.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
-import { readDir } from "@tauri-apps/plugin-fs";
 import { resolveResource } from "@tauri-apps/api/path";
 import {
   Button,
@@ -43,6 +42,8 @@ export default function BasicSfzGenerator() {
 
   useEffect(() => {
     async function init() {
+      if (!window.__TAURI__) return;
+      const { readDir } = await import("@tauri-apps/plugin-fs");
       const base = await resolveResource("sfz_sounds");
       const entries = await readDir(base);
       const files = entries
@@ -70,6 +71,7 @@ export default function BasicSfzGenerator() {
   }, [outDir]);
 
   async function pickFolder() {
+    if (!window.__TAURI__) return;
     const dir = await openDialog({ directory: true, multiple: false });
     if (dir) setOutDir(dir as string);
   }

--- a/src/components/SFZSongForm.test.tsx
+++ b/src/components/SFZSongForm.test.tsx
@@ -47,6 +47,7 @@ describe('SFZSongForm', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     localStorage.clear();
+    (window as any).__TAURI__ = {};
     vi.mocked(invoke).mockResolvedValue({});
     for (const k of Object.keys(listeners)) delete listeners[k];
   });

--- a/src/components/SFZSongForm.tsx
+++ b/src/components/SFZSongForm.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { resolveResource } from "@tauri-apps/api/path";
 import { convertFileSrc, invoke } from "@tauri-apps/api/core";
-import { readFile } from "@tauri-apps/plugin-fs";
 import { listen } from "@tauri-apps/api/event";
 import { Midi } from "@tonejs/midi";
 import {
@@ -75,9 +74,10 @@ export default function SFZSongForm() {
   >(null);
 
   useEffect(() => {
-    if (midiFile) {
+    if (midiFile && window.__TAURI__) {
       (async () => {
         try {
+          const { readFile } = await import("@tauri-apps/plugin-fs");
           const data = await readFile(midiFile);
           const midi = new Midi(data);
           setMidiMeta({


### PR DESCRIPTION
## Summary
- guard Tauri file system plugin usage behind runtime check for web-only builds
- ensure tests simulate Tauri by defining `window.__TAURI__`

## Testing
- `npm test`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b5df85488325a65ec9164a34d7ac