### PR TITLE
fix: handle missing npx

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -954,6 +954,9 @@ pub async fn sfz_convert_flac_to_wav(
     delete_flac: Option<bool>,
 ) -> Result<String, String> {
     let script = PathBuf::from("scripts").join("sfz-flac-to-wav.ts");
+    if which("npx").is_err() {
+        return Err("npx not found; install Node.js".to_string());
+    }
     let mut cmd = PCommand::new("npx");
     cmd.arg("tsx").arg(&script);
     if let Some(r) = root {

--- a/src-tauri/tests/sfz_convert_flac_to_wav.rs
+++ b/src-tauri/tests/sfz_convert_flac_to_wav.rs
@@ -1,0 +1,11 @@
+use blossom_lib::commands::sfz_convert_flac_to_wav;
+use std::env;
+
+#[tokio::test]
+async fn sfz_convert_flac_to_wav_errors_if_npx_missing() {
+    let original_path = env::var("PATH").unwrap_or_default();
+    env::set_var("PATH", "");
+    let result = sfz_convert_flac_to_wav(None, None).await;
+    env::set_var("PATH", original_path);
+    assert!(result.unwrap_err().contains("npx not found"));
+}


### PR DESCRIPTION
## Summary
- validate `npx` is available before running FLAC->WAV conversion
- test error path when `npx` is missing

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68b41964f4648325860ec48a841030a8