### PR TITLE
feat: add responsive sidebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import { Routes, Route, useLocation } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { Box } from "@mui/material";
+import { Box, useMediaQuery } from "@mui/material";
 import TopBar from "./components/TopBar";
+import Sidebar from "./components/Sidebar";
 import ErrorBoundary from "./components/ErrorBoundary";
 import CreateUserDialog from "./components/CreateUserDialog";
 import RetroTV from "./components/RetroTV";
@@ -34,6 +35,7 @@ export default function App() {
   const currentUserId = useUsers((s) => s.currentUserId);
   const switchUser = useUsers((s) => s.switchUser);
   const [showUserDialog, setShowUserDialog] = useState(false);
+  const isMobile = useMediaQuery("(max-width:600px)");
 
   useEffect(() => {
     const ids = Object.keys(users);
@@ -46,12 +48,13 @@ export default function App() {
 
   return (
     <ErrorBoundary>
-        <TopBar />
-        {pathname !== "/calendar" && pathname !== "/comfy" && (
-            <RetroTV>NO SIGNAL</RetroTV>
-          )}
-        <CreateUserDialog open={showUserDialog} onClose={() => setShowUserDialog(false)} />
-      <Box sx={{ pt: 'var(--top-bar-height)' }}>
+      <TopBar />
+      <Sidebar />
+      {pathname !== "/calendar" && pathname !== "/comfy" && (
+        <RetroTV>NO SIGNAL</RetroTV>
+      )}
+      <CreateUserDialog open={showUserDialog} onClose={() => setShowUserDialog(false)} />
+      <Box sx={{ pt: 'var(--top-bar-height)', pl: isMobile ? 0 : 60 }}>
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/objects" element={<Objects />} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { Box, Drawer, IconButton, Tooltip, useMediaQuery } from "@mui/material";
+import { useNavigate, useLocation } from "react-router-dom";
+import { FaBars, FaHome, FaCameraRetro, FaCalendarAlt, FaTasks, FaWrench } from "react-icons/fa";
+import SettingsDrawer from "./SettingsDrawer";
+import TaskDrawer from "./TaskDrawer";
+
+export default function Sidebar() {
+  const nav = useNavigate();
+  const { pathname } = useLocation();
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [taskOpen, setTaskOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const isMobile = useMediaQuery("(max-width:600px)");
+
+  const items = [
+    { label: "Home", icon: <FaHome />, onClick: () => nav("/"), path: "/" },
+    { label: "ComfyUI", icon: <FaCameraRetro />, onClick: () => nav("/comfy"), path: "/comfy" },
+    { label: "Calendar", icon: <FaCalendarAlt />, onClick: () => nav("/calendar"), path: "/calendar" },
+    { label: "Tasks", icon: <FaTasks />, onClick: () => setTaskOpen(true) },
+    { label: "Settings", icon: <FaWrench />, onClick: () => setSettingsOpen(true) },
+  ];
+
+  const renderButtons = (closeDrawer: boolean) => (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 2,
+        mt: 2,
+      }}
+    >
+      {items.map((it) => (
+        <Tooltip title={it.label} key={it.label}>
+          <IconButton
+            onClick={() => {
+              it.onClick();
+              if (closeDrawer) setDrawerOpen(false);
+            }}
+            aria-label={it.label}
+            aria-current={it.path && pathname === it.path ? "page" : undefined}
+            sx={
+              it.path && pathname === it.path
+                ? { color: "#000", backgroundColor: "#fff", borderRadius: 1 }
+                : { color: "white" }
+            }
+          >
+            {it.icon}
+          </IconButton>
+        </Tooltip>
+      ))}
+    </Box>
+  );
+
+  return (
+    <>
+      {isMobile ? (
+        <>
+          <Tooltip title="Menu">
+            <IconButton
+              onClick={() => setDrawerOpen(true)}
+              sx={{ position: "fixed", top: 12, left: 8, zIndex: 3, color: "white" }}
+              aria-label="Menu"
+              aria-expanded={drawerOpen}
+            >
+              <FaBars />
+            </IconButton>
+          </Tooltip>
+          <Drawer
+            anchor="left"
+            open={drawerOpen}
+            onClose={() => setDrawerOpen(false)}
+            PaperProps={{ sx: { width: 60, backgroundColor: "transparent" } }}
+          >
+            {renderButtons(true)}
+          </Drawer>
+        </>
+      ) : (
+        <Box
+          sx={{
+            position: "fixed",
+            top: "var(--top-bar-height)",
+            left: 0,
+            width: 60,
+            height: "calc(100vh - var(--top-bar-height))",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 2,
+            py: 2,
+            zIndex: 1,
+          }}
+        >
+          {renderButtons(false)}
+        </Box>
+      )}
+      {settingsOpen && (
+        <SettingsDrawer open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+      )}
+      {taskOpen && (
+        <TaskDrawer open={taskOpen} onClose={() => setTaskOpen(false)} />
+      )}
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add responsive Sidebar component that switches to Drawer on small screens
- integrate sidebar into App layout

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68c5a744ba6c8325ac84577fcec83dac