### PR TITLE
test(commands): add intent extraction tests

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1231,6 +1231,51 @@ fn extract_intent(content: &str) -> String {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::extract_intent;
+
+    #[test]
+    fn parses_npc() {
+        assert_eq!(
+            extract_intent("{\"intent\":\"npc\",\"confidence\":0.9}"),
+            "npc"
+        );
+    }
+
+    #[test]
+    fn parses_rules() {
+        assert_eq!(
+            extract_intent("{\"intent\":\"rules\",\"confidence\":0.8}"),
+            "rules"
+        );
+    }
+
+    #[test]
+    fn parses_lore() {
+        assert_eq!(
+            extract_intent("{\"intent\":\"lore\",\"confidence\":0.95}"),
+            "lore"
+        );
+    }
+
+    #[test]
+    fn parses_notes() {
+        assert_eq!(
+            extract_intent("{\"intent\":\"notes\",\"confidence\":0.99}"),
+            "notes"
+        );
+    }
+
+    #[test]
+    fn defaults_to_notes_on_low_confidence() {
+        assert_eq!(
+            extract_intent("{\"intent\":\"npc\",\"confidence\":0.2}"),
+            "notes"
+        );
+    }
+}
+
 /* ==============================
 Transcription
 ============================== */


### PR DESCRIPTION
## Summary
- verify intent classifier supports `npc`, `rules`, `lore`, and `notes`
- ensure low-confidence intents fall back to `notes`

## Testing
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b6ed8e408325ad502cd0aa50345f