### PR TITLE
docs: remove NPC PDF upload references

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ npm test  # run JavaScript tests
 
 ## UI Usage
 
-- **Uploading PDFs:** Use the D&D forms' PDF upload dialogs to import NPCs, rules,
-  lore, or spells. Parsed entries appear in their respective lists once the
-  background task finishes.
+- **Uploading PDFs:** Use the D&D forms' upload dialogs to import rules, lore, or
+  spells. Parsed entries appear in their respective lists once the background
+  task finishes.
 - **World inventory:** After NPCs are loaded, open the *World Inventory* page to
   see a consolidated list of items along with the NPCs that carry them.
 - **Ollama enrichment:** Features such as General Chat and the NPC Maker start
@@ -103,9 +103,8 @@ npm test  # run JavaScript tests
 ### Manual end‑to‑end test
 
 1. Start the app with `npm run tauri dev`.
-2. Upload an NPC PDF and confirm the character appears in the list.
-3. Visit *World Inventory* and verify items aggregate under their NPC owners.
-4. Open General Chat and send a message to trigger `start_ollama`; check that a
+2. Visit *World Inventory* and verify items aggregate under their NPC owners.
+3. Open General Chat and send a message to trigger `start_ollama`; check that a
    model response is received.
 
 ## RetroTV component


### PR DESCRIPTION
## Summary
- remove NPC PDF references from README
- adjust manual test instructions to exclude NPC PDFs

## Testing
- `npm test -- --run`
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*
- `cargo test` *(fails: system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf584198c48325bcecb3767e81a8bd