### PR TITLE
feat(settings): add microphone toggle

### DIFF
--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -238,6 +238,8 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
     toggleHqSidechain,
     hqChorus,
     toggleHqChorus,
+    micEnabled,
+    toggleMicEnabled,
   } = useAudioDefaults();
   const { theme, setTheme } = useTheme();
   const currentUserId = useUsers((state) => state.currentUserId);
@@ -286,6 +288,11 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
     { label: "Current User", section: "user" as Section, elementId: "current-user" },
     { label: "Python Path", section: "environment" as Section, elementId: "python-path" },
     { label: "Default Save Folder", section: "environment" as Section, elementId: "output-folder" },
+    {
+      label: "Enable Microphone",
+      section: "editor" as Section,
+      elementId: "mic-enabled",
+    },
     { label: "BPM", section: "editor" as Section, elementId: "bpm" },
     { label: "Key", section: "editor" as Section, elementId: "key" },
     { label: "HQ Stereo", section: "editor" as Section, elementId: "hq-stereo" },
@@ -427,6 +434,12 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   const EditorSection = () => (
     <>
       <Typography variant="subtitle1">Audio Defaults</Typography>
+      <Box id="mic-enabled" sx={{ mt: 1 }}>
+        <FormControlLabel
+          control={<Switch checked={micEnabled} onChange={toggleMicEnabled} />}
+          label="Enable Microphone"
+        />
+      </Box>
       <Box id="bpm" sx={{ mt: 1 }}>
         <TextField
           type="number"

--- a/src/features/audioDefaults/useAudioDefaults.test.ts
+++ b/src/features/audioDefaults/useAudioDefaults.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useAudioDefaults } from "./useAudioDefaults";
+
+describe("useAudioDefaults microphone", () => {
+  beforeEach(() => {
+    useAudioDefaults.setState({
+      bpm: 80,
+      key: "Auto",
+      hqStereo: true,
+      hqReverb: true,
+      hqSidechain: true,
+      hqChorus: true,
+      micEnabled: true,
+    });
+    useAudioDefaults.persist.clearStorage();
+  });
+
+  it("toggles micEnabled", () => {
+    expect(useAudioDefaults.getState().micEnabled).toBe(true);
+    useAudioDefaults.getState().toggleMicEnabled();
+    expect(useAudioDefaults.getState().micEnabled).toBe(false);
+  });
+});

--- a/src/features/audioDefaults/useAudioDefaults.ts
+++ b/src/features/audioDefaults/useAudioDefaults.ts
@@ -8,12 +8,14 @@ interface AudioDefaultsState {
   hqReverb: boolean;
   hqSidechain: boolean;
   hqChorus: boolean;
+  micEnabled: boolean;
   setBpm: (bpm: number) => void;
   setKey: (key: string) => void;
   toggleHqStereo: () => void;
   toggleHqReverb: () => void;
   toggleHqSidechain: () => void;
   toggleHqChorus: () => void;
+  toggleMicEnabled: () => void;
 }
 
 export const useAudioDefaults = create<AudioDefaultsState>()(
@@ -25,12 +27,14 @@ export const useAudioDefaults = create<AudioDefaultsState>()(
       hqReverb: true,
       hqSidechain: true,
       hqChorus: true,
+      micEnabled: true,
       setBpm: (bpm: number) => set({ bpm }),
       setKey: (key: string) => set({ key }),
       toggleHqStereo: () => set((s) => ({ hqStereo: !s.hqStereo })),
       toggleHqReverb: () => set((s) => ({ hqReverb: !s.hqReverb })),
       toggleHqSidechain: () => set((s) => ({ hqSidechain: !s.hqSidechain })),
       toggleHqChorus: () => set((s) => ({ hqChorus: !s.hqChorus })),
+      toggleMicEnabled: () => set((s) => ({ micEnabled: !s.micEnabled })),
     }),
     { name: "audio-defaults" }
   )

--- a/src/features/transcription/useTranscription.ts
+++ b/src/features/transcription/useTranscription.ts
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useAudioDefaults } from "../audioDefaults/useAudioDefaults";
 
 export function useTranscription() {
   const [recording, setRecording] = useState(false);
@@ -7,8 +8,13 @@ export function useTranscription() {
   const media = useRef<MediaRecorder | null>(null);
   const chunks = useRef<Blob[]>([]);
   const stream = useRef<MediaStream | null>(null);
+  const micEnabled = useAudioDefaults((s) => s.micEnabled);
 
   async function start() {
+    if (!micEnabled) {
+      setTranscript("Microphone is disabled in settings.");
+      return;
+    }
     try {
       stream.current = await navigator.mediaDevices.getUserMedia({ audio: true });
     } catch (err: any) {

--- a/src/utils/useAudioLevel.ts
+++ b/src/utils/useAudioLevel.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useAudioDefaults } from "../features/audioDefaults/useAudioDefaults";
 
 /**
  * React hook that reports the current audio output level.
@@ -18,7 +19,7 @@ import { useEffect, useRef, useState } from "react";
 export function useAudioLevel(source?: AudioNode): number {
   const [level, setLevel] = useState(0);
   const frame = useRef<number>();
-
+  const micEnabled = useAudioDefaults((s) => s.micEnabled);
   useEffect(() => {
     const AudioCtx =
       (window as any).AudioContext || (window as any).webkitAudioContext;
@@ -34,7 +35,7 @@ export function useAudioLevel(source?: AudioNode): number {
     let active = true;
     if (source) {
       source.connect(analyser);
-    } else if (navigator?.mediaDevices) {
+    } else if (navigator?.mediaDevices && micEnabled) {
       (async () => {
         try {
           stream = await navigator.mediaDevices.getDisplayMedia({
@@ -79,7 +80,7 @@ export function useAudioLevel(source?: AudioNode): number {
         ctx.close();
       }
     };
-  }, [source]);
+  }, [source, micEnabled]);
 
   return level;
 }


### PR DESCRIPTION
## Summary
- allow users to enable or disable microphone input via a persistent setting
- expose microphone toggle in Settings drawer under Audio Defaults
- respect microphone setting in audio level and transcription hooks

## Testing
- `npm test -- --run`
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c54e299483259d0c16f54ec0cdae