### PR TITLE
feat(audio): add configurable audio presets

### DIFF
--- a/docs/audio-presets.md
+++ b/docs/audio-presets.md
@@ -1,0 +1,15 @@
+# Audio Presets
+
+The **Audio Defaults** section in Settings now supports presets.
+Select a preset from the list to apply its BPM, key, and effect
+quality toggles. Built-in presets include `default`, `podcast`, and
+`lofi`.
+
+To save your own preset:
+
+1. Adjust the audio settings as desired.
+2. Enter a name in the *New Preset Name* field.
+3. Click **Save Preset**.
+
+Saved presets are stored locally via Zustand persistence and will be
+available the next time you open Blossom.

--- a/src/components/SettingsDrawer.tsx
+++ b/src/components/SettingsDrawer.tsx
@@ -26,6 +26,7 @@ import { useSettings, type ModuleKey, type WidgetKey } from "../features/setting
 import { usePaths } from "../features/paths/usePaths";
 import { useOutput } from "../features/output/useOutput";
 import { useAudioDefaults } from "../features/audioDefaults/useAudioDefaults";
+import { presetCatalog } from "../features/audioDefaults/presets";
 import { useTheme, type Theme } from "../features/theme/ThemeContext";
 import { useComfyTutorial } from "../features/comfyTutorial/useComfyTutorial";
 import { useUsers } from "../features/users/useUsers";
@@ -222,6 +223,10 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
     toggleHqChorus,
     micEnabled,
     toggleMicEnabled,
+    currentPreset,
+    customPresets,
+    setPreset,
+    savePreset,
   } = useAudioDefaults();
   const { theme, setTheme } = useTheme();
   const currentUserId = useUsers((state) => state.currentUserId);
@@ -238,6 +243,8 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   const [outputSaved, setOutputSaved] = useState(false);
   const [ambienceMessage, setAmbienceMessage] = useState<string | null>(null);
   const [generatingAmbience, setGeneratingAmbience] = useState(false);
+  const [presetName, setPresetName] = useState("");
+  const [presetSaved, setPresetSaved] = useState(false);
 
   const [pythonDraft, setPythonDraft] = useState(pythonPath);
   const [folderDraft, setFolderDraft] = useState(folder);
@@ -269,6 +276,11 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
     { label: "Current User", section: "user" as Section, elementId: "current-user" },
     { label: "Python Path", section: "environment" as Section, elementId: "python-path" },
     { label: "Default Save Folder", section: "environment" as Section, elementId: "output-folder" },
