### PR TITLE
feat: add play handler to music dashboard

### DIFF
--- a/src/components/MusicDashboard.test.tsx
+++ b/src/components/MusicDashboard.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import MusicDashboard from './MusicDashboard';
+import { convertFileSrc } from '@tauri-apps/api/core';
+
+const list = () => [
+  {
+    id: '1',
+    title: 'Song',
+    prompt: '',
+    createdAt: 0,
+    status: 'completed',
+    wavPath: 'file.wav',
+  },
+];
+const remove = vi.fn();
+const update = vi.fn();
+
+vi.mock('../stores/musicJobs', () => ({
+  useMusicJobs: (selector: any) => selector({ list, remove, update }),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  convertFileSrc: vi.fn((p: string) => p),
+}));
+
+describe('MusicDashboard', () => {
+  it('plays audio when play button clicked', () => {
+    const playSpy = vi.fn();
+    class MockAudio {
+      src: string;
+      constructor(src: string) {
+        this.src = src;
+      }
+      play = playSpy;
+    }
+    (globalThis as any).Audio = MockAudio as any;
+
+    render(<MusicDashboard />);
+    const [btn] = screen.getAllByRole('button', { name: 'play' });
+    fireEvent.click(btn);
+    expect(convertFileSrc).toHaveBeenCalledWith('file.wav');
+    expect(playSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/MusicDashboard.tsx
+++ b/src/components/MusicDashboard.tsx
@@ -17,6 +17,11 @@ export default function MusicDashboard() {
     update(id, { status: 'pending', progress: 0 });
   };
 
+  const onPlay = (path: string) => {
+    const audio = new Audio(convertFileSrc(path));
+    void audio.play();
+  };
+
   return (
     <Box>
       <Typography variant="h6" sx={{ mb: 2 }}>Project Dashboard</Typography>
@@ -49,7 +54,7 @@ export default function MusicDashboard() {
                 <TableCell>
                   <Stack direction="row" spacing={1} alignItems="center">
                     {j.wavPath && (
-                      <IconButton aria-label="play">
+                      <IconButton aria-label="play" onClick={() => onPlay(j.wavPath!)}>
                         <PlayArrowIcon />
                       </IconButton>
                     )}


### PR DESCRIPTION
## Summary
- play generated songs directly from MusicDashboard
- add unit test covering audio playback

## Testing
- `npm test -- --run src/components/MusicDashboard.test.tsx`
- `npm test -- --run` *(fails: Unterminated string literal in NpcForm.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b41e3b75e883258cac31005c392163