### PR TITLE
docs(npc): replace DND references

### DIFF
--- a/npc/log/README.md
+++ b/npc/log/README.md
@@ -12,6 +12,6 @@ Entries are appended in JSON Lines format to `npc-import.log`. Each line is a JS
 Examples:
 
 ```json
-{"timestamp":"2024-01-01T12:00:00Z","world":"forgotten-realms","id":"abc123","name":"Elminster"}
-{"timestamp":"2024-01-02T12:00:00Z","world":"forgotten-realms","id":"","name":"","errorCode":"E123","message":"Parse failed"}
+{"timestamp":"2024-01-01T12:00:00Z","world":"mystic-lands","id":"abc123","name":"Eldric"}
+{"timestamp":"2024-01-02T12:00:00Z","world":"mystic-lands","id":"","name":"","errorCode":"E123","message":"Parse failed"}
 ```


### PR DESCRIPTION
## Summary
- replace forgotten realms references with generic mystic-lands in NPC import log
- remove DND-specific character name in example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf73f0f38083258cdc251a7451c691