+    {
+      label: "Preset",
+      section: "editor" as Section,
+      elementId: "preset",
+    },
     {
       label: "Enable Microphone",
       section: "editor" as Section,
@@ -415,6 +427,46 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   const EditorSection = () => (
     <>
       <Typography variant="subtitle1">Audio Defaults</Typography>
+      <Box id="preset" sx={{ mt: 1 }}>
+        <FormControl fullWidth>
+          <InputLabel id="preset-label">Preset</InputLabel>
+          <Select
+            labelId="preset-label"
+            label="Preset"
+            value={currentPreset ?? ""}
+            onChange={(e) => setPreset(e.target.value as string)}
+          >
+            {Object.keys(presetCatalog).map((n) => (
+              <MenuItem key={n} value={n}>
+                {n}
+              </MenuItem>
+            ))}
+            {Object.keys(customPresets).map((n) => (
+              <MenuItem key={n} value={n}>
+                {n}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <TextField
+          label="New Preset Name"
+          value={presetName}
+          onChange={(e) => setPresetName(e.target.value)}
+          sx={{ mt: 2 }}
+        />
+        <Button
+          variant="outlined"
+          sx={{ mt: 1 }}
+          onClick={() => {
+            savePreset(presetName);
+            setPresetName("");
+            setPresetSaved(true);
+          }}
+          disabled={!presetName}
+        >
+          Save Preset
+        </Button>
+      </Box>
       <Box id="mic-enabled" sx={{ mt: 1 }}>
         <FormControlLabel
           control={<Switch checked={micEnabled} onChange={toggleMicEnabled} />}
@@ -693,6 +745,12 @@ export default function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
             autoHideDuration={3000}
             onClose={() => setAudioSaved(false)}
             message="Audio defaults saved"
+          />
+          <Snackbar
+            open={presetSaved}
+            autoHideDuration={3000}
+            onClose={() => setPresetSaved(false)}
+            message="Preset saved"
           />
             <Snackbar
               open={pathsSaved}

--- a/src/features/audioDefaults/presets.ts
+++ b/src/features/audioDefaults/presets.ts
@@ -1,0 +1,39 @@
+export interface Preset {
+  bpm: number;
+  key: string;
+  hqStereo: boolean;
+  hqReverb: boolean;
+  hqSidechain: boolean;
+  hqChorus: boolean;
+  micEnabled: boolean;
+}
+
+export const presetCatalog: Record<string, Preset> = {
+  default: {
+    bpm: 80,
+    key: "Auto",
+    hqStereo: true,
+    hqReverb: true,
+    hqSidechain: true,
+    hqChorus: true,
+    micEnabled: true,
+  },
+  podcast: {
+    bpm: 80,
+    key: "Auto",
+    hqStereo: false,
+    hqReverb: false,
+    hqSidechain: false,
+    hqChorus: false,
+    micEnabled: true,
+  },
+  lofi: {
+    bpm: 60,
+    key: "Auto",
+    hqStereo: true,
+    hqReverb: true,
+    hqSidechain: false,
+    hqChorus: true,
+    micEnabled: true,
+  },
+};

--- a/src/features/audioDefaults/useAudioDefaults.ts
+++ b/src/features/audioDefaults/useAudioDefaults.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { presetCatalog, type Preset } from "./presets";
 
 interface AudioDefaultsState {
   bpm: number;
@@ -9,6 +10,8 @@ interface AudioDefaultsState {
   hqSidechain: boolean;
   hqChorus: boolean;
   micEnabled: boolean;
+  currentPreset: string | null;
+  customPresets: Record<string, Preset>;
   setBpm: (bpm: number) => void;
   setKey: (key: string) => void;
   toggleHqStereo: () => void;
@@ -16,6 +19,8 @@ interface AudioDefaultsState {
   toggleHqSidechain: () => void;
   toggleHqChorus: () => void;
   toggleMicEnabled: () => void;
+  setPreset: (name: string) => void;
+  savePreset: (name: string) => void;
 }
 
 export const useAudioDefaults = create<AudioDefaultsState>()(
@@ -28,6 +33,8 @@ export const useAudioDefaults = create<AudioDefaultsState>()(
       hqSidechain: true,
       hqChorus: true,
       micEnabled: true,
+      currentPreset: "default",
+      customPresets: {},
       setBpm: (bpm: number) => set({ bpm }),
       setKey: (key: string) => set({ key }),
       toggleHqStereo: () => set((s) => ({ hqStereo: !s.hqStereo })),
@@ -35,6 +42,28 @@ export const useAudioDefaults = create<AudioDefaultsState>()(
       toggleHqSidechain: () => set((s) => ({ hqSidechain: !s.hqSidechain })),
       toggleHqChorus: () => set((s) => ({ hqChorus: !s.hqChorus })),
       toggleMicEnabled: () => set((s) => ({ micEnabled: !s.micEnabled })),
+      setPreset: (name: string) =>
+        set((s) => {
+          const preset = presetCatalog[name] ?? s.customPresets[name];
+          if (!preset) return s;
+          return { ...s, ...preset, currentPreset: name };
+        }),
+      savePreset: (name: string) =>
+        set((s) => ({
+          customPresets: {
+            ...s.customPresets,
+            [name]: {
+              bpm: s.bpm,
+              key: s.key,
+              hqStereo: s.hqStereo,
+              hqReverb: s.hqReverb,
+              hqSidechain: s.hqSidechain,
+              hqChorus: s.hqChorus,
+              micEnabled: s.micEnabled,
+            },
+          },
+          currentPreset: name,
+        })),
     }),
     { name: "audio-defaults" }
   )


### PR DESCRIPTION
## Summary
- add preset catalog for audio defaults
- allow selecting and saving audio presets in settings
- persist preset selection and document usage

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c4b7684f3483258b97f72cb7410a46