### PR TITLE
feat: add npc event chat command

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -54,6 +54,7 @@ fn main() {
             commands::start_ollama,
             commands::stop_ollama,
             commands::general_chat,
+            commands::npc_event_chat,
             commands::detect_intent,
             commands::retrieve_context,
             // PDF tools:

--- a/src-tauri/tests/npc_event_chat.rs
+++ b/src-tauri/tests/npc_event_chat.rs
@@ -1,0 +1,17 @@
+use blossom_lib::commands::parse_npc_event;
+
+#[test]
+fn parse_npc_event_valid() {
+    let json = "{\"who\":\"Alice\",\"action\":\"attack\",\"targets\":[\"orc\"],\"effects\":[\"hit\"],\"narration\":\"Alice hits the orc.\"}";
+    let event = parse_npc_event(json).unwrap();
+    assert_eq!(event.who, "Alice");
+    assert_eq!(event.targets, vec!["orc"]);
+    assert_eq!(event.narration, "Alice hits the orc.");
+}
+
+#[test]
+fn parse_npc_event_invalid() {
+    let json = "{\"who\":\"Bob\"}"; // missing fields
+    assert!(parse_npc_event(json).is_err());
+}
+

--- a/src/components/HomeChat.test.tsx
+++ b/src/components/HomeChat.test.tsx
@@ -15,15 +15,21 @@ describe('HomeChat', () => {
     cleanup();
   });
 
-  it('sends to general_chat', async () => {
-    (invoke as any).mockResolvedValue('Reply');
+  it('sends to npc_event_chat', async () => {
+    (invoke as any).mockResolvedValue({
+      who: 'n',
+      action: 'say',
+      targets: [],
+      effects: [],
+      narration: 'Reply',
+    });
     render(<HomeChat />);
     fireEvent.change(screen.getByPlaceholderText('Ask Blossom...'), {
       target: { value: 'Hello' },
     });
     fireEvent.click(screen.getByRole('button', { name: /send/i }));
     await waitFor(() => {
-      expect(invoke).toHaveBeenCalledWith('general_chat', {
+      expect(invoke).toHaveBeenCalledWith('npc_event_chat', {
         messages: [{ role: 'user', content: 'Hello' }],
       });
     });

--- a/src/components/HomeChat.tsx
+++ b/src/components/HomeChat.tsx
@@ -14,6 +14,14 @@ interface Message {
   content: string;
 }
 
+interface NpcEvent {
+  who: string;
+  action: string;
+  targets: string[];
+  effects: string[];
+  narration: string;
+}
+
 export default function HomeChat() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
@@ -50,7 +58,10 @@ export default function HomeChat() {
           role,
           content,
         }));
-        reply = await invoke<string>("general_chat", { messages: history });
+        const event = await invoke<NpcEvent>("npc_event_chat", {
+          messages: history,
+        });
+        reply = event.narration;
       }
     } catch (e: any) {
       reply = String(e);

--- a/src/discord/bot.ts
+++ b/src/discord/bot.ts
@@ -26,6 +26,14 @@ const INTENT_PROMPTS: Record<string, string> = {
   notes: "You are a helpful assistant for personal or miscellaneous notes.",
 };
 
+interface NpcEvent {
+  who: string;
+  action: string;
+  targets: string[];
+  effects: string[];
+  narration: string;
+}
+
 interface BotState {
   npcEnabled: boolean;
   chatChannel: TextBasedChannel | null;
@@ -86,13 +94,13 @@ async function sendWavForTranscription(
         if (rolePrompt) {
           messages.unshift({ role: "system", content: rolePrompt });
         }
-        const reply = await invoke<string>("general_chat", { messages });
-        await state.chatChannel.send(reply);
+        const event = await invoke<NpcEvent>("npc_event_chat", { messages });
+        await state.chatChannel.send(event.narration);
         if (state.player) {
           try {
             const audio = (await invoke(
               "higgs_tts",
-              { text: reply, speaker: NPC_VOICE_ID },
+              { text: event.narration, speaker: NPC_VOICE_ID },
             )) as number[] | Uint8Array;
             const uint8 =
               audio instanceof Uint8Array ? audio : new Uint8Array(audio);

--- a/src/pages/GeneralChat.test.tsx
+++ b/src/pages/GeneralChat.test.tsx
@@ -37,7 +37,14 @@ describe('GeneralChat', () => {
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === 'start_ollama') return Promise.resolve();
       if (cmd === 'detect_intent') return Promise.resolve('notes');
-      if (cmd === 'general_chat') return Promise.resolve('Reply');
+      if (cmd === 'npc_event_chat')
+        return Promise.resolve({
+          who: 'n',
+          action: 'say',
+          targets: [],
+          effects: [],
+          narration: 'Reply',
+        });
       return Promise.resolve();
     });
     (listen as any).mockImplementation(() => Promise.resolve(() => {}));
@@ -59,7 +66,7 @@ describe('GeneralChat', () => {
       const detect = calls.find(([cmd]: [string]) => cmd === 'detect_intent');
       expect(detect).toBeTruthy();
       expect(detect[1]).toEqual({ query: 'Hello' });
-      const chatCall = calls.find(([cmd]: [string]) => cmd === 'general_chat');
+      const chatCall = calls.find(([cmd]: [string]) => cmd === 'npc_event_chat');
       expect(chatCall[1]).toEqual({
         messages: [
           { role: 'system', content: 'You are a helpful assistant for personal or miscellaneous notes.' },
@@ -78,7 +85,14 @@ describe('GeneralChat', () => {
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === 'start_ollama') return Promise.resolve();
       if (cmd === 'detect_intent') return Promise.resolve('notes');
-      if (cmd === 'general_chat') return Promise.resolve('Reply');
+      if (cmd === 'npc_event_chat')
+        return Promise.resolve({
+          who: 'n',
+          action: 'say',
+          targets: [],
+          effects: [],
+          narration: 'Reply',
+        });
       return Promise.resolve();
     });
     (listen as any).mockImplementation(() => Promise.resolve(() => {}));
@@ -97,7 +111,7 @@ describe('GeneralChat', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
     await waitFor(() => {
       const calls = (invoke as any).mock.calls;
-      const chatCall = calls.find(([cmd]: [string]) => cmd === 'general_chat');
+      const chatCall = calls.find(([cmd]: [string]) => cmd === 'npc_event_chat');
       expect(chatCall[1]).toEqual({
         messages: [
           { role: 'system', content: 'You are a helpful assistant for personal or miscellaneous notes.' },
@@ -113,7 +127,7 @@ describe('GeneralChat', () => {
     fireEvent.click(screen.getAllByRole('button', { name: /send/i })[0]);
     await waitFor(() => {
       const calls = (invoke as any).mock.calls;
-      const secondChatCall = calls.filter(([cmd]: [string]) => cmd === 'general_chat')[1];
+      const secondChatCall = calls.filter(([cmd]: [string]) => cmd === 'npc_event_chat')[1];
       expect(secondChatCall[1]).toEqual({
         messages: [
           { role: 'system', content: 'You are a helpful assistant for personal or miscellaneous notes.' },
@@ -130,7 +144,7 @@ describe('GeneralChat', () => {
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === 'start_ollama') return Promise.resolve();
       if (cmd === 'detect_intent') return Promise.resolve('notes');
-      if (cmd === 'general_chat') return Promise.reject('fail');
+      if (cmd === 'npc_event_chat') return Promise.reject('fail');
       return Promise.resolve();
     });
     (listen as any).mockImplementation(() => Promise.resolve(() => {}));
@@ -172,7 +186,7 @@ describe('GeneralChat', () => {
 
     expect(await screen.findByText(/CPU: 1%/)).toBeInTheDocument();
     const chatCalls = (invoke as any).mock.calls.filter(
-      ([cmd]: [string]) => cmd === 'general_chat'
+      ([cmd]: [string]) => cmd === 'npc_event_chat'
     );
     expect(chatCalls).toHaveLength(0);
   });
@@ -201,7 +215,7 @@ describe('GeneralChat', () => {
 
     expect(await screen.findByText(/CPU: 1%/)).toBeInTheDocument();
     const chatCalls = (invoke as any).mock.calls.filter(
-      ([cmd]: [string]) => cmd === 'general_chat'
+      ([cmd]: [string]) => cmd === 'npc_event_chat'
     );
     expect(chatCalls).toHaveLength(0);
   });
@@ -211,7 +225,14 @@ describe('GeneralChat', () => {
       if (cmd === 'start_ollama') return Promise.resolve();
       if (cmd === 'detect_intent') return Promise.resolve('npc');
       if (cmd === 'retrieve_context') return Promise.resolve('NPC ctx');
-      if (cmd === 'general_chat') return Promise.resolve('Hi');
+      if (cmd === 'npc_event_chat')
+        return Promise.resolve({
+          who: 'n',
+          action: 'say',
+          targets: [],
+          effects: [],
+          narration: 'Hi',
+        });
       return Promise.resolve();
     });
     (listen as any).mockImplementation(() => Promise.resolve(() => {}));
@@ -234,7 +255,7 @@ describe('GeneralChat', () => {
       const calls = (invoke as any).mock.calls;
       const retrieve = calls.find(([cmd]: [string]) => cmd === 'retrieve_context');
       expect(retrieve[1]).toEqual({ query: 'Who is Bob?', intent: 'npc' });
-      const chatCall = calls.find(([cmd]: [string]) => cmd === 'general_chat');
+      const chatCall = calls.find(([cmd]: [string]) => cmd === 'npc_event_chat');
       expect(chatCall[1]).toEqual({
         messages: [
           { role: 'system', content: 'You are roleplaying a non-player character. Stay in character and use any provided context.' },
@@ -251,7 +272,14 @@ describe('GeneralChat', () => {
       if (cmd === 'start_ollama') return Promise.resolve();
       if (cmd === 'detect_intent') return Promise.resolve('lore');
       if (cmd === 'retrieve_context') return Promise.resolve('Lore ctx');
-      if (cmd === 'general_chat') return Promise.resolve('Hi');
+      if (cmd === 'npc_event_chat')
+        return Promise.resolve({
+          who: 'n',
+          action: 'say',
+          targets: [],
+          effects: [],
+          narration: 'Hi',
+        });
       return Promise.resolve();
     });
     (listen as any).mockImplementation(() => Promise.resolve(() => {}));
@@ -277,7 +305,7 @@ describe('GeneralChat', () => {
         query: 'Tell me about the realm',
         intent: 'lore',
       });
-      const chatCall = calls.find(([cmd]: [string]) => cmd === 'general_chat');
+      const chatCall = calls.find(([cmd]: [string]) => cmd === 'npc_event_chat');
       expect(chatCall[1]).toEqual({
         messages: [
           { role: 'system', content: 'You are a lore expert. Use the provided context to answer questions about the world or setting.' },
@@ -293,7 +321,14 @@ describe('GeneralChat', () => {
     (invoke as any).mockImplementation((cmd: string) => {
       if (cmd === 'start_ollama') return Promise.resolve();
       if (cmd === 'detect_intent') return Promise.resolve('rules');
-      if (cmd === 'general_chat') return Promise.resolve('Ok');
+      if (cmd === 'npc_event_chat')
+        return Promise.resolve({
+          who: 'n',
+          action: 'say',
+          targets: [],
+          effects: [],
+          narration: 'Ok',
+        });
       return Promise.resolve();
     });
     (listen as any).mockImplementation(() => Promise.resolve(() => {}));
@@ -316,7 +351,7 @@ describe('GeneralChat', () => {
       const calls = (invoke as any).mock.calls;
       const retrieve = calls.find(([cmd]: [string]) => cmd === 'retrieve_context');
       expect(retrieve).toBeFalsy();
-      const chatCall = calls.find(([cmd]: [string]) => cmd === 'general_chat');
+      const chatCall = calls.find(([cmd]: [string]) => cmd === 'npc_event_chat');
       expect(chatCall[1]).toEqual({
         messages: [
           { role: 'system', content: 'You are a rules assistant. Provide answers based on official game mechanics.' },

--- a/src/pages/GeneralChat.tsx
+++ b/src/pages/GeneralChat.tsx
@@ -36,6 +36,14 @@ interface Message {
   ts: number;
 }
 
+interface NpcEvent {
+  who: string;
+  action: string;
+  targets: string[];
+  effects: string[];
+  narration: string;
+}
+
 interface Chat {
   id: string;
   name: string;
@@ -190,7 +198,8 @@ export default function GeneralChat() {
         if (rolePrompt) {
           msgs.unshift({ role: "system", content: rolePrompt });
         }
-        reply = await invoke("general_chat", { messages: msgs });
+        const event = await invoke<NpcEvent>("npc_event_chat", { messages: msgs });
+        reply = event.narration;
       }
       const asst: Message = { role: "assistant", content: reply, ts: Date.now() };
       updateChat(currentChat.id, [...newMessages, asst]);


### PR DESCRIPTION
## Summary
- add npc_event_chat command wrapping Ollama and parsing structured JSON
- update Discord bot and chat components to use structured NPC events
- add tests for NPC event JSON parsing

## Testing
- `cargo test npc_event_chat -- --nocapture` *(failed to capture final output)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c1672c6083259c14ea1263ef2ec7