### PR TITLE
refactor: remove unused DND workflow

### DIFF
--- a/src-tauri/python/photogenic.py
+++ b/src-tauri/python/photogenic.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import re
 from pathlib import Path
@@ -62,8 +61,6 @@ ACTION_REGEX = re.compile(
     re.IGNORECASE,
 )
 
-ROOT_DIR = Path(__file__).resolve().parents[2]
-DEFAULT_WORKFLOW = ROOT_DIR / "src" / "comfy" / "dnd_portrait.json"
 COMFY_API_URL = os.environ.get("COMFY_API_URL", "http://127.0.0.1:8188")
 LOCAL_LLM_URL = os.environ.get("LOCAL_LLM_URL", "http://localhost:11434/api/generate")
 LOCAL_LLM_MODEL = os.environ.get("LOCAL_LLM_MODEL", "llama2")
@@ -106,10 +103,7 @@ def generate_image(prompt: str, workflow: dict | None = None, api_url: str | Non
     if api_url is None:
         api_url = COMFY_API_URL
     if workflow is None:
-        try:
-            workflow = json.loads(DEFAULT_WORKFLOW.read_text())
-        except Exception:
-            return False
+        return False
     for node in workflow.get("nodes", []):
         if node.get("type") == "CLIPTextEncode":
             widgets = node.get("widgets_values")


### PR DESCRIPTION
## Summary
- remove DND-specific workflow constant from photogenic utility
- require explicit workflow for ComfyUI image generation

## Testing
- `PYTHONPATH=src-tauri/python pytest src-tauri/python/tests -q` *(fails: deterministic render, validate entry offline)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9ce970848325bc4a31f4a881276b