### PR TITLE
chore: ignore test snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 
 # Ignore example voice and ambience audio files
 src-tauri/python/samples/**/*.wav
+
+# Ignore test snapshots
+**/__snapshots__/


### PR DESCRIPTION
## Summary
- ignore `__snapshots__` directories so snapshot artifacts are not versioned

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bf31f34ac48325974acec70329da06