### PR TITLE
fix(music): import jsonlHandlers and drop unused cancel

### DIFF
--- a/src/components/MusicGenForm.tsx
+++ b/src/components/MusicGenForm.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Box, Button, Grid, MenuItem, Stack, TextField, Typography } from '@mui/material';
 import { useMusicJobs } from '../stores/musicJobs';
-import { cancelMusicJob, startMusicGenMelody, startMusicGenText } from '../utils/musicGen';
+import { startMusicGenMelody, startMusicGenText, jsonlHandlers } from '../utils/musicGen';
 import { saveTempFile } from '../utils/files';
 
 const GENRES = ['Lo-fi', 'Hip-hop', 'Ambient', 'Cinematic', 'Rock', 'Pop'];


### PR DESCRIPTION
## Summary
- remove unused cancelMusicJob import
- wire in jsonlHandlers to parse progress updates

## Testing
- `npm test -- --run` *(fails: vitest: not found)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*
- `cargo test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b41e29ad0c83258b7c3c0a2c67252c