### PR TITLE
feat(chat): route intents through retrieval

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -55,6 +55,7 @@ fn main() {
             commands::stop_ollama,
             commands::general_chat,
             commands::detect_intent,
+            commands::retrieve_context,
             // PDF tools:
             commands::pdf_add,
             commands::pdf_remove,

--- a/src-tauri/tests/comfy_start_stop.rs
+++ b/src-tauri/tests/comfy_start_stop.rs
@@ -1,11 +1,12 @@
-use blossom_lib::commands::{comfy_start, comfy_stop, __has_comfy_child};
+use blossom_lib::commands::{__has_comfy_child, comfy_start, comfy_stop};
 use std::{env, fs};
-use which::which;
 use tauri::Manager;
+use which::which;
 
 #[tokio::test]
 async fn start_and_stop_comfy() {
-    let _rt = <tauri::test::MockRuntime as tauri_runtime::Runtime<()>>::new(Default::default()).unwrap();
+    let _rt =
+        <tauri::test::MockRuntime as tauri_runtime::Runtime<()>>::new(Default::default()).unwrap();
     let app = tauri::test::mock_builder()
         .build(tauri::test::mock_context(tauri::test::noop_assets()))
         .unwrap();

--- a/src-tauri/tests/comfy_status.rs
+++ b/src-tauri/tests/comfy_status.rs
@@ -1,5 +1,8 @@
-use blossom_lib::commands::{comfy_status, __has_comfy_child, __set_comfy_child};
-use tokio::{process::Command, time::{sleep, Duration}};
+use blossom_lib::commands::{__has_comfy_child, __set_comfy_child, comfy_status};
+use tokio::{
+    process::Command,
+    time::{sleep, Duration},
+};
 
 #[tokio::test]
 async fn comfy_status_clears_finished_process() {

--- a/src-tauri/tests/npc_log.rs
+++ b/src-tauri/tests/npc_log.rs
@@ -4,7 +4,8 @@ use tauri::{test::mock_app, Manager};
 
 #[tokio::test]
 async fn append_npc_log_includes_errors() {
-    let _rt = <tauri::test::MockRuntime as tauri_runtime::Runtime<()>>::new(Default::default()).unwrap();
+    let _rt =
+        <tauri::test::MockRuntime as tauri_runtime::Runtime<()>>::new(Default::default()).unwrap();
     let app = mock_app();
     let handle = app.app_handle().clone();
 


### PR DESCRIPTION
## Summary
- call new `retrieve_context` from TypeScript and Discord paths when intent is `npc` or `lore`
- add `retrieve_context` command and register it with Tauri
- add unit tests for intent routing across npc, lore, rules, and notes

## Testing
- `npm test -- --run`
- `cargo test` *(fails: system library `gobject-2.0` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c4beb6b0148325963be6156e59d0c5