### PR TITLE
refactor: remove NPC PDF parsing

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -589,16 +589,6 @@ pub struct RuleRecord {
 }
 
 #[tauri::command]
-pub async fn parse_npc_pdf<R: Runtime>(
-    app: AppHandle<R>,
-    path: String,
-) -> Result<Vec<Value>, String> {
-    let out = run_pdf_tool(&app, &["npcs", &path])?;
-    let v: Value = serde_json::from_str(&out).map_err(|e| e.to_string())?;
-    serde_json::from_value(v["npcs"].clone()).map_err(|e| e.to_string())
-}
-
-#[tauri::command]
 pub async fn pdf_add<R: Runtime>(app: AppHandle<R>, path: String) -> Result<Value, String> {
     let out = run_pdf_tool(&app, &["add", &path])?;
     serde_json::from_str(&out).map_err(|e| e.to_string())
@@ -684,30 +674,6 @@ pub async fn parse_lore_pdf<R: Runtime>(
     let out = run_pdf_tool(&app, &["lore", &path])?;
     let v: Value = serde_json::from_str(&out).map_err(|e| e.to_string())?;
     serde_json::from_value(v["lore"].clone()).map_err(|e| e.to_string())
-}
-
-#[tauri::command]
-pub async fn enqueue_parse_npc_pdf<R: Runtime>(
-    app: AppHandle<R>,
-    queue: State<'_, TaskQueue>,
-    path: String,
-    world: String,
-) -> Result<u64, String> {
-    let py = conda_python();
-    if !py.exists() {
-        return Err(format!("Python not found at {}", py.display()));
-    }
-    let script = pdf_tools_path(&app);
-    if !script.exists() {
-        return Err(format!("Script not found at {}", script.display()));
-    }
-    let cmd = TaskCommand::ParseNpcPdf {
-        py: py.to_string_lossy().to_string(),
-        script: script.to_string_lossy().to_string(),
-        path,
-        world,
-    };
-    Ok(queue.enqueue("Import NPC PDF".into(), cmd).await)
 }
 
 /* ==============================

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -130,8 +130,6 @@ fn main() {
             commands::pdf_ingest,
             commands::parse_spell_pdf,
             commands::parse_rule_pdf,
-            commands::parse_npc_pdf,
-            commands::enqueue_parse_npc_pdf,
             commands::parse_lore_pdf,
             // Blender:
             commands::blender_run_script,

--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -49,7 +49,6 @@ export type TaskCommand =
       seed: number;
     }
   | { id: 'PdfIngest'; py: string; script: string; doc_id: string }
-  | { id: 'ParseNpcPdf'; py?: string; script?: string; path: string; world: string }
   | { id: 'ParseSpellPdf'; py?: string; script?: string; path: string }
   | { id: 'ParseRulePdf'; py?: string; script?: string; path: string }
   | { id: 'ParseLorePdf'; py?: string; script?: string; path: string; world: string }
@@ -62,7 +61,6 @@ const TASK_IDS: TaskCommand['id'][] = [
   'Example',
   'LofiGenerateGpu',
   'PdfIngest',
-  'ParseNpcPdf',
   'ParseSpellPdf',
   'ParseRulePdf',
   'ParseLorePdf',


### PR DESCRIPTION
## Summary
- drop `parse_npc_pdf` and `enqueue_parse_npc_pdf` commands
- remove `ParseNpcPdf` task type and related handlers
- trim frontend task types accordingly

## Testing
- `npm test -- --run` *(fails: vitest not found)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf561b6fe88325b983b25bb10837c8