### PR TITLE
refactor(feature-nav): remove stocks entry

### DIFF
--- a/src/components/FeatureNav.tsx
+++ b/src/components/FeatureNav.tsx
@@ -13,7 +13,6 @@ import {
   FaGamepad,
   FaDiceD20,
   FaMicrophone,
-  FaChartLine,
   FaFilm,
   FaBroom,
   FaTools,


### PR DESCRIPTION
## Summary
- drop unused `stocks` module icon from FeatureNav navigation

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bf3b817750832588da5c7f3e25d92e