### PR TITLE
refactor: remove music navigation

### DIFF
--- a/src/components/FeatureNav.tsx
+++ b/src/components/FeatureNav.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Box, IconButton } from "@mui/material";
 import { getContrastColor } from "../utils/color";
 import {
-  FaMusic,
   FaCubes,
   FaCameraRetro,
   FaRobot,
@@ -38,9 +37,6 @@ type Item = {
 
 export const ITEMS: Item[] = [
   { key: "objects", icon: <FaCubes />, label: "3D Object", path: "/objects", color: "rgba(165,216,255,0.55)" },
-  { key: "music", icon: <FaMusic />, label: "Music", path: "/music", color: "rgba(245,176,194,0.55)" },
-  { key: "aimusic", icon: <FaRobot />, label: "AI Music", path: "/ai-music", color: "rgba(200,180,255,0.55)" },
-  { key: "sfz", icon: <FaMusic />, label: "SFZ Music", path: "/sfz-music", color: "rgba(200,150,200,0.55)" },
   { key: "calendar", icon: <FaCalendarAlt />, label: "Calendar", path: "/calendar", color: "rgba(211,200,255,0.55)" },
   { key: "comfy", icon: <FaCameraRetro />, label: "ComfyUI", path: "/comfy", color: "rgba(255,213,165,0.55)" },
   { key: "assistant", icon: <FaRobot />, label: "AI Assistant", path: "/assistant", color: "rgba(175,245,215,0.55)" },

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -132,10 +132,8 @@ const THEME_GROUPS: { label: string; options: { value: Theme; label: string }[] 
   },
 ];
 
-const MODULE_LABELS: Record<ModuleKey, string> = {
+const MODULE_LABELS: Partial<Record<ModuleKey, string>> = {
   objects: "3D Object",
-  music: "Lo‑Fi Music",
-  aimusic: "AI Music",
   calendar: "Calendar",
   comfy: "ComfyUI",
   assistant: "AI Assistant",

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -7,7 +7,6 @@ import {
   FaTasks,
   FaArrowLeft,
   FaCameraRetro,
-  FaMusic,
   FaCalendarAlt,
 } from "react-icons/fa";
 import { useNavigate, useLocation } from "react-router-dom";
@@ -93,27 +92,12 @@ export default function TopBar() {
             </IconButton>
           </Tooltip>
 
-          <Tooltip title="Music">
-            <IconButton
-              onClick={() => nav("/music")}
-              sx={{
-                ...fixedIconButtonSx,
-                left: { xs: 116, sm: 156 },
-                ...activeSx("/music"),
-              }}
-              aria-label="Music"
-              aria-current={pathname === "/music" ? "page" : undefined}
-            >
-              <FaMusic />
-            </IconButton>
-          </Tooltip>
-
           <Tooltip title="Calendar">
             <IconButton
               onClick={() => nav("/calendar")}
               sx={{
                 ...fixedIconButtonSx,
-                left: { xs: 152, sm: 204 },
+                left: { xs: 116, sm: 156 },
                 ...activeSx("/calendar"),
               }}
               aria-label="Calendar"


### PR DESCRIPTION
## Summary
- drop music-related entries from FeatureNav
- remove /music shortcut from TopBar
- prune music and AI music module labels from SettingsDrawer

## Testing
- `npm test -- --run`
- `cargo test` *(fails: gobject-2.0 library missing)*
- `pytest src-tauri/python/tests` *(fails: FFmpeg is required but was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c02a13971883258a23af98f16157a6