### PR TITLE
chore: remove stock provider env settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,3 @@
 # Example environment configuration for Blossom
-# Set the stock provider to Twelve Data and supply your API key.
-# Free tier allows up to 800 requests per day and 8 requests per minute.
-STOCKS_PROVIDER=twelvedata
-TWELVEDATA_API_KEY=your_key_here
 # Base URL for the ComfyUI API (defaults to http://127.0.0.1:8188)
 VITE_COMFY_API_URL=http://127.0.0.1:8188


### PR DESCRIPTION
## Summary
- drop Alpha Vantage and Twelve Data config examples

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bf3edae13083259ba1ded08ecb446a