### PR TITLE
feat: stream structured task progress

### DIFF
--- a/src/store/tasks.ts
+++ b/src/store/tasks.ts
@@ -53,6 +53,11 @@ interface RawTask {
   started_at?: string;
 }
 
+interface TaskEventPayload {
+  task: RawTask;
+  progress?: Record<string, unknown>;
+}
+
 function normalize(raw: RawTask): Task {
   if (typeof raw.status === 'string') {
     return {
@@ -187,8 +192,8 @@ export const useTasks = create<TasksState>((set, get) => ({
   },
   subscribe: async () => {
     try {
-      const unlisten = await listen<RawTask>('task_updated', (e) => {
-        const task = normalize(e.payload);
+      const unlisten = await listen<TaskEventPayload>('task_updated', (e) => {
+        const task = normalize(e.payload.task);
         set((state) => ({ tasks: { ...state.tasks, [task.id]: task } }));
         if (['completed', 'cancelled', 'failed'].includes(task.status)) {
           get().stopPolling(task.id);


### PR DESCRIPTION
## Summary
- emit JSON progress payloads from PDF lore extraction
- propagate progress updates through task queue events
- consume structured task events on the frontend store for smoother progress

## Testing
- `npm test -- --run`
- `cargo test` *(fails: cannot find function `script_path`)*
- `pytest src-tauri/python/tests` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b9a6e70883258f81e7c20c6b4dc6