### PR TITLE
refactor(app): remove music routes

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -8,7 +8,6 @@ vi.mock('./components/TopBar', () => ({ default: () => <div /> }));
 vi.mock('./components/CreateUserDialog', () => ({ default: () => <div /> }));
 vi.mock('./pages/Comfy', () => ({ default: () => <div>Comfy</div> }));
 vi.mock('./pages/Home', () => ({ default: () => <div>Home</div> }));
-vi.mock('./pages/SFZMusic', () => ({ default: () => <div>SFZ</div> }));
 
 // Provide minimal implementations for hooks used by RetroTV/App
 vi.mock('./features/theme/ThemeContext', () => ({
@@ -25,6 +24,7 @@ import App from './App';
 afterEach(() => {
   cleanup();
 });
+
 
 describe('App RetroTV overlay', () => {
   it('shows RetroTV on non-Comfy routes', () => {
@@ -44,14 +44,4 @@ describe('App RetroTV overlay', () => {
     );
     expect(screen.queryByText('NO SIGNAL')).toBeNull();
   });
-
-  it('hides RetroTV on the SFZ Music route', () => {
-    render(
-      <MemoryRouter initialEntries={[{ pathname: '/sfz-music' }]}> 
-        <App />
-      </MemoryRouter>
-    );
-    expect(screen.queryByText('NO SIGNAL')).toBeNull();
-  });
 });
-

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,9 +9,6 @@ import { useUsers } from "./features/users/useUsers";
 import Home from "./pages/Home";
 import Objects from "./pages/Objects";
 import Blender from "./pages/Blender";
-import Music from "./pages/Music";
-import SFZMusic from "./pages/SFZMusic";
-import AIMusic from "./pages/AIMusic";
 import Calendar from "./pages/Calendar";
 import Comfy from "./pages/Comfy";
 import Assistant from "./pages/Assistant";
@@ -51,8 +48,7 @@ export default function App() {
   return (
     <ErrorBoundary>
         <TopBar />
-        {pathname !== "/calendar" && pathname !== "/comfy" &&
-          pathname !== "/sfz-music" && (
+        {pathname !== "/calendar" && pathname !== "/comfy" && (
             <RetroTV>NO SIGNAL</RetroTV>
           )}
         <CreateUserDialog open={showUserDialog} onClose={() => setShowUserDialog(false)} />
@@ -61,9 +57,6 @@ export default function App() {
           <Route path="/" element={<Home />} />
           <Route path="/objects" element={<Objects />} />
           <Route path="/objects/blender" element={<Blender />} />
-          <Route path="/music" element={<Music />} />
-          <Route path="/ai-music" element={<AIMusic />} />
-          <Route path="/sfz-music" element={<SFZMusic />} />
           <Route path="/calendar" element={<Calendar />} />
           <Route path="/comfy" element={<Comfy />} />
           <Route path="/assistant" element={<Assistant />} />


### PR DESCRIPTION
## Summary
- remove Music, AIMusic, and SFZMusic routes and related conditionals
- update App tests for removed music routes

## Testing
- `npm test`
- `cargo test` *(fails: javascriptcoregtk-4.1 not found)*
- `pytest src-tauri/python/tests` *(fails: 2 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa6a26ec48325bfaa3c0983c48dd4