### PR TITLE
docs: remove stock configuration references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Modules
-- `src/`: React + TypeScript app (Vite). Components use PascalCase (`RetroTV.tsx`); utilities and stores use camelCase (`sfzLoader.ts`, `stocks.ts`). Tests live alongside files as `*.test.ts(x)`.
+- `src/`: React + TypeScript app (Vite). Components use PascalCase (`RetroTV.tsx`); utilities and stores use camelCase (`sfzLoader.ts`). Tests live alongside files as `*.test.ts(x)`.
 - `src-tauri/`: Tauri (Rust) backend with integration/unit tests under `src-tauri/tests`. Python helpers live in `src-tauri/python/` with tests in `src-tauri/python/tests`.
 - `scripts/`: TypeScript maintenance scripts (run via `tsx`), e.g. `reindex.ts`, `gen-schemas.ts`.
 - `public/`, `assets/`, `models/`: static assets and data.

--- a/README.md
+++ b/README.md
@@ -117,12 +117,6 @@ When a user uploads a video, it plays automatically on an endless loop.
 
 ## Configuration and optional features
 
-- **Alpha Vantage API key:** Set the `ALPHAVANTAGE_API_KEY` environment variable (or add
-  `alphavantage_api_key` to `~/.blossom/config.json`) so the app can fetch stock
-  news.
-- **Stock data provider:** Set `STOCKS_PROVIDER=twelvedata` and provide a
-  `TWELVEDATA_API_KEY` to fetch quotes and time series from Twelve Data. The
-  free tier allows up to 800 requests per day and 8 per minute.
 - **Paths:** ComfyUI is bundled and starts automatically, so no directory needs
   to be configured. The Python interpreter path is detected automatically but
   can be changed there if needed.


### PR DESCRIPTION
## Summary
- remove Alpha Vantage and Twelve Data configuration bullets
- drop outdated `stocks.ts` reference from repository guidelines

## Testing
- `npm test -- --run` *(fails: NpcForm.test.tsx transform error)*
- `cargo test` *(fails: missing system library glib-2.0)*
- `pytest python/tests` *(fails: FFmpeg not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2e287050832597789c2bb43ddab1