### PR TITLE
refactor(tasks): remove ParseNpcPdf

### DIFF
--- a/src/store/tasks.test.ts
+++ b/src/store/tasks.test.ts
@@ -78,6 +78,12 @@ describe('enqueueTask validation', () => {
     );
   });
 
+  it('rejects removed ParseNpcPdf task id', async () => {
+    await expect(
+      useTasks.getState().enqueueTask('ParseNpcPdf', {} as any),
+    ).rejects.toThrow('Task command for ParseNpcPdf is missing id: {}');
+  });
+
   it('throws when required fields are missing for GenerateSong', async () => {
     await expect(
       useTasks.getState().enqueueTask('GenerateSong', { spec: {} as any }),

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -49,7 +49,6 @@ export type TaskCommand =
       seed: number;
     }
   | { id: 'PdfIngest'; py: string; script: string; doc_id: string }
-  | { id: 'ParseNpcPdf'; py?: string; script?: string; path: string; world: string }
   | { id: 'ParseSpellPdf'; py?: string; script?: string; path: string }
   | { id: 'ParseRulePdf'; py?: string; script?: string; path: string }
   | { id: 'ParseLorePdf'; py?: string; script?: string; path: string; world: string }
@@ -62,7 +61,6 @@ const TASK_IDS: TaskCommand['id'][] = [
   'Example',
   'LofiGenerateGpu',
   'PdfIngest',
-  'ParseNpcPdf',
   'ParseSpellPdf',
   'ParseRulePdf',
   'ParseLorePdf',


### PR DESCRIPTION
## Summary
- drop unused ParseNpcPdf task variant and constant entry
- ensure tasks store treats ParseNpcPdf as invalid

## Testing
- `npm test -- --run` *(fails: Unable to load SFZ: piano.sfz)*
- `npx vitest run src/store/tasks.test.ts`
- `cargo test` *(failed: interrupted during build)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf560b5a908325bdb1b09a9863728a