### PR TITLE
fix(music): refresh job lists

### DIFF
--- a/src/components/MusicDashboard.tsx
+++ b/src/components/MusicDashboard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Box, Button, IconButton, LinearProgress, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import DownloadIcon from '@mui/icons-material/Download';
@@ -8,9 +9,14 @@ import AudioPlayer from './AudioPlayer';
 import { convertFileSrc } from '@tauri-apps/api/core';
 
 export default function MusicDashboard() {
-  const list = useMusicJobs((s) => s.list)();
+  const list = useMusicJobs((s) => s.list());
   const remove = useMusicJobs((s) => s.remove);
   const update = useMusicJobs((s) => s.update);
+
+  const latestCompleted = useMemo(
+    () => list.find((j) => j.status === 'completed' && j.wavPath),
+    [list]
+  );
 
   const onRegenerate = (id: string) => {
     // Simple regeneration: reset status to pending (actual re-run can be added to re-use prompts)
@@ -69,10 +75,10 @@ export default function MusicDashboard() {
       )}
 
       {/* Quick preview for the most recent completed */}
-      {list.find((j) => j.status === 'completed' && j.wavPath) && (
+      {latestCompleted && (
         <Box sx={{ mt: 3 }}>
           <Typography variant="subtitle1">Latest Preview</Typography>
-          <AudioPlayer src={list.find((j) => j.status === 'completed' && j.wavPath)!.wavPath!} />
+          <AudioPlayer src={latestCompleted.wavPath!} />
         </Box>
       )}
     </Box>

--- a/src/components/MusicQueue.tsx
+++ b/src/components/MusicQueue.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Box, Button, IconButton, LinearProgress, Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
 import CancelIcon from '@mui/icons-material/Cancel';
 import ReplayIcon from '@mui/icons-material/Replay';
@@ -5,9 +6,12 @@ import { useMusicJobs } from '../stores/musicJobs';
 import { cancelMusicJob } from '../utils/musicGen';
 
 export default function MusicQueue() {
-  const listAll = useMusicJobs((s) => s.list)();
+  const listAll = useMusicJobs((s) => s.list());
   const update = useMusicJobs((s) => s.update);
-  const queue = listAll.filter((j) => j.status === 'pending' || j.status === 'in_progress');
+  const queue = useMemo(
+    () => listAll.filter((j) => j.status === 'pending' || j.status === 'in_progress'),
+    [listAll]
+  );
 
   const onCancel = async (id: string) => {
     await cancelMusicJob(id);


### PR DESCRIPTION
## Summary
- make music job selectors reactive in dashboard and queue
- memoize derived lists so UI updates with job changes

## Testing
- `npm test -- --run` *(fails: Unable to load SFZ piano.sfz; Could not locate better-sqlite3 bindings)*

------
https://chatgpt.com/codex/tasks/task_e_68b41e1f26ac832590621312e3705fb6