### PR TITLE
fix(music): support final wav playback

### DIFF
--- a/src/components/MusicDashboard.test.tsx
+++ b/src/components/MusicDashboard.test.tsx
@@ -3,16 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import MusicDashboard from './MusicDashboard';
 import { convertFileSrc } from '@tauri-apps/api/core';
 
-const list = () => [
-  {
-    id: '1',
-    title: 'Song',
-    prompt: '',
-    createdAt: 0,
-    status: 'completed',
-    wavPath: 'file.wav',
-  },
-];
+let list: any = () => [];
 const remove = vi.fn();
 const update = vi.fn();
 
@@ -26,6 +17,16 @@ vi.mock('@tauri-apps/api/core', () => ({
 
 describe('MusicDashboard', () => {
   it('plays audio when play button clicked', () => {
+    list = () => [
+      {
+        id: '1',
+        title: 'Song',
+        prompt: '',
+        createdAt: 0,
+        status: 'completed',
+        wavPath: 'file.wav',
+      },
+    ];
     const playSpy = vi.fn();
     class MockAudio {
       src: string;
@@ -40,6 +41,34 @@ describe('MusicDashboard', () => {
     const [btn] = screen.getAllByRole('button', { name: 'play' });
     fireEvent.click(btn);
     expect(convertFileSrc).toHaveBeenCalledWith('file.wav');
+    expect(playSpy).toHaveBeenCalled();
+  });
+
+  it('handles wavPathFinal for playback', () => {
+    list = () => [
+      {
+        id: '1',
+        title: 'Song',
+        prompt: '',
+        createdAt: 0,
+        status: 'completed',
+        wavPathFinal: 'final.wav',
+      },
+    ];
+    const playSpy = vi.fn();
+    class MockAudio {
+      src: string;
+      constructor(src: string) {
+        this.src = src;
+      }
+      play = playSpy;
+    }
+    (globalThis as any).Audio = MockAudio as any;
+
+    render(<MusicDashboard />);
+    const [btn] = screen.getAllByRole('button', { name: 'play' });
+    fireEvent.click(btn);
+    expect(convertFileSrc).toHaveBeenCalledWith('final.wav');
     expect(playSpy).toHaveBeenCalled();
   });
 });

--- a/src/components/MusicDashboard.tsx
+++ b/src/components/MusicDashboard.tsx
@@ -14,7 +14,10 @@ export default function MusicDashboard() {
   const update = useMusicJobs((s) => s.update);
 
   const latestCompleted = useMemo(
-    () => list.find((j) => j.status === 'completed' && j.wavPath),
+    () =>
+      list.find(
+        (j) => j.status === 'completed' && (j.wavPathFinal || j.wavPath)
+      ),
     [list]
   );
 
@@ -59,13 +62,23 @@ export default function MusicDashboard() {
                 </TableCell>
                 <TableCell>
                   <Stack direction="row" spacing={1} alignItems="center">
-                    {j.wavPath && (
-                      <IconButton aria-label="play" onClick={() => onPlay(j.wavPath!)}>
+                    {(j.wavPathFinal || j.wavPath) && (
+                      <IconButton
+                        aria-label="play"
+                        onClick={() => onPlay(j.wavPathFinal ?? j.wavPath!)}
+                      >
                         <PlayArrowIcon />
                       </IconButton>
                     )}
-                    {j.wavPath && (
-                      <Button size="small" component="a" href={convertFileSrc(j.wavPath)} download target="_blank" rel="noreferrer">
+                    {(j.wavPathFinal || j.wavPath) && (
+                      <Button
+                        size="small"
+                        component="a"
+                        href={convertFileSrc(j.wavPathFinal ?? j.wavPath!)}
+                        download
+                        target="_blank"
+                        rel="noreferrer"
+                      >
                         <DownloadIcon fontSize="small" sx={{ mr: 0.5 }} /> Download
                       </Button>
                     )}
@@ -83,7 +96,9 @@ export default function MusicDashboard() {
       {latestCompleted && (
         <Box sx={{ mt: 3 }}>
           <Typography variant="subtitle1">Latest Preview</Typography>
-          <AudioPlayer src={latestCompleted.wavPath!} />
+          <AudioPlayer
+            src={(latestCompleted.wavPathFinal ?? latestCompleted.wavPath)!}
+          />
         </Box>
       )}
     </Box>

--- a/src/stores/musicJobs.ts
+++ b/src/stores/musicJobs.ts
@@ -11,6 +11,7 @@ export interface MusicJob {
   status: JobStatus;
   progress?: number; // 0-100
   wavPath?: string; // final output from python
+  wavPathFinal?: string; // post-processed final output
   draftUrl?: string; // local preview (e.g., uploaded melody)
   error?: string;
 }


### PR DESCRIPTION
## Summary
- handle `wavPathFinal` alongside `wavPath` in music dashboard
- expose optional `wavPathFinal` in job store
- test playback for `wavPathFinal`

## Testing
- `npm run dev`
- `npm test`
- `cargo test` *(fails: glib-2.0 not found)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf65dc357c832583caf753d547a3d7