### PR TITLE
feat: add vault search command

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -545,6 +545,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "sqlx",
  "sysinfo",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "io-ut
 png = "0.17"
 rand = "0.8"
 base64 = "0.21"
+sha2 = "0.10"
 
 [dev-dependencies]
 tauri = { version = "2", features = ["protocol-asset", "test"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -60,6 +60,7 @@ fn main() {
             commands::pdf_remove,
             commands::pdf_list,
             commands::pdf_search,
+            commands::vault_search,
             commands::pdf_ingest,
             commands::parse_spell_pdf,
             commands::parse_rule_pdf,


### PR DESCRIPTION
## Summary
- add `vault_search` command with hashed embeddings for note retrieval
- include vault results in general chat context
- expose vault search through Tauri commands

## Testing
- `cargo test` *(fails: generate_ambience_logs_output: ambience_generator.py not found)*
- `npm test` *(fails: vitest: not found)*
- `pytest src-tauri/python/tests` *(fails: test_validate_entry_offline)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ba42828c83258eda42064e1e5fe